### PR TITLE
Add CppWinRTGenerateWindowsMetadata property to more quickly determine if a project outputs a winmd.

### DIFF
--- a/nuget/CppWinrtRules.Project.xml
+++ b/nuget/CppWinrtRules.Project.xml
@@ -73,7 +73,7 @@
     
   <BoolProperty Name="CppWinRTGenerateWindowsMetadata"
                 DisplayName="Generate Windows Metadata"
-                Description="Enables or disabled the generation of Windows Metadata"
+                Description="Enables or disables the generation of Windows Metadata"
                 Category="General" />
 
 </Rule>

--- a/nuget/CppWinrtRules.Project.xml
+++ b/nuget/CppWinrtRules.Project.xml
@@ -70,5 +70,10 @@
                 DisplayName="Optimized"
                 Description="Enables component projection optimization features (e.g., unified construction)"
                 Category="General" />
+    
+  <BoolProperty Name="CppWinRTGenerateWindowsMetadata"
+                DisplayName="Generate Windows Metadata"
+                Description="Enables or disabled the generation of Windows Metadata"
+                Category="General" />
 
 </Rule>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </ItemGroup>
     </Target>
 
+    <!-- Target used only to evaluate CppWinRTGenerateWindowsMetadata if it doesn't already have a value -->
     <Target Name="ComputeCppWinRTResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"
             DependsOnTargets="GetCppWinRTMdMergeInputs">
@@ -419,6 +420,7 @@ $(XamlMetaDataProviderPch)
     </Target>
 
     <!-- Only copy winmd to output folder if CppWinRTGenerateWindowsMetadata is true -->
+    <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTResolvedWinMDToOutputDirectory"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == 'true'"
             DependsOnTargets="CppWinRTMergeProjectWinMDInputs;$(CppWinRTResolvedWinMDToOutputDirectoryDependsOn)"

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -37,7 +37,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <WindowsSDK_MetadataFoundationPath Condition="('$(WindowsSDK_MetadataFoundationPath)'!='') And !Exists($(WindowsSDK_MetadataFoundationPath))">$(WindowsSDK_MetadataPathVersioned)</WindowsSDK_MetadataFoundationPath>
 
         <GetTargetPathDependsOn>
-            $(GetTargetPathDependsOn);GetCppWinRTMdMergeInputs;CppWinRTResolveWinMD;
+            $(GetTargetPathDependsOn);ComputeCppWinRTResolvedWinMD;CppWinRTResolvedWinMD;
         </GetTargetPathDependsOn>
         <PrepareForBuildDependsOn>
             $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion;
@@ -50,7 +50,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             $(ComputeMidlInputsTargets);CppWinRTComputeXamlGeneratedMidlInputs;CppWinRTSetMidlReferences;
         </ComputeMidlInputsTargets>
         <AfterMidlTargets>
-            $(AfterMidlTargets);GetCppWinRTMdMergeInputs;CppWinRTMergeProjectWinMDInputs;CppWinRTResolveWinMD;
+            $(AfterMidlTargets);
+            GetCppWinRTMdMergeInputs;
+            CppWinRTMergeProjectWinMDInputs;
+            ComputeCppWinRTResolvedWinMD;
+            CppWinRTResolvedWinMD;
+            CppWinRTResolvedWinMDToOutputDirectory;
         </AfterMidlTargets>
         <ResolveAssemblyReferencesDependsOn>
             $(ResolveAssemblyReferencesDependsOn);GetCppWinRTProjectWinMDReferences;CppWinRTRemoveStaticLibraries;
@@ -112,8 +117,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </ItemGroup>
     </Target>
 
