### PR TITLE
Change array_ref m_size from uint32_t to size_type

### DIFF
--- a/10.0.14393.0/winrt/base.h
+++ b/10.0.14393.0/winrt/base.h
@@ -1997,13 +1997,13 @@ struct array_ref
 
 protected:
 
-    array_ref(pointer data, uint32_t size) :
+    array_ref(pointer data, size_type size) :
         m_data(data),
         m_size(size)
     {}
 
     pointer m_data = nullptr;
-    uint32_t m_size = 0;
+    size_type m_size = 0;
 };
 
 template <typename T>


### PR DESCRIPTION
Just cosmetic change, since array_ref defines size_type.

Other places that also may be changed are:
- make_array_iterator(T * data, uint32_t size, uint32_t index = 0)
- com_array impl_put_size(com_array & value, const uint32_t size) an impl_detach() result pair
- array_size_proxy m_size and operator uint32_t * () noexcept
- com_array_proxy constructor and m_size