### PR TITLE
Fix include path for generated component (.g.cpp) files

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -1152,9 +1152,9 @@ namespace winrt::@::implementation
 
     static void write_component_cpp(writer& w, TypeDef const& type)
     {
-        auto filename = get_component_filename(type);
-
         {
+            auto filename = get_component_filename(type);
+
             auto format = R"(#include "%.h"
 )";
 
@@ -1163,6 +1163,8 @@ namespace winrt::@::implementation
 
         if (settings.component_opt)
         {
+            auto filename = get_generated_component_filename(type);
+
             auto format = R"(#include "%.g.cpp"
 )";
 


### PR DESCRIPTION
Generated component headers (.g.h) and C++ source files (.g.cpp)
are emitted into a _directory structure_ that mirrors the
namespace that the WinRT component is found in.

For instance, for a component such as:

```
namespace Foo.Bar
{
    runtimeclass Baz
    {
        void Frob();
    }:
}
```

The .g.h and .g.cpp files will be emitted into a newly created
subdirectory `Foo/Bar` of the output directory given to `cppwinrt.exe`
as the `-out` parameter.

Meanwhile, the component source file (.cpp file, meant to be edited by
the user implementing the component), emits a `#include` that assumes
that the .g.cpp file will be emitted directly in the output directory as
a fully-qualified name of the file. Specifically, the include that is
emitted is:

```
#include "Foo.Bar.Baz.g.cpp"
```

While the file `Foo.Bar.Baz.g.cpp` doesn't even exist. In reality the
file that exists and that should be included is:

```
#include "Foo/Bar/Baz.g.cpp"
```

The component header (.h file, meant to be edited by the user
implementing the component) already emits the correct include path for
the .g.h file that is emitted in the same way as the .g.cpp file is.

Note that this is _typically_ not an issue for users who specify a `-name`
parameter to `cppwinrt.exe`, which strips the fully qualified namespace
from generated file names and doesn't cause the directory structure
to be created. It is an issue if `-name` isn't specified or if
`cppwinrt.exe` is unable to strip the namespace from all types that are
found in the input `winmd`s.

---

This commit fixes the issue by using the `get_generated_component_filename`
helper to synthesize the name of the file that should be included when
the .g.cpp file is included. This follows the approach that the
component header already uses when emitting the include for the .g.h file.