### PR TITLE
Fix implementation of static events

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -478,15 +478,15 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method) || is_remove_overload(method))
                     {
-                        auto format = R"(    auto %::%(%)
+                        auto format = R"(    % %::%(%)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
         return f.%(%);
     }
 )";
 
-
                         w.write(format,
+                            signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),

--- a/test/test_component/Simple.h
+++ b/test/test_component/Simple.h
@@ -12,6 +12,10 @@ namespace winrt::test_component::implementation
         Windows::Foundation::IAsyncOperation<int32_t> Operation(Windows::Foundation::DateTime value);
         Windows::Foundation::IAsyncAction Action(Windows::Foundation::DateTime value);
         Windows::Foundation::IInspectable Object(Windows::Foundation::DateTime const& value);
+
+        // All we care about static events (for now) is that they build.
+        static event_token StaticEvent(Windows::Foundation::EventHandler<IInspectable> const&) { return {}; }
+        static void StaticEvent(event_token) { }
     };
 }
 namespace winrt::test_component::factory_implementation

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -54,6 +54,7 @@ namespace test_component
         Windows.Foundation.IAsyncOperation<Int32> Operation(Windows.Foundation.DateTime value);
         Windows.Foundation.IAsyncAction Action(Windows.Foundation.DateTime value);
         Object Object(Windows.Foundation.DateTime value);
+        static event Windows.Foundation.EventHandler<Object> StaticEvent;
     }
 
     runtimeclass DeferrableEventArgs


### PR DESCRIPTION
Return value for static events was declared as event_token in the header (when built as a component), but as auto in the implementation.

Align implementation with header.

This fixes #364 