### PR TITLE
Support for x86 builds with Clang

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -18,6 +18,12 @@ namespace winrt::impl
 
     using library_handle = handle_type<library_traits>;
 
+    inline int32_t __stdcall fallback_RoGetActivationFactory(void*, guid const&, void** factory) noexcept
+    {
+        *factory = nullptr;
+        return error_class_not_available;
+    }
+
     template <typename Interface>
     hresult get_runtime_activation_factory(param::hstring const& name, void** result) noexcept
     {
@@ -27,14 +33,7 @@ namespace winrt::impl
         }
 
         static int32_t(__stdcall * handler)(void* classId, guid const& iid, void** factory) noexcept;
-
-        impl::load_runtime_function("RoGetActivationFactory", handler,
-            [](void*, guid const&, void** factory) noexcept -> int32_t
-            {
-                *factory = nullptr;
-                return error_class_not_available;
-            });
-
+        impl::load_runtime_function("RoGetActivationFactory", handler, fallback_RoGetActivationFactory);
         hresult hr = handler(*(void**)(&name), guid_of<Interface>(), result);
 
         if (hr == impl::error_not_initialized)

--- a/strings/base_agile_ref.h
+++ b/strings/base_agile_ref.h
@@ -119,36 +119,35 @@ namespace winrt::impl
         result = fallback;
     }
 
+    inline int32_t __stdcall fallback_RoGetAgileReference(uint32_t, winrt::guid const& iid, void* object, void** reference) noexcept
+    {
+        *reference = nullptr;
+        static constexpr guid git_clsid{ 0x00000323, 0x0000, 0x0000, { 0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46 } };
+
+        com_ptr<IGlobalInterfaceTable> git;
+        hresult hr = WINRT_IMPL_CoCreateInstance(git_clsid, nullptr, 1 /*CLSCTX_INPROC_SERVER*/, guid_of<IGlobalInterfaceTable>(), git.put_void());
+
+        if (hr < 0)
+        {
+            return hr;
+        }
+
+        uint32_t cookie{};
+        hr = git->RegisterInterfaceInGlobal(object, iid, &cookie);
+
+        if (hr < 0)
+        {
+            return hr;
+        }
+
+        *reference = new agile_ref_fallback(std::move(git), cookie);
+        return 0;
+    }
+
     inline hresult get_agile_reference(winrt::guid const& iid, void* object, void** reference) noexcept
     {
         static int32_t(__stdcall * handler)(uint32_t options, winrt::guid const& iid, void* object, void** reference) noexcept;
-
-        load_runtime_function("RoGetAgileReference", handler,
-            [](uint32_t, winrt::guid const& iid, void* object, void** reference) noexcept -> int32_t
-            {
-                *reference = nullptr;
-                static constexpr guid git_clsid{ 0x00000323, 0x0000, 0x0000, { 0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46 } };
-
-                com_ptr<IGlobalInterfaceTable> git;
-                hresult hr = WINRT_IMPL_CoCreateInstance(git_clsid, nullptr, 1 /*CLSCTX_INPROC_SERVER*/, guid_of<IGlobalInterfaceTable>(), git.put_void());
-
-                if (hr < 0)
-                {
-                    return hr;
-                }
-
-                uint32_t cookie{};
-                hr = git->RegisterInterfaceInGlobal(object, iid, &cookie);
-
-                if (hr < 0)
-                {
-                    return hr;
-                }
-
-                *reference = new agile_ref_fallback(std::move(git), cookie);
-                return 0;
-            });
-
+        load_runtime_function("RoGetAgileReference", handler, fallback_RoGetAgileReference);
         return handler(0, iid, object, reference);
     }
 }

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -335,6 +335,11 @@ namespace winrt::impl
         return { new(raw) event_array<T>(capacity), take_ownership_from_abi };
     }
 
+    inline int32_t __stdcall fallback_RoTransformError(int32_t, int32_t, void*) noexcept
+    {
+        return 1;
+    }
+
     template <typename Delegate, typename... Arg>
     bool invoke(Delegate const& delegate, Arg const&... args) noexcept
     {
@@ -347,13 +352,7 @@ namespace winrt::impl
             int32_t const code = to_hresult();
 
             static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
-
-            impl::load_runtime_function("RoTransformError", handler,
-                [](int32_t, int32_t, void*) noexcept
-                {
-                    return 1;
-                });
-
+            impl::load_runtime_function("RoTransformError", handler, fallback_RoTransformError);
             handler(code, 0, nullptr);
 
             if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED


### PR DESCRIPTION
Fixed #496 

The Clang compiler *still* lacks the Visual C++ support for lambdas with `stdcall` calling convention. This update removes the use of those lambdas where calling convention matters so that the Clang compiler may be used to build x86 binaries.