### PR TITLE
Race condition in resume_foreground(DispatcherQueue)

### DIFF
--- a/strings/base_coroutine_system.h
+++ b/strings/base_coroutine_system.h
@@ -25,16 +25,14 @@ WINRT_EXPORT namespace winrt
 
             bool await_suspend(std::experimental::coroutine_handle<> handle)
             {
-                m_queued = m_dispatcher.TryEnqueue(m_priority, [handle]
+                return m_dispatcher.TryEnqueue(m_priority, [handle, this]
                     {
+                        m_queued = true;
                         handle();
                     });
-
-                return m_queued;
             }
 
         private:
-
             Windows::System::DispatcherQueue const& m_dispatcher;
             Windows::System::DispatcherQueuePriority const m_priority;
             bool m_queued{};


### PR DESCRIPTION
This fixes the problem of async_suspend accessing member variables after calling TryEnqueue.

It's possible for the lambda to run before control returns to the caller of TryEnqueue. This led to async_suspend accessing m_queued after it has already been destroyed by the lambda.

We make the lambda responsible for setting m_queued prior to resuming the coroutine.  The lambda can infer that the task was queued by the fact that the lambda is running at all!

If the enqueue fails, then m_queued remains at its initial value of false.

This fixes #370