### PR TITLE
Improve <experimental/coroutine> feature detection

### DIFF
--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -22,7 +22,7 @@
 #include <directxmath.h>
 #endif
 
-#ifndef __clang__
+#if __has_include(<experimental/coroutine>)
 
 #include <experimental/coroutine>
 


### PR DESCRIPTION
When compiling with LLVM/Clang on Windows, while using the Microsoft STL headers the current ```#ifndef __clang__``` does not work. The final binary would contain duplicate symbols from the std::experimental namespace

Instead of checking for a specific compiler we can check if the header file exists