-    <Target Name="CppWinRTResolveWinMD"
-            Condition="'@(CppWinRTMdMergeInputs)' != '' AND '$(CppWinRTEnableComponentProjection)' == 'true'"
+    <Target Name="ComputeCppWinRTResolvedWinMD"
+            Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"
+            DependsOnTargets="GetCppWinRTMdMergeInputs">
+        <PropertyGroup>
+            <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'!= ''">true</CppWinRTGenerateWindowsMetadata>
+            <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'== ''">false</CppWinRTGenerateWindowsMetadata>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="CppWinRTResolvedWinMD"
+            Condition="'$(CppWinRTGenerateWindowsMetadata)' == 'true'"
             Returns="@(WinMDFullPath)">
         <ItemGroup>
             <WinMDFullPath Remove="@(WinMDFullPath)"/>
@@ -127,7 +141,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 <ProjectType>$(ConfigurationType)</ProjectType>
             </WinMDFullPath>
         </ItemGroup>
-        <Message Text="CppWinRTResolveWinMD: @(WinMDFullPath->'%(FullPath)')" Importance="$(CppWinRTVerbosity)"/>
+        <Message Text="CppWinRTResolvedWinMD: @(WinMDFullPath->'%(FullPath)')" Importance="$(CppWinRTVerbosity)"/>
     </Target>
 
     <!-- Static library reference files are merged into the project that
@@ -372,7 +386,7 @@ $(XamlMetaDataProviderPch)
     <Target Name="CppWinRTMergeProjectWinMDInputs"
             DependsOnTargets="Midl;GetCppWinRTMdMergeInputs;$(CppWinRTMergeProjectWinMDInputsDependsOn)"
             Inputs="@(CppWinRTMdMergeInputs)"
-            Outputs="$(CppWinRTProjectWinMD)">
+            Outputs="@(_MdMergedOutput);$(IntDir)mdmerge.rsp">
         <PropertyGroup>
             <!--Note: CppWinRTNamespaceMergeDepth supersedes CppWinRTMergeDepth-->
             <_MdMergeDepth Condition="'$(CppWinRTNamespaceMergeDepth)' != ''">-n:$(CppWinRTNamespaceMergeDepth)</_MdMergeDepth>
@@ -401,11 +415,19 @@ $(XamlMetaDataProviderPch)
             <_MdMergedOutput Remove="@(_MdMergedOutput)"/>
             <_MdMergedOutput Include="$(CppWinRTMergedDir)*.winmd"/>
         </ItemGroup>
+        <Message Text="CppWinRTMdMerge output: @(MdMergeOutput)" Importance="$(CppWinRTVerbosity)"/>
+    </Target>
+
+    <!-- Only copy winmd to output folder if CppWinRTGenerateWindowsMetadata is true -->
+    <Target Name="CppWinRTResolvedWinMDToOutputDirectory"
+            Condition="'$(CppWinRTGenerateWindowsMetadata)' == 'true'"
+            DependsOnTargets="CppWinRTMergeProjectWinMDInputs;$(CppWinRTResolvedWinMDToOutputDirectoryDependsOn)"
+            Inputs="@(_MdMergedOutput)"
+            Outputs="$(CppWinRTProjectWinMD)">
         <Copy UseHardlinksIfPossible="$(CppWinRTUseHardlinksIfPossible)"
             SkipUnchangedFiles="$(CppWinRTSkipUnchangedFiles)"
             SourceFiles="@(_MdMergedOutput)"
             DestinationFiles="@(_MdMergedOutput->'$(OutDir)%(Filename)%(Extension)')" />
