### PR TITLE
Apply EBO declspec to forward declaration 

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -292,7 +292,7 @@ namespace cppwinrt
             return;
         }
 
-        auto format = R"(    template <%> struct %;
+        auto format = R"(    template <%> struct __declspec(empty_bases) %;
 )";
 
         w.write(format,


### PR DESCRIPTION
as well as to specializations, to avoid inconsistent EBO application, which can also manifest as crashing ODR violations (not just unoptimized code).