### PR TITLE
Guid key testing

### DIFF
--- a/test/test_win7/guid_key.cpp
+++ b/test/test_win7/guid_key.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+TEST_CASE("guid_key")
+{
+    auto uri = guid_of<Uri>();
+    auto deferral = guid_of<Deferral>();
+
+    std::map<guid, std::string> ordered;
+    ordered[uri] = "Uri";
+    ordered[deferral] = "Deferral";
+    REQUIRE(ordered[uri] == "Uri");
+    REQUIRE(ordered[deferral] == "Deferral");
+
+    std::unordered_map<guid, std::string> unordered;
+    unordered[uri] = "Uri";
+    unordered[deferral] = "Deferral";
+    REQUIRE(unordered[uri] == "Uri");
+    REQUIRE(unordered[deferral] == "Deferral");
+}

--- a/test/test_win7/test_win7.vcxproj
+++ b/test/test_win7/test_win7.vcxproj
@@ -328,6 +328,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="GetMany.cpp" />
+    <ClCompile Include="guid_key.cpp" />
     <ClCompile Include="iid_ppv_args.cpp" />
     <ClCompile Include="inspectable_interop.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
The previous PRs to add support for `winrt::guid` keys by implementing `std::hash` and `operator<` (#464, #466) failed to include any tests. Here is a test for these.