### PR TITLE
Fixing CppWinRT_IncludePath and the include paths that build on it to point to the generated headers

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -15,6 +15,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsNativeLanguage>true</IsNativeLanguage>
         <!-- This causes VS to add the platform WinMD references for the target SDK -->
         <WinMDAssembly>true</WinMDAssembly>
+        <!--Set a value to prevent SDK's uap.props from setting it and pointing to the wrong headers-->
+        <CppWinRT_IncludePath>PreventSdkUapPropsAssignment</CppWinRT_IncludePath>
     </PropertyGroup>
 
     <ItemDefinitionGroup>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -32,6 +32,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         <GeneratedFilesDir Condition="'$(GeneratedFilesDir)' == ''">$(IntDir)Generated Files\</GeneratedFilesDir>
         <!--Override SDK's uap.props setting to ensure version-matched headers-->
+        <CppWinRT_OldIncludePath>$(CppWinRT_IncludePath)</CppWinRT_OldIncludePath>
         <CppWinRT_IncludePath>$(GeneratedFilesDir)</CppWinRT_IncludePath>
         <!--TEMP: Override NuGet SDK's erroneous setting in uap.props -->
         <WindowsSDK_MetadataFoundationPath Condition="('$(WindowsSDK_MetadataFoundationPath)'!='') And !Exists($(WindowsSDK_MetadataFoundationPath))">$(WindowsSDK_MetadataPathVersioned)</WindowsSDK_MetadataFoundationPath>
@@ -40,7 +41,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             $(GetTargetPathDependsOn);ComputeCppWinRTResolvedWinMD;CppWinRTResolvedWinMD;
         </GetTargetPathDependsOn>
         <PrepareForBuildDependsOn>
-            $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion;
+            $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion;CppWinRTFixSDKIncludes;
         </PrepareForBuildDependsOn>
         <!-- Note: Before* targets run before Compute* targets. -->
         <BeforeMidlCompileTargets>
@@ -115,6 +116,28 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 <AdditionalOptions>%(ClCompile.AdditionalOptions) /DWINRT_NO_MAKE_DETECTION</AdditionalOptions>
             </ClCompile>
         </ItemGroup>
+    </Target>
+  
+    <!-- Fix includes to point to the generated C++/WinRT headers rather than the one in the SDK -->
+    <Target Name="CppWinRTFixSDKIncludes"
+            BeforeTargets="SetBuildDefaultEnvironmentVariables"
+            Condition="'$(CppWinRT_IncludePath)' != '$(CppWinRT_OldIncludePath)'">
+        <ItemGroup>
+            <_FixedSDKIncludes Remove="@(_FixedSDKIncludes)"/>
+            <_FixedSDKIncludes Include="$(WindowsSDK_IncludePath)"/>
+            <_FixedSDKIncludes Condition="'$(CppWinRT_OldIncludePath)' != ''" Remove="$(CppWinRT_OldIncludePath)"/>
+            <_FixedSDKIncludes Include="$(CppWinRT_IncludePath)"/>
+        </ItemGroup>
+        <ItemGroup>
+            <_FixedIncludes Remove="@(_FixedIncludes)"/>
+            <_FixedIncludes Include="$(IncludePath)"/>
+            <_FixedIncludes Condition="'$(CppWinRT_OldIncludePath)' != ''" Remove="$(CppWinRT_OldIncludePath)"/>
+            <_FixedIncludes Include="$(CppWinRT_IncludePath)"/>
+        </ItemGroup>
+        <PropertyGroup>
+            <WindowsSDK_IncludePath>@(_FixedSDKIncludes)</WindowsSDK_IncludePath>
+            <IncludePath>@(_FixedIncludes)</IncludePath>
+        </PropertyGroup>    
     </Target>
 
     <!-- Target used only to evaluate CppWinRTGenerateWindowsMetadata if it doesn't already have a value -->

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -32,7 +32,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         <GeneratedFilesDir Condition="'$(GeneratedFilesDir)' == ''">$(IntDir)Generated Files\</GeneratedFilesDir>
         <!--Override SDK's uap.props setting to ensure version-matched headers-->
-        <CppWinRT_OldIncludePath>$(CppWinRT_IncludePath)</CppWinRT_OldIncludePath>
         <CppWinRT_IncludePath>$(GeneratedFilesDir)</CppWinRT_IncludePath>
         <!--TEMP: Override NuGet SDK's erroneous setting in uap.props -->
         <WindowsSDK_MetadataFoundationPath Condition="('$(WindowsSDK_MetadataFoundationPath)'!='') And !Exists($(WindowsSDK_MetadataFoundationPath))">$(WindowsSDK_MetadataPathVersioned)</WindowsSDK_MetadataFoundationPath>