-        <Message Text="CppWinRTMdMerge output: @(MdMergeOutput)" Importance="$(CppWinRTVerbosity)"/>
     </Target>
 
     <!-- Build the platform projection from the winmds that sip with the platform in the Windows SDK -->

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -67,7 +67,7 @@ C++/WinRT behavior can be customized with these project properties:
 | CppWinRTFastAbi | true \| *false | Enables Fast ABI feature for both consuming and producing projections |
 | CppWinRTProjectLanguage | C++/CX \| *C++/WinRT | Selects the C++ dialect for the project.  C++/WinRT provides full projection support, C++/CX permits consuming projection headers. |
 | CppWinRTOptimized | true \| *false | Enables component projection [optimization features](https://kennykerr.ca/2019/06/07/cppwinrt-optimizing-components/) |
-| CppWinRTGenerateWindowsMetadata | true \| *false | Enables or disabled the generation of Windows Metadata as the project output |
+| CppWinRTGenerateWindowsMetadata | true \| *false | Indicates whether this project produces Windows Metadata |
 \*Default value
 
 To customize common C++/WinRT project properties: 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -67,6 +67,7 @@ C++/WinRT behavior can be customized with these project properties:
 | CppWinRTFastAbi | true \| *false | Enables Fast ABI feature for both consuming and producing projections |
 | CppWinRTProjectLanguage | C++/CX \| *C++/WinRT | Selects the C++ dialect for the project.  C++/WinRT provides full projection support, C++/CX permits consuming projection headers. |
 | CppWinRTOptimized | true \| *false | Enables component projection [optimization features](https://kennykerr.ca/2019/06/07/cppwinrt-optimizing-components/) |
+| CppWinRTGenerateWindowsMetadata | true \| *false | Enables or disabled the generation of Windows Metadata as the project output |
 \*Default value
 
 To customize common C++/WinRT project properties: 

--- a/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
+++ b/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
@@ -87,7 +87,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>TestRuntimeComponent1.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
+++ b/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
@@ -88,7 +88,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>TestRuntimeComponent2.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
+++ b/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
@@ -88,7 +88,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>TestRuntimeComponent3.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
+++ b/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
@@ -88,7 +88,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>TestRuntimeComponentEmpty.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/vsix/ProjectTemplates/VC/Windows Desktop/ConsoleApplication/ConsoleApplication.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Desktop/ConsoleApplication/ConsoleApplication.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/vsix/ProjectTemplates/VC/Windows Desktop/ConsoleApplication/ConsoleApplication.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Desktop/ConsoleApplication/ConsoleApplication.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/vsix/ProjectTemplates/VC/Windows Desktop/WindowsApplication/WindowsApplication.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Desktop/WindowsApplication/WindowsApplication.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/vsix/ProjectTemplates/VC/Windows Desktop/WindowsApplication/WindowsApplication.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Desktop/WindowsApplication/WindowsApplication.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/BlankApp.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/BlankApp.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/BlankApp.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/BlankApp.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>

--- a/vsix/ProjectTemplates/VC/Windows Universal/CoreApp/CoreApp.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/CoreApp/CoreApp.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>

--- a/vsix/ProjectTemplates/VC/Windows Universal/CoreApp/CoreApp.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/CoreApp/CoreApp.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>

--- a/vsix/ProjectTemplates/VC/Windows Universal/StaticLibrary/StaticLibrary.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/StaticLibrary/StaticLibrary.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <CppWinRTParameters>-lib $(MSBuildProjectName)</CppWinRTParameters>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>

--- a/vsix/ProjectTemplates/VC/Windows Universal/WindowsRuntimeComponent/WindowsRuntimeComponent.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/WindowsRuntimeComponent/WindowsRuntimeComponent.vcxproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
-    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
+    <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>

--- a/vsix/ProjectTemplates/VC/Windows Universal/WindowsRuntimeComponent/WindowsRuntimeComponent.vcxproj
+++ b/vsix/ProjectTemplates/VC/Windows Universal/WindowsRuntimeComponent/WindowsRuntimeComponent.vcxproj
@@ -3,6 +3,7 @@
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <CppWinRTGenerateWindowsMetadata >true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{$guid1$}</ProjectGuid>
     <ProjectName>$projectname$</ProjectName>


### PR DESCRIPTION
This PR adds the CppWinRTGenerateWindowsMetadata property to more quickly determine if a project outputs a winmd. This allows a project to determine this without evaluating all its project references for the presence of static libraries.

Tested NuGetTest.sln as well as various razzle projects.

Fixes #399 