### PR TITLE
WINRT_LEAN_AND_MEAN should not exclude overridable interfaces

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1780,7 +1780,7 @@ namespace cppwinrt
         }
     }
 
-    static void write_produce(writer& w, TypeDef const& type)
+    static void write_produce(writer& w, TypeDef const& type, cache const& c)
     {
         auto format = R"(    template <typename D%>
     struct produce<D, %> : produce_base<D, %>
@@ -1790,7 +1790,7 @@ namespace cppwinrt
 
         auto generics = type.GenericParam();
         auto guard{ w.push_generic_params(generics) };
-        bool const lean_and_mean = !can_produce(type);
+        bool const lean_and_mean = !can_produce(type, c);
 
         if (lean_and_mean)
         {

--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -176,7 +176,7 @@ namespace cppwinrt
         write_impl_namespace(w);
         w.write_each<write_consume_definitions>(members.interfaces);
         w.write_each<write_delegate_implementation>(members.delegates);
-        w.write_each<write_produce>(members.interfaces);
+        w.write_each<write_produce>(members.interfaces, c);
         w.write_each<write_dispatch_overridable>(members.classes);
         write_close_namespace(w);
 

--- a/cppwinrt/helpers.h
+++ b/cppwinrt/helpers.h
@@ -855,7 +855,7 @@ namespace cppwinrt
             !members.delegates.empty();
     }
 
-    static bool can_produce(TypeDef const& type)
+    static bool can_produce(TypeDef const& type, cache const& c)
     {
         auto attribute = get_attribute(type, "Windows.Foundation.Metadata", "ExclusiveToAttribute");
 
@@ -864,12 +864,26 @@ namespace cppwinrt
             return true;
         }
 
+        auto interface_name = type_name(type);
+        auto class_name = get_attribute_value<ElemSig::SystemType>(attribute, 0).name;
+        auto class_type = c.find_required(class_name);
+
+        for (auto&& impl : class_type.InterfaceImpl())
+        {
+            if (has_attribute(impl, "Windows.Foundation.Metadata", "OverridableAttribute"))
+            {
+                if (interface_name == type_name(impl.Interface()))
+                {
+                    return true;
+                }
+            }
+        }
+
         if (!settings.component)
         {
             return false;
         }
 
-        auto class_name = get_attribute_value<ElemSig::SystemType>(attribute, 0).name;
         return settings.component_filter.includes(class_name);
     }
 }

--- a/cppwinrt/type_writers.h
+++ b/cppwinrt/type_writers.h
@@ -35,7 +35,19 @@ namespace cppwinrt
             name_space(type.TypeNamespace())
         {
         }
+
+        explicit type_name(coded_index<TypeDefOrRef> const& type)
+        {
+            auto const& [type_namespace, type_name] = get_type_namespace_and_name(type);
+            name_space = type_namespace;
+            name = type_name;
+        }
     };
+
+    bool operator==(type_name const& left, type_name const& right)
+    {
+        return left.name == right.name && left.name_space == right.name_space;
+    }
 
     bool operator==(type_name const& left, std::string_view const& right)
     {


### PR DESCRIPTION
Fixes #415 
