### PR TITLE
Fixed links in markdown files

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -108,14 +108,14 @@ If you are not working in Visual Studio, set the **MinVersion** and
 Read the docs!
 ==============
 
-To learn how to use the C++/WinRT library, browse the [Docs] (./Docs) folder for topics of interest.
+To learn how to use the C++/WinRT library, browse the [Docs](./Docs) folder for topics of interest.
 
-The [Header File Design] (./Docs/Header File Design.md) document contains a great discussion of the architecture of and best practices for using the C++/WinRT header files.
+The [Header File Design](./Docs/Header File Design.md) document contains a great discussion of the architecture of and best practices for using the C++/WinRT header files.
 
-For a discussion of the naming conventions used in the C++/WinRT library, read [Naming Conventions] (./Docs/Naming Conventions.md).
+For a discussion of the naming conventions used in the C++/WinRT library, read [Naming Conventions](./Docs/Naming Conventions.md).
 
-Unlike C++/CX, with C++/WinRT you typically pass and receive familar C++ data types when calling WinRT APIs. More information is in [Using Standard C++ types with C++ WinRT] (./Docs/Using Standard C++ types with C++ WinRT.md).
+Unlike C++/CX, with C++/WinRT you typically pass and receive familar C++ data types when calling WinRT APIs. More information is in [Using Standard C++ types with C++ WinRT](./Docs/Using Standard C++ types with C++ WinRT.md).
 
-For information about how to migrate existing C++/CX code to C++/WinRT, read [Migrating C++ CX source code to C++ WinRT] (./Docs/Migrating C++ CX source code to C++ WinRT.md).
+For information about how to migrate existing C++/CX code to C++/WinRT, read [Migrating C++ CX source code to C++ WinRT](./Docs/Migrating C++ CX source code to C++ WinRT.md).
 
-When you need to write code that works directly with COM and WinRT interfaces, you'll find the necessary information in [Interoperability Helper Functions] (./Docs/Interoperability Helper Functions.md).
+When you need to write code that works directly with COM and WinRT interfaces, you'll find the necessary information in [Interoperability Helper Functions](./Docs/Interoperability Helper Functions.md).

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ pull requests. Please read this entire page carefully.
 
 #### From an engineering standpoint, please make sure that you can build and test the code. Familiarize yourself with our project guidelines and coding conventions. 
 We recommend that you read these great posts about open source: 
-* [Open Source Contribution Etiquette] (http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza 
-* [Don't "Push" Your Pull Requests] (https://www.igvita.com/2011/12/19/dont-push-your-pull-requests) by Ilya Grigorik 
-* [A Successful Git Branching Model] (http://nvie.com/posts/a-successful-git-branching-model/) by Vincent Driessen 
+* [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza 
+* [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests) by Ilya Grigorik 
+* [A Successful Git Branching Model](http://nvie.com/posts/a-successful-git-branching-model/) by Vincent Driessen 
 
 Before you start working on a feature or substantial code contribution please discuss it with the team and ensure it is an appropriate addition to the core product. 
 


### PR DESCRIPTION
Links in `README.md` and `Getting Started.md` had a space between the square and round brackets, breaking the rendering of the link.

This pull request fixes them.