### PR TITLE
Add prefix to build folder to avoid incorrect tab completion

### DIFF
--- a/build_projection.cmd
+++ b/build_projection.cmd
@@ -28,5 +28,5 @@ if "%target_configuration%"=="" (
 )
 
 echo Building projection into %target_platform% %target_configuration%
-%~p0\build\x64\Release\cppwinrt.exe -in local -out %~p0\build\%target_platform%\%target_configuration% -verbose
+%~p0\_build\x64\Release\cppwinrt.exe -in local -out %~p0\_build\%target_platform%\%target_configuration% -verbose
 echo.

--- a/cppwinrt.props
+++ b/cppwinrt.props
@@ -39,9 +39,9 @@
     <CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">2.3.4.5</CppWinRTBuildVersion>
     <CmakePlatform>$(Platform)</CmakePlatform>
     <CmakePlatform Condition="'$(Platform)'=='Win32'">x86</CmakePlatform>
-    <CmakeOutDir Condition="'$(CmakeOutDir)'==''">$(SolutionDir)build\$(CmakePlatform)\$(Configuration)</CmakeOutDir>
+    <CmakeOutDir Condition="'$(CmakeOutDir)'==''">$(SolutionDir)_build\$(CmakePlatform)\$(Configuration)</CmakeOutDir>
     <CppWinRTDir>$(CmakeOutDir)\</CppWinRTDir>
-    <CppWinRTDir Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$(SolutionDir)build\x86\$(Configuration)\</CppWinRTDir>
+    <CppWinRTDir Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$(SolutionDir)_build\x86\$(Configuration)\</CppWinRTDir>
     <OutDir>$(CmakeOutDir)\</OutDir>
   </PropertyGroup>
 

--- a/run_tests.cmd
+++ b/run_tests.cmd
@@ -1,6 +1,6 @@
-build\x64\Debug\test.exe
-build\x64\Debug\test_fast.exe
-build\x64\Debug\test_slow.exe
-build\x64\Debug\test_old.exe
-build\x64\Debug\test_module_lock_custom.exe
-build\x64\Debug\test_module_lock_none.exe
+_build\x64\Debug\test.exe
+_build\x64\Debug\test_fast.exe
+_build\x64\Debug\test_slow.exe
+_build\x64\Debug\test_old.exe
+_build\x64\Debug\test_module_lock_custom.exe
+_build\x64\Debug\test_module_lock_none.exe


### PR DESCRIPTION
Running `build_projection.cmd` is a routine part of C++/WinRT development and this makes for a more convenient inner loop as it avoids command line tab completion to the build folder.