### PR TITLE
Use relative paths in C++ projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Debug
 Release
 Generated Files
 obj
+vsix/LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 *_p.c
 *.c
 test*.xml
-build
+*.nupkg
+_build
 packages
 Debug
 Release

--- a/cppwinrt.props
+++ b/cppwinrt.props
@@ -39,7 +39,7 @@
     <CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">2.3.4.5</CppWinRTBuildVersion>
     <CmakePlatform>$(Platform)</CmakePlatform>
     <CmakePlatform Condition="'$(Platform)'=='Win32'">x86</CmakePlatform>
-    <CmakeOutDir Condition="'$(CmakeOutDir)'==''">$(SolutionDir)_build\$(CmakePlatform)\$(Configuration)</CmakeOutDir>
+    <CmakeOutDir Condition="'$(CmakeOutDir)'==''">$(MSBuildThisFileDirectory)_build\$(CmakePlatform)\$(Configuration)</CmakeOutDir>
     <CppWinRTDir>$(CmakeOutDir)\</CppWinRTDir>
     <CppWinRTDir Condition="'$(Platform)'=='ARM' or '$(Platform)'=='ARM64'">$(SolutionDir)_build\x86\$(Configuration)\</CppWinRTDir>
     <OutDir>$(CmakeOutDir)\</OutDir>

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -115,7 +115,7 @@
     <RootNamespace>cppwinrt</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\cppwinrt.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\cppwinrt.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/fast_fwd/fast_fwd.vcxproj
+++ b/fast_fwd/fast_fwd.vcxproj
@@ -41,7 +41,7 @@
     <RootNamespace>fastfwd</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\cppwinrt.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\cppwinrt.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/prebuild/prebuild.vcxproj
+++ b/prebuild/prebuild.vcxproj
@@ -40,7 +40,7 @@
     <RootNamespace>cppwinrt</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\cppwinrt.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\cppwinrt.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
`$(SolutionDir)` may have an incorrect value during command-line builds. This method is guaranteed to work, no matter what directory the user is building from. I also took an opportunity to update the gitignore. Thanks!