### PR TITLE
terminate must be noreturn

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -565,10 +565,11 @@ WINRT_EXPORT namespace winrt
         return pointer;
     }
 
-    inline void terminate() noexcept
+    [[noreturn]] inline void terminate() noexcept
     {
         static void(__stdcall * handler)(int32_t) noexcept;
         impl::load_runtime_function("RoFailFastWithErrorContext", handler, impl::fallback_RoFailFastWithErrorContext);
         handler(to_hresult());
+        abort();
     }
 }


### PR DESCRIPTION
Libraries in the OS require `winrt::teminate` to be `[[noreturn]]` - I removed the attribute to placate Clang which didn't consider the function as not returning from all paths, but that breaks code unacceptably inside the OS. Instead, I've added a call to `abort` to make Clang happy even though it will never be called.