### PR TITLE
Race condition in resume_foreground(DispatcherQueue)

### DIFF
--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -62,6 +62,8 @@ extern "C"
     void    __stdcall WINRT_WakeAllConditionVariable(winrt::impl::condition_variable* cv) noexcept;
     void*   __stdcall WINRT_InterlockedPushEntrySList(void* head, void* entry) noexcept;
     void*   __stdcall WINRT_InterlockedFlushSList(void* head) noexcept;
+    int32_t __stdcall WINRT_WaitOnAddress(volatile void* address, void* compare_address, size_t address_size, uint32_t milliseconds) noexcept;
+    void    __stdcall WINRT_WakeByAddressAll(void* address) noexcept;
 
     void* __stdcall WINRT_CreateEventW(void*, int32_t, int32_t, void*) noexcept;
     int32_t __stdcall WINRT_SetEvent(void*) noexcept;
@@ -157,6 +159,8 @@ WINRT_IMPL_LINK(WakeConditionVariable, 4)
 WINRT_IMPL_LINK(WakeAllConditionVariable, 4)
 WINRT_IMPL_LINK(InterlockedPushEntrySList, 8)
 WINRT_IMPL_LINK(InterlockedFlushSList, 4)
+WINRT_IMPL_LINK(WaitOnAddress, 16)
+WINRT_IMPL_LINK(WakeByAddressAll, 4)
 
 WINRT_IMPL_LINK(CreateEventW, 16)
 WINRT_IMPL_LINK(SetEvent, 4)

--- a/strings/base_lock.h
+++ b/strings/base_lock.h
@@ -118,4 +118,29 @@ WINRT_EXPORT namespace winrt
     private:
         impl::condition_variable m_cv{};
     };
+
+    struct slim_event
+    {
+        slim_event(slim_event const&) = delete;
+        slim_event const& operator=(slim_event const&) = delete;
+        slim_event() noexcept = default;
+
+        void signal() noexcept
+        {
+            signaled = true;
+            WINRT_WakeByAddressAll(&signaled);
+        }
+
+        void wait() noexcept
+        {
+            while (!signaled)
+            {
+                bool not_ready = false;
+                WINRT_WaitOnAddress(&signaled, &not_ready, sizeof(not_ready), 0xFFFFFFFF); // INFINITE
+            }
+        }
+
+    private:
+        bool signaled = false;
+    };
 }


### PR DESCRIPTION
It's possible for the lambda to run before control returns to the caller of TryEnqueue. This led to async_suspend accessing m_queued after it has already been destroyed.

We need to prevent the lambda from invoking the handler until async_suspend has stored the result of TryEnqueue into m_queued.

We do this by making the lambda wait until async_suspend is ready before invoking the handler. The slim_event cannot be a local in await_suspend because the lambda may run after await_suspend has returned. We put it in the awaiter. (Another option is putting it in the lambda, but that was messier.)

I chose a slim_event rather than a full kernel event because allocating a kernel event for every co_await seemed too expensive, especially because the wait is almost never going to block.

This commit introduces winrt::slim_event which is an event that starts out unsignaled but can be signaled. Once signaled, it cannot be reset. It is the size of a bool. For simplicity, only infinite waits are permitted. (Otherwise, I would have to recalculate the timeout when a spurious wake occurs.)

This fixes #370 