@@ -41,7 +40,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             $(GetTargetPathDependsOn);ComputeCppWinRTResolvedWinMD;CppWinRTResolvedWinMD;
         </GetTargetPathDependsOn>
         <PrepareForBuildDependsOn>
-            $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion;CppWinRTFixSDKIncludes;
+            $(PrepareForBuildDependsOn);CppWinRTVerifyKitVersion;
         </PrepareForBuildDependsOn>
         <!-- Note: Before* targets run before Compute* targets. -->
         <BeforeMidlCompileTargets>
@@ -118,28 +117,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </ItemGroup>
     </Target>
   
-    <!-- Fix includes to point to the generated C++/WinRT headers rather than the one in the SDK -->
-    <Target Name="CppWinRTFixSDKIncludes"
-            BeforeTargets="SetBuildDefaultEnvironmentVariables"
-            Condition="'$(CppWinRT_IncludePath)' != '$(CppWinRT_OldIncludePath)'">
-        <ItemGroup>
-            <_FixedSDKIncludes Remove="@(_FixedSDKIncludes)"/>
-            <_FixedSDKIncludes Include="$(WindowsSDK_IncludePath)"/>
-            <_FixedSDKIncludes Remove="$(CppWinRT_OldIncludePath)"/>
-            <_FixedSDKIncludes Include="$(CppWinRT_IncludePath)"/>
-        </ItemGroup>
-        <ItemGroup>
-            <_FixedIncludes Remove="@(_FixedIncludes)"/>
-            <_FixedIncludes Include="$(IncludePath)"/>
-            <_FixedIncludes Remove="$(CppWinRT_OldIncludePath)"/>
-            <_FixedIncludes Include="$(CppWinRT_IncludePath)"/>
-        </ItemGroup>
-        <PropertyGroup>
-            <WindowsSDK_IncludePath>@(_FixedSDKIncludes)</WindowsSDK_IncludePath>
-            <IncludePath>@(_FixedIncludes)</IncludePath>
-        </PropertyGroup>    
-    </Target>
-
     <!-- Target used only to evaluate CppWinRTGenerateWindowsMetadata if it doesn't already have a value -->
     <Target Name="ComputeCppWinRTResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -116,7 +116,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             </ClCompile>
         </ItemGroup>
     </Target>
-  
+
     <!-- Target used only to evaluate CppWinRTGenerateWindowsMetadata if it doesn't already have a value -->
     <Target Name="ComputeCppWinRTResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''"

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -125,13 +125,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <ItemGroup>
             <_FixedSDKIncludes Remove="@(_FixedSDKIncludes)"/>
             <_FixedSDKIncludes Include="$(WindowsSDK_IncludePath)"/>
-            <_FixedSDKIncludes Condition="'$(CppWinRT_OldIncludePath)' != ''" Remove="$(CppWinRT_OldIncludePath)"/>
+            <_FixedSDKIncludes Remove="$(CppWinRT_OldIncludePath)"/>
             <_FixedSDKIncludes Include="$(CppWinRT_IncludePath)"/>
         </ItemGroup>
         <ItemGroup>
             <_FixedIncludes Remove="@(_FixedIncludes)"/>
             <_FixedIncludes Include="$(IncludePath)"/>
-            <_FixedIncludes Condition="'$(CppWinRT_OldIncludePath)' != ''" Remove="$(CppWinRT_OldIncludePath)"/>
+            <_FixedIncludes Remove="$(CppWinRT_OldIncludePath)"/>
             <_FixedIncludes Include="$(CppWinRT_IncludePath)"/>
         </ItemGroup>
         <PropertyGroup>


### PR DESCRIPTION
Currently CppWinRT_IncludePath points to the includes in the installed Windows SDK and not to the dynamically generated headers.  This causes for scenarios where if a nuget SDK only has a partial set of winmds, the headers for the excluded winmds are found in the installed Windows SDK path.  This change fixes that by making CppWinRT_IncludePath and a few include paths that build on it to point to the generated headers location by removing the C++/WinRT SDK path and including the generated headers path.

It would have been ideal to do this in a props, but given we rely on InitDir which is set after our props, I ended up doing this as part of a target.