### PR TITLE
Avoid using memcpy

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -105,7 +105,7 @@ namespace winrt::impl
         }
 
         auto header = precreate_hstring_on_heap(length);
-        memcpy(header->buffer, value, sizeof(wchar_t) * length);
+        memcpy_s(header->buffer, sizeof(wchar_t) * length, value, sizeof(wchar_t) * length);
         return header;
     }
 


### PR DESCRIPTION
C++/WinRT is used in places where `memcpy` is no longer permitted.