### PR TITLE
Add a better default for CppWinRTGenerateWindowsMetadata for CX projects.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -23,6 +23,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <XamlNamespace Condition="'$(XamlNamespace)' == ''">Windows.UI.Xaml</XamlNamespace>
         <XamlMetaDataProviderIdl Condition="'$(XamlMetaDataProviderIdl)'== ''">$(GeneratedFilesDir)XamlMetaDataProvider.idl</XamlMetaDataProviderIdl>
         <XamlMetaDataProviderCpp Condition="'$(XamlMetaDataProviderCpp)'== ''">$(GeneratedFilesDir)XamlMetaDataProvider.cpp</XamlMetaDataProviderCpp>
+
+        <!-- For CX projects, CppWinRT will never output a winmd-->
+        <!-- NOTE: We don't set a default here as the default requires evaluation of project references
+             and this is done by the ComputeCppWinRTResolvedWinMD target. -->
+        <CppWinRTGenerateWindowsMetadata Condition="'$(CppWinRTGenerateWindowsMetadata)' == '' AND '$(CppWinRTProjectLanguage)' == 'C++/CX' ">false</CppWinRTGenerateWindowsMetadata>
+        <CppWinRTGenerateWindowsMetadata Condition="'$(CppWinRTGenerateWindowsMetadata)' == '' AND '$(XamlLanguage)' == 'C++' ">false</CppWinRTGenerateWindowsMetadata>
         <!-- For CX projects, turn off the component projection generation-->
         <CppWinRTEnableComponentProjection Condition="'$(CppWinRTEnableComponentProjection)' == '' AND '$(CppWinRTProjectLanguage)' == 'C++/CX' ">false</CppWinRTEnableComponentProjection>
         <CppWinRTEnableComponentProjection Condition="'$(CppWinRTEnableComponentProjection)' == '' AND '$(XamlLanguage)' == 'C++' ">false</CppWinRTEnableComponentProjection>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -125,9 +125,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Target Name="ComputeCppWinRTResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"
             DependsOnTargets="GetCppWinRTMdMergeInputs">
-
-        <Warning Text="CppWinRTGenerateWindowsMetadata property is undefined. Falling back to dynamic evaluation." />
-
         <PropertyGroup>
             <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'!= ''">true</CppWinRTGenerateWindowsMetadata>
             <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'== ''">false</CppWinRTGenerateWindowsMetadata>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -27,10 +27,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- For CX projects, CppWinRT will never output a winmd-->
         <!-- NOTE: We don't set a default here as the default requires evaluation of project references
              and this is done by the ComputeCppWinRTResolvedWinMD target. -->
-        <CppWinRTGenerateWindowsMetadata Condition="'$(CppWinRTGenerateWindowsMetadata)' == '' AND '$(CppWinRTProjectLanguage)' == 'C++/CX' ">false</CppWinRTGenerateWindowsMetadata>
         <CppWinRTGenerateWindowsMetadata Condition="'$(CppWinRTGenerateWindowsMetadata)' == '' AND '$(XamlLanguage)' == 'C++' ">false</CppWinRTGenerateWindowsMetadata>
         <!-- For CX projects, turn off the component projection generation-->
-        <CppWinRTEnableComponentProjection Condition="'$(CppWinRTEnableComponentProjection)' == '' AND '$(CppWinRTProjectLanguage)' == 'C++/CX' ">false</CppWinRTEnableComponentProjection>
         <CppWinRTEnableComponentProjection Condition="'$(CppWinRTEnableComponentProjection)' == '' AND '$(XamlLanguage)' == 'C++' ">false</CppWinRTEnableComponentProjection>
         <CppWinRTEnableComponentProjection Condition="'$(CppWinRTEnableComponentProjection)' == ''">true</CppWinRTEnableComponentProjection>
         <CppWinRTEnablePlatformProjection Condition="'$(CppWinRTEnablePlatformProjection)' == ''">true</CppWinRTEnablePlatformProjection>
@@ -127,6 +125,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Target Name="ComputeCppWinRTResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"
             DependsOnTargets="GetCppWinRTMdMergeInputs">
+
+        <Warning Text="CppWinRTGenerateWindowsMetadata property is undefined. Falling back to dynamic evaluation." />
+
         <PropertyGroup>
             <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'!= ''">true</CppWinRTGenerateWindowsMetadata>
             <CppWinRTGenerateWindowsMetadata Condition="'@(CppWinRTMdMergeInputs)'== ''">false</CppWinRTGenerateWindowsMetadata>


### PR DESCRIPTION
In #404, we added a property to enable Windows Metadata. We calculate a default is one is not specified, but there are a few cases where we know we should disable it without the need to calculate anything.

If the project specifically set a property to indicate it's a CX project, we will never generate a WinMD and we can therefore set CppWinRTGenerateWindowsMetadata to false. 