### PR TITLE
The CppWinRTAddXamlReferences/CppWinRTSetXamlLocalAssembly targets should only execute if the xaml language is CppWinRT.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -535,7 +535,9 @@ $(XamlMetaDataProviderPch)
     <Target Name="CppWinRTMakeProjections" DependsOnTargets="CppWinRTCalculateEnabledProjections;CppWinRTMakePlatformProjection;CppWinRTMakeReferenceProjection;CppWinRTMakeComponentProjection;$(CppWinRTMakeProjectionsDependsOn)" />
 
     <!--Add references to all merged project WinMD files for Xaml Compiler-->
-    <Target Name="CppWinRTAddXamlReferences" DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn)">
+    <Target Name="CppWinRTAddXamlReferences"
+            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT'"
+            DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn)">
         <ItemGroup>
             <XamlReferencesToCompile Include="$(OutDir)*.winmd" />
         </ItemGroup>
@@ -543,7 +545,9 @@ $(XamlMetaDataProviderPch)
 
     <!--Clear merged assembly and set local assembly for Xaml Compiler.
         (Note: this can be removed when CppWinRT references are removed from the Xaml targets file.)-->
-    <Target Name="CppWinRTSetXamlLocalAssembly" DependsOnTargets="$(CppWinRTSetXamlLocalAssemblyDependsOn)">
+    <Target Name="CppWinRTSetXamlLocalAssembly"            
+            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT'"
+            DependsOnTargets="$(CppWinRTSetXamlLocalAssemblyDependsOn)">
         <PropertyGroup>
             <CppWinRTMetadataAssembly></CppWinRTMetadataAssembly>
             <XamlLocalAssembly>$(CppWinRTProjectWinMD)</XamlLocalAssembly>


### PR DESCRIPTION
The CppWinRTAddXamlReferences/CppWinRTSetXamlLocalAssembly targets should only execute if the xaml language is CppWinRT.

Currently this also affects CX projects and since the winmd files are not yet available by the time this target runs, it causes non-determinism for subsequent builds when files do exist.