### PR TITLE
Fix support for delegates returning arrays of structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages
 Debug
 Release
 Generated Files
+obj

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -965,7 +965,7 @@ namespace cppwinrt
         }
     }
 
-    static void write_consume_return_type(writer& w, method_signature const& signature)
+    static void write_consume_return_type(writer& w, method_signature const& signature, bool delegate_types)
     {
         if (!signature.return_signature())
         {
@@ -981,6 +981,7 @@ namespace cppwinrt
         %* %{};)";
 
             w.abi_types = true;
+            w.delegate_types = delegate_types;
 
             w.write(format,
                 signature.return_param_name(),
@@ -988,6 +989,7 @@ namespace cppwinrt
                 signature.return_param_name());
 
             w.abi_types = false;
+            w.delegate_types = false;
         }
         else if (category == param_category::object_type || category == param_category::string_type)
         {
@@ -1077,7 +1079,7 @@ namespace cppwinrt
             bind<write_comma_generic_types>(generics),
             method_name,
             bind<write_consume_params>(signature),
-            bind<write_consume_return_type>(signature),
+            bind<write_consume_return_type>(signature, false),
             type,
             get_abi_name(method),
             bind<write_abi_args>(signature),
@@ -2447,7 +2449,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 bind_list(", ", generics),
                 bind<write_consume_params>(signature),
-                bind<write_consume_return_type>(signature),
+                bind<write_consume_return_type>(signature, true),
                 type_name,
                 bind_list(", ", generics),
                 bind<write_abi_args>(signature),
@@ -2500,7 +2502,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 type_name,
                 type_name,
                 bind<write_consume_params>(signature),
-                bind<write_consume_return_type>(signature),
+                bind<write_consume_return_type>(signature, true),
                 type_name,
                 bind<write_abi_args>(signature),
                 bind<write_consume_return_statement>(signature));

--- a/cppwinrt/type_writers.h
+++ b/cppwinrt/type_writers.h
@@ -106,6 +106,7 @@ namespace cppwinrt
 
         std::string type_namespace;
         bool abi_types{};
+        bool delegate_types{};
         bool param_names{};
         bool consume_types{};
         bool async_types{};
@@ -275,6 +276,10 @@ namespace cppwinrt
                     else if ((name == "Point" || name == "Size" || name == "Rect") && ns == "Windows.Foundation")
                     {
                         write("@::%", ns, name);
+                    }
+                    else if (delegate_types)
+                    {
+                        write("struct impl::struct_%_%", get_impl_name(ns), name);
                     }
                     else
                     {

--- a/test/test/struct_delegate.cpp
+++ b/test/test/struct_delegate.cpp
@@ -1,0 +1,21 @@
+#include "pch.h"
+#include "winrt/test_component.delegates.h"
+
+using namespace winrt;
+using namespace test_component;
+
+TEST_CASE("struct_delegate")
+{
+    Delegates::StructDelegate d = []
+    {
+        return com_array{ Struct{ L"First", L"Second" }, Struct{ L"Third", L"Fourth" } };
+    };
+
+    auto values = d();
+
+    REQUIRE(values.size() == 2);
+    REQUIRE(values[0].First == L"First");
+    REQUIRE(values[0].Second == L"Second");
+    REQUIRE(values[1].First == L"Third");
+    REQUIRE(values[1].Second == L"Fourth");
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -417,6 +417,7 @@
     <ClCompile Include="return_params_abi.cpp" />
     <ClCompile Include="single_threaded_observable_vector.cpp" />
     <ClCompile Include="structs.cpp" />
+    <ClCompile Include="struct_delegate.cpp" />
     <ClCompile Include="tearoff.cpp" />
     <ClCompile Include="thread_pool.cpp" />
     <ClCompile Include="uniform_in_params.cpp" />

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -11,6 +11,12 @@ namespace Windows.Foundation.Metadata
 
 namespace test_component
 {
+    struct Struct
+    {
+        String First;
+        String Second;
+    };
+
     namespace Delegates
     {
         delegate void AgileDelegate();
@@ -22,6 +28,7 @@ namespace test_component
         delegate String[] ReturnStringArrayDelegate();
         delegate void OutStringArrayDelegate(out String[] value);
         delegate void RefStringArrayDelegate(ref String[] value);
+        delegate test_component.Struct[] StructDelegate();
     }
 
     enum Signed
@@ -37,12 +44,6 @@ namespace test_component
         First = 0,
         Second = 1,
         Third = 2
-    };
-
-    struct Struct
-    {
-        String First;
-        String Second;
     };
 
     runtimeclass Simple


### PR DESCRIPTION
Fixes #509

This is a very obscure edge case, so much so that there has never been a shipping API that has done this. Still, it's good Scott caught it and we can get it fixed.

The fix isn't ideal but it's all I can justify at this stage. A deeper refactoring to somehow make this more generic will have to wait. 

More complete testing will come in the [testwinrt](https://github.com/microsoft/testwinrt) repo.