### PR TITLE
Fixed compile error in event_revoker::operator bool()

### DIFF
--- a/10.0.16299.0/winrt/base.h
+++ b/10.0.16299.0/winrt/base.h
@@ -3976,7 +3976,7 @@ WINRT_EXPORT namespace winrt
 
         explicit operator bool() const noexcept
         {
-            return m_object != nullptr;
+            return static_cast<bool>(m_object);
         }
 
     private:


### PR DESCRIPTION
This code causes the compile error "...\cppwinrt\winrt\base.h(3858): error C2678: binary '!=': no operator found which takes a left-hand operand of type 'const winrt::weak_ref<I>' (or there is no acceptable conversion):

```
winrt::event_revoker<IAppServiceConnection> r;
if (r)
{
// ...
}
```
