### PR TITLE
Only build the reference projection when there are references.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -443,7 +443,7 @@ $(XamlMetaDataProviderPch)
 
   <!--Build reference projection from WinMD project references and dynamic library project references-->
   <Target Name="CppWinRTMakeReferenceProjection"
-          Condition="'$(CppWinRTEnableReferenceProjection)' == 'true'"
+          Condition="'@(CppWinRTDirectWinMDReferences)@(CppWinRTDynamicProjectWinMDReferences)' != '' AND '$(CppWinRTEnableReferenceProjection)' == 'true'"
           DependsOnTargets="GetCppWinRTProjectWinMDReferences;GetCppWinRTPlatformWinMDReferences;GetCppWinRTDirectWinMDReferences;$(CppWinRTMakeReferenceProjectionDependsOn)"
           Inputs="@(CppWinRTDirectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
           Outputs="@(CppWinRTDirectWinMDReferences->'$(GeneratedFilesDir)winrt\%(Filename).h');@(CppWinRTDynamicProjectWinMDReferences->'$(GeneratedFilesDir)winrt\%(Filename).h')">


### PR DESCRIPTION
Only build the reference projection when there are references.

Fixes #391 