### PR TITLE
Format the targets file.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -433,7 +433,6 @@ $(XamlMetaDataProviderPch)
     <!--Build reference projection from WinMD project references and dynamic library project references-->
     <Target Name="CppWinRTMakeReferenceProjection"
             Condition="'@(CppWinRTDirectWinMDReferences)@(CppWinRTDynamicProjectWinMDReferences)' != '' AND '$(CppWinRTEnableReferenceProjection)' == 'true'"
-            Condition="'$(CppWinRTEnableReferenceProjection)' == 'true'"
             DependsOnTargets="GetCppWinRTProjectWinMDReferences;GetCppWinRTPlatformWinMDReferences;GetCppWinRTDirectWinMDReferences;$(CppWinRTMakeReferenceProjectionDependsOn)"
             Inputs="@(CppWinRTDirectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
             Outputs="$(IntDir)cppwinrt_ref.rsp">


### PR DESCRIPTION
Currently the targets file uses a mix of 2 and 4 space indents. This change makes it 4 spaces throughout the file to make it consistent with the props file.