### PR TITLE
Workarounds to improve IntelliSense

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -366,14 +366,14 @@ namespace cppwinrt
 
         if (empty(generics))
         {
-            auto format = R"(    template <> inline constexpr auto& name_v<%>{ L"%.%" };
+            auto format = R"(    template <> inline constexpr auto& name_v<%> = L"%.%";
 )";
 
             w.write(format, type, type_name.name_space, type_name.name);
         }
         else
         {
-            auto format = R"(    template <%> inline constexpr auto name_v<%>{ zcombine(L"%.%<"%, L">") };
+            auto format = R"(    template <%> inline constexpr auto name_v<%> = zcombine(L"%.%<"%, L">");
 )";
 
             w.write(format,

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -916,8 +916,9 @@ namespace cppwinrt
         auto method_name = get_name(method);
         auto type = method.Parent();
 
-        w.write("        %auto %(%) const%;\n",
+        w.write("        %WINRT_IMPL_AUTO(%) %(%) const%;\n",
             is_get_overload(method) ? "[[nodiscard]] " : "",
+            signature.return_signature(),
             method_name,
             bind<write_consume_params>(signature),
             is_noexcept(method) ? " noexcept" : "");
@@ -1054,7 +1055,7 @@ namespace cppwinrt
 
         if (is_noexcept(method))
         {
-            format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
+            format = R"(    template <typename D%> WINRT_IMPL_AUTO(%) consume_%<D%>::%(%) const noexcept
     {%
         WINRT_VERIFY_(0, WINRT_IMPL_SHIM(%)->%(%));%
     }
@@ -1062,7 +1063,7 @@ namespace cppwinrt
         }
         else
         {
-            format = R"(    template <typename D%> auto consume_%<D%>::%(%) const
+            format = R"(    template <typename D%> WINRT_IMPL_AUTO(%) consume_%<D%>::%(%) const
     {%
         check_hresult(WINRT_IMPL_SHIM(%)->%(%));%
     }
@@ -1071,6 +1072,7 @@ namespace cppwinrt
 
         w.write(format,
             bind<write_comma_generic_typenames>(generics),
+            signature.return_signature(),
             type_impl_name,
             bind<write_comma_generic_types>(generics),
             method_name,
@@ -1118,13 +1120,14 @@ namespace cppwinrt
         // return static_cast<% const&>(*this).%(%);
         //
 
-        std::string_view format = R"(    inline auto %::%(%) const%
+        std::string_view format = R"(    inline WINRT_IMPL_AUTO(%) %::%(%) const%
     {
         return [&](% const& winrt_impl_base) { return winrt_impl_base.%(%); }(*this);
     }
 )";
 
         w.write(format,
+            signature.return_signature(),
             class_type.TypeName(),
             method_name,
             bind<write_consume_params>(signature),

--- a/strings/base_foundation.h
+++ b/strings/base_foundation.h
@@ -102,9 +102,9 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
 
 namespace winrt::impl
 {
-    template <> inline constexpr auto& name_v<Windows::Foundation::Point>{ L"Windows.Foundation.Point" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Size>{ L"Windows.Foundation.Size" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Rect>{ L"Windows.Foundation.Rect" };
+    template <> inline constexpr auto& name_v<Windows::Foundation::Point> = L"Windows.Foundation.Point";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Size> = L"Windows.Foundation.Size";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Rect> = L"Windows.Foundation.Rect";
 
     template <> struct category<Windows::Foundation::Point>
     {
@@ -123,13 +123,13 @@ namespace winrt::impl
 
 #ifdef WINRT_IMPL_NUMERICS
 
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float2>{ L"Windows.Foundation.Numerics.Vector2" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3>{ L"Windows.Foundation.Numerics.Vector3" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4>{ L"Windows.Foundation.Numerics.Vector4" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3x2>{ L"Windows.Foundation.Numerics.Matrix3x2" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4x4>{ L"Windows.Foundation.Numerics.Matrix4x4" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::quaternion>{ L"Windows.Foundation.Numerics.Quaternion" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::plane>{ L"Windows.Foundation.Numerics.Plane" };
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float2> = L"Windows.Foundation.Numerics.Vector2";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3> = L"Windows.Foundation.Numerics.Vector3";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4> = L"Windows.Foundation.Numerics.Vector4";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3x2> = L"Windows.Foundation.Numerics.Matrix3x2";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4x4> = L"Windows.Foundation.Numerics.Matrix4x4";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::quaternion> = L"Windows.Foundation.Numerics.Quaternion";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::plane> = L"Windows.Foundation.Numerics.Plane";
 
     template <> struct category<Windows::Foundation::Numerics::float2>
     {

--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -271,12 +271,12 @@ namespace winrt::impl
     }
 
     template <size_t Size>
-    constexpr std::array<uint32_t, 5> process_msg_block(std::array<uint8_t, Size> const& input, uint32_t start_pos, std::array<uint32_t, 5> const& intermediate_hash) noexcept
+    constexpr std::array<uint32_t, 5> process_msg_block(std::array<uint8_t, Size> const& input, size_t start_pos, std::array<uint32_t, 5> const& intermediate_hash) noexcept
     {
         uint32_t const K[4] = { 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6 };
         std::array<uint32_t, 80> W = {};
 
-        uint32_t t = 0;
+        size_t t = 0;
         uint32_t temp = 0;
 
         for (t = 0; t < 16; t++)
@@ -357,13 +357,13 @@ namespace winrt::impl
     }
 
     template <size_t Size, size_t RemainingSize, size_t... Index>
-    constexpr std::array<uint8_t, RemainingSize + 1> make_remaining([[maybe_unused]] std::array<uint8_t, Size> const& input, [[maybe_unused]] uint32_t start_pos, std::index_sequence<Index...>) noexcept
+    constexpr std::array<uint8_t, RemainingSize + 1> make_remaining([[maybe_unused]] std::array<uint8_t, Size> const& input, [[maybe_unused]] size_t start_pos, std::index_sequence<Index...>) noexcept
     {
         return { input[Index + start_pos]..., 0x80 };
     }
 
     template <size_t Size>
-    constexpr auto make_remaining(std::array<uint8_t, Size> const& input, uint32_t start_pos) noexcept
+    constexpr auto make_remaining(std::array<uint8_t, Size> const& input, size_t start_pos) noexcept
     {
         constexpr auto remaining_size = Size % 64;
         return make_remaining<Size, remaining_size>(input, start_pos, std::make_index_sequence<remaining_size>());
@@ -409,7 +409,7 @@ namespace winrt::impl
     constexpr auto calculate_sha1(std::array<uint8_t, Size> const& input) noexcept
     {
         std::array<uint32_t, 5> intermediate_hash{ 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
-        uint32_t i = 0;
+        size_t i = 0;
 
         while (i + 64 <= Size)
         {
@@ -536,44 +536,44 @@ namespace winrt::impl
     constexpr guid generic_guid_v{};
 
     template <typename T>
-    constexpr auto& basic_signature_v{""};
+    constexpr auto& basic_signature_v = "";
 
-    template <> inline constexpr auto& basic_signature_v<bool>{"b1"};
-    template <> inline constexpr auto& basic_signature_v<int8_t>{"i1"};
-    template <> inline constexpr auto& basic_signature_v<int16_t>{"i2"};
-    template <> inline constexpr auto& basic_signature_v<int32_t>{"i4"};
-    template <> inline constexpr auto& basic_signature_v<int64_t>{"i8"};
-    template <> inline constexpr auto& basic_signature_v<uint8_t>{"u1"};
-    template <> inline constexpr auto& basic_signature_v<uint16_t>{"u2"};
-    template <> inline constexpr auto& basic_signature_v<uint32_t>{"u4"};
-    template <> inline constexpr auto& basic_signature_v<uint64_t>{"u8"};
-    template <> inline constexpr auto& basic_signature_v<float>{"f4"};
-    template <> inline constexpr auto& basic_signature_v<double>{"f8"};
-    template <> inline constexpr auto& basic_signature_v<char16_t>{"c2"};
-    template <> inline constexpr auto& basic_signature_v<guid>{"g16"};
-    template <> inline constexpr auto& basic_signature_v<hstring>{"string"};
-    template <> inline constexpr auto& basic_signature_v<Windows::Foundation::IInspectable>{"cinterface(IInspectable)"};
+    template <> inline constexpr auto& basic_signature_v<bool> = "b1";
+    template <> inline constexpr auto& basic_signature_v<int8_t> = "i1";
+    template <> inline constexpr auto& basic_signature_v<int16_t> = "i2";
+    template <> inline constexpr auto& basic_signature_v<int32_t> = "i4";
+    template <> inline constexpr auto& basic_signature_v<int64_t> = "i8";
+    template <> inline constexpr auto& basic_signature_v<uint8_t> = "u1";
+    template <> inline constexpr auto& basic_signature_v<uint16_t> = "u2";
+    template <> inline constexpr auto& basic_signature_v<uint32_t> = "u4";
+    template <> inline constexpr auto& basic_signature_v<uint64_t> = "u8";
+    template <> inline constexpr auto& basic_signature_v<float> = "f4";
+    template <> inline constexpr auto& basic_signature_v<double> = "f8";
+    template <> inline constexpr auto& basic_signature_v<char16_t> = "c2";
+    template <> inline constexpr auto& basic_signature_v<guid> = "g16";
+    template <> inline constexpr auto& basic_signature_v<hstring> = "string";
+    template <> inline constexpr auto& basic_signature_v<Windows::Foundation::IInspectable> = "cinterface(IInspectable)";
 
-    template <> inline constexpr auto& name_v<bool>{ L"Boolean" };
-    template <> inline constexpr auto& name_v<int8_t>{ L"Int8" };
-    template <> inline constexpr auto& name_v<int16_t>{ L"Int16" };
-    template <> inline constexpr auto& name_v<int32_t>{ L"Int32" };
-    template <> inline constexpr auto& name_v<int64_t>{ L"Int64" };
-    template <> inline constexpr auto& name_v<uint8_t>{ L"UInt8" };
-    template <> inline constexpr auto& name_v<uint16_t>{ L"UInt16" };
-    template <> inline constexpr auto& name_v<uint32_t>{ L"UInt32" };
-    template <> inline constexpr auto& name_v<uint64_t>{ L"UInt64" };
-    template <> inline constexpr auto& name_v<float>{ L"Single" };
-    template <> inline constexpr auto& name_v<double>{ L"Double" };
-    template <> inline constexpr auto& name_v<char16_t>{ L"Char16" };
-    template <> inline constexpr auto& name_v<guid>{ L"Guid" };
-    template <> inline constexpr auto& name_v<hstring>{ L"String" };
-    template <> inline constexpr auto& name_v<hresult>{ L"Windows.Foundation.HResult" };
-    template <> inline constexpr auto& name_v<event_token>{ L"Windows.Foundation.EventRegistrationToken" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::IInspectable>{ L"Object" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::TimeSpan>{ L"Windows.Foundation.TimeSpan" };
-    template <> inline constexpr auto& name_v<Windows::Foundation::DateTime>{ L"Windows.Foundation.DateTime" };
-    template <> inline constexpr auto& name_v<IAgileObject>{ L"IAgileObject" };
+    template <> inline constexpr auto& name_v<bool> = L"Boolean";
+    template <> inline constexpr auto& name_v<int8_t> = L"Int8";
+    template <> inline constexpr auto& name_v<int16_t> = L"Int16";
+    template <> inline constexpr auto& name_v<int32_t> = L"Int32";
+    template <> inline constexpr auto& name_v<int64_t> = L"Int64";
+    template <> inline constexpr auto& name_v<uint8_t> = L"UInt8";
+    template <> inline constexpr auto& name_v<uint16_t> = L"UInt16";
+    template <> inline constexpr auto& name_v<uint32_t> = L"UInt32";
+    template <> inline constexpr auto& name_v<uint64_t> = L"UInt64";
+    template <> inline constexpr auto& name_v<float> = L"Single";
+    template <> inline constexpr auto& name_v<double> = L"Double";
+    template <> inline constexpr auto& name_v<char16_t> = L"Char16";
+    template <> inline constexpr auto& name_v<guid> = L"Guid";
+    template <> inline constexpr auto& name_v<hstring> = L"String";
+    template <> inline constexpr auto& name_v<hresult> = L"Windows.Foundation.HResult";
+    template <> inline constexpr auto& name_v<event_token> = L"Windows.Foundation.EventRegistrationToken";
+    template <> inline constexpr auto& name_v<Windows::Foundation::IInspectable> = L"Object";
+    template <> inline constexpr auto& name_v<Windows::Foundation::TimeSpan> = L"Windows.Foundation.TimeSpan";
+    template <> inline constexpr auto& name_v<Windows::Foundation::DateTime> = L"Windows.Foundation.DateTime";
+    template <> inline constexpr auto& name_v<IAgileObject> = L"IAgileObject";
 
     template <> struct category<bool> { using type = basic_category; };
     template <> struct category<int8_t> { using type = basic_category; };

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -15,6 +15,12 @@
 
 #define WINRT_IMPL_SHIM(...) (*(abi_t<__VA_ARGS__>**)&static_cast<__VA_ARGS__ const&>(static_cast<D const&>(*this)))
 
+#ifdef __INTELLISENSE__
+#define WINRT_IMPL_AUTO(...) __VA_ARGS__
+#else
+#define WINRT_IMPL_AUTO(...) auto
+#endif
+
 // Note: this is a workaround for a false-positive warning produced by the Visual C++ 15.9 compiler.
 #pragma warning(disable : 5046)
 

--- a/test/old_tests/UnitTests/IReference.cpp
+++ b/test/old_tests/UnitTests/IReference.cpp
@@ -30,23 +30,6 @@ TEST_CASE("IReference guids")
     REQUIRE(guid_of<IReference<Numerics::float4x4>>() == ireference_matrix4x4);
     REQUIRE(guid_of<IReference<Numerics::plane>>() == ireference_plane);
     REQUIRE(guid_of<IReference<Numerics::quaternion>>() == ireference_quaternion);
-
-    REQUIRE(guid_of<IReference<bool>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<bool>)));
-    REQUIRE(guid_of<IReference<uint8_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<uint8_t>)));
-    REQUIRE(guid_of<IReference<int16_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<int16_t>)));
-    REQUIRE(guid_of<IReference<uint32_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<uint32_t>)));
-    REQUIRE(guid_of<IReference<int32_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<int32_t>)));
-    REQUIRE(guid_of<IReference<uint64_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<uint64_t>)));
-    REQUIRE(guid_of<IReference<int64_t>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<int64_t>)));
-    REQUIRE(guid_of<IReference<float>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<float>)));
-    REQUIRE(guid_of<IReference<double>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<double>)));
-    REQUIRE(guid_of<IReference<guid>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<GUID>)));
-
-    REQUIRE(guid_of<IReference<winrt::Windows::Foundation::Point>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<::ABI::Windows::Foundation::Point>)));
-    REQUIRE(guid_of<IReference<winrt::Windows::Foundation::Rect>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<::ABI::Windows::Foundation::Rect>)));
-
-    REQUIRE(guid_of<IReference<winrt::Windows::Foundation::DateTime>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<::ABI::Windows::Foundation::DateTime>)));
-    REQUIRE(guid_of<IReference<winrt::Windows::Foundation::TimeSpan>>() == guid(__uuidof(::ABI::Windows::Foundation::IReference<::ABI::Windows::Foundation::TimeSpan>)));
 }
 
 TEST_CASE("IReference, constructor and getter")


### PR DESCRIPTION
A collection of changes to address various issues with IntelliSense usability.

* Use `=` instead of `{ }` for variable templates to workaround IntelliSense bug
* Use `WINRT_IMPL_AUTO` to avoid poor IntelliSense performance due to return type deduction
* Address type conversion warnings from IntelliSense compiler

Also a tweak to avoid brittle ABI headers not defining GUID specializations.

Fixes #384 