### PR TITLE
Improve type name compatibility

### DIFF
--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -84,14 +84,12 @@ namespace cppwinrt
 
         // Class names are always required for activation.
         // Class, enum, and struct names are required for producing GUIDs for generic types.
-        // Interface and delegates names are not required by WinRT.
+        // Interface and delegates names are required for Xaml compatibility.
         w.write_each<write_name>(members.classes);
         w.write_each<write_name>(members.enums);
         w.write_each<write_name>(members.structs);
-        write_lean_and_mean(w);
         w.write_each<write_name>(members.interfaces);
         w.write_each<write_name>(members.delegates);
-        write_endif(w);
 
         w.write_each<write_guid>(members.interfaces);
         w.write_each<write_guid>(members.delegates);

--- a/test/test/generic_type_names.cpp
+++ b/test/test/generic_type_names.cpp
@@ -1,10 +1,7 @@
-//
-// Note that WINRT_LEAN_AND_MEAN is not defined for these tests.
-//
-
 // Windows.Foundation is intentionally *not* included here to ensure that stable names/guids
 // are generated with only the xxx.0.h header. This ensures that indirect declarations produce
 // stable identity values.
+#define WINRT_LEAN_AND_MEAN
 #include "winrt/Windows.Storage.h"
 
 #include "catch.hpp"

--- a/test/test/generic_types.cpp
+++ b/test/test/generic_types.cpp
@@ -11,6 +11,6 @@ TEST_CASE("generic_types")
 
     // Clang 9 doesn't think this is a constant expression.
 #ifndef __clang__
-    REQUIRE_EQUAL_NAME(L"{96369f54-8eb6-48f0-abce-c1b211e627c3}", IStringable);
+    REQUIRE_EQUAL_NAME(L"Windows.Foundation.IStringable", IStringable);
 #endif
 }


### PR DESCRIPTION
Fixes #446 

The WINRT_LEAN_AND_MEAN optimization causes some trouble for Xaml. It sounds like a Xaml bug but righting that ship is pretty hard. This tweak provides greater compatibility, while reducing the overall benefit of WINRT_LEAN_AND_MEAN a little.