### PR TITLE
NDEBUG fix

### DIFF
--- a/10.0.14393.0/winrt/base.h
+++ b/10.0.14393.0/winrt/base.h
@@ -55,7 +55,7 @@ extern "C"
 #pragma comment(linker, "/alternatename:WINRT_SetRestrictedErrorInfo=SetRestrictedErrorInfo")
 #endif
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(NDEBUG)
 
 #include <assert.h>
 

--- a/10.0.15063.0/winrt/base.h
+++ b/10.0.15063.0/winrt/base.h
@@ -55,7 +55,7 @@ extern "C"
 #pragma comment(linker, "/alternatename:WINRT_SetRestrictedErrorInfo=SetRestrictedErrorInfo")
 #endif
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(NDEBUG)
 
 #include <assert.h>
 


### PR DESCRIPTION
Fix `NDEBUG` randomly breaking parts of the library because `assert` goes to `((void)0)` when the macro is defined.