### PR TITLE
Do not pass nullptr arrays to the ABI

### DIFF
--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -353,13 +353,15 @@ WINRT_EXPORT namespace winrt
     template <typename T>
     auto get_abi(array_view<T> object) noexcept
     {
+        auto data = object.size() ? object.data() : (T*)alignof(T);
+
         if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, T>)
         {
-            return (void**)object.data();
+            return (void**)data;
         }
         else
         {
-            return reinterpret_cast<impl::arg_out<std::remove_const_t<T>>>(const_cast<std::remove_const_t<T>*>(object.data()));
+            return reinterpret_cast<impl::arg_out<std::remove_const_t<T>>>(const_cast<std::remove_const_t<T>*>(data));
         }
     }
 

--- a/test/test/in_params.cpp
+++ b/test/test/in_params.cpp
@@ -44,6 +44,15 @@ TEST_CASE("in_params")
     REQUIRE(object.InStructArray({ {L"1",L"2"}, {L"3",L"4"} }) == L"1234");
     REQUIRE(object.InEnumArray({ Signed::First, Signed::Second }) == L"FirstSecond");
 
+    // Ensure 0-length arrays are passed as non-null pointers to the ABI,
+    // in order to keep RPC happy.
+    REQUIRE(object.InInt32Array({ }) == L"");
+    REQUIRE(object.InStringArray({ }) == L"");
+    REQUIRE(object.InObjectArray({ }) == L"");
+    REQUIRE(object.InStringableArray({ }) == L"");
+    REQUIRE(object.InStructArray({ }) == L"");
+    REQUIRE(object.InEnumArray({ }) == L"");
+
     // params::hstring optimizations
     REQUIRE(object.InString(L"") == L"");
     REQUIRE(object.InString({}) == L"");

--- a/test/test/out_params.cpp
+++ b/test/test/out_params.cpp
@@ -151,6 +151,16 @@ TEST_CASE("out_params")
         REQUIRE(value[1] == Signed::Second);
         REQUIRE(value[2] == static_cast<Signed>(0));
     }
+    // Ensure 0-length arrays are passed as non-null pointers to the ABI,
+    // in order to keep RPC happy.
+    {
+        REQUIRE_NOTHROW(object.RefInt32Array({}));
+        REQUIRE_NOTHROW(object.RefStringArray({}));
+        REQUIRE_NOTHROW(object.RefObjectArray({}));
+        REQUIRE_NOTHROW(object.RefStringableArray({}));
+        REQUIRE_NOTHROW(object.RefStructArray({}));
+        REQUIRE_NOTHROW(object.RefEnumArray({}));
+    }
 
     object.Fail(true);
 

--- a/test/test_component/Class.cpp
+++ b/test/test_component/Class.cpp
@@ -207,6 +207,8 @@ namespace winrt::test_component::implementation
 
     hstring Class::InInt32Array(array_view<int32_t const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -218,6 +220,8 @@ namespace winrt::test_component::implementation
     }
     hstring Class::InStringArray(array_view<hstring const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -229,6 +233,8 @@ namespace winrt::test_component::implementation
     }
     hstring Class::InObjectArray(array_view<Windows::Foundation::IInspectable const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -240,6 +246,8 @@ namespace winrt::test_component::implementation
     }
     hstring Class::InStringableArray(array_view<Windows::Foundation::IStringable const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -251,6 +259,8 @@ namespace winrt::test_component::implementation
     }
     hstring Class::InStructArray(array_view<Struct const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -262,6 +272,8 @@ namespace winrt::test_component::implementation
     }
     hstring Class::InEnumArray(array_view<Signed const> value)
     {
+        simulate_rpc_behavior(value);
+
         hstring result;
 
         for (auto&& v : value)
@@ -304,68 +316,98 @@ namespace winrt::test_component::implementation
 
     void Class::RefInt32Array(array_view<int32_t> value)
     {
-        int32_t counter{};
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                return ++counter;
-            });
+        if (value.size())
+        {
+            int32_t counter{};
+
+            std::generate(value.begin(), value.end() - 1, [&]
+                {
+                    return ++counter;
+                });
+        }
     }
 
     void Class::RefStringArray(array_view<hstring> value)
     {
-        int32_t counter{};
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                return hstring{ std::to_wstring(++counter) };
-            });
+        if (value.size())
+        {
+            int32_t counter{};
+
+            std::generate(value.begin(), value.end() - 1, [&]
+                {
+                    return hstring{ std::to_wstring(++counter) };
+                });
+        }
     }
 
     void Class::RefObjectArray(array_view<Windows::Foundation::IInspectable> value)
     {
-        int32_t counter{};
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                return make<Value>(++counter);
-            });
+        if (value.size())
+        {
+            int32_t counter{};
+
+            std::generate(value.begin(), value.end() - 1, [&]
+                {
+                    return make<Value>(++counter);
+                });
+        }
     }
 
     void Class::RefStringableArray(array_view<Windows::Foundation::IStringable> value)
     {
-        int32_t counter{};
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                return make<Value>(++counter);
-            });
+        if (value.size())
+        {
+            int32_t counter{};
+
+            std::generate(value.begin(), value.end() - 1, [&]
+                {
+                    return make<Value>(++counter);
+                });
+        }
     }
 
     void Class::RefStructArray(array_view<Struct> value)
     {
-        int32_t counter{};
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                return Struct
+        if (value.size())
+        {
+            int32_t counter{};
+
+            std::generate(value.begin(), value.end() - 1, [&]
                 {
-                    hstring{ std::to_wstring(++counter) },
-                    hstring{ std::to_wstring(++counter) }
-                };
-            });
+                    return Struct
+                    {
+                        hstring{ std::to_wstring(++counter) },
+                        hstring{ std::to_wstring(++counter) }
+                    };
+                });
+        }
     }
 
     void Class::RefEnumArray(array_view<Signed> value)
     {
-        Signed counter{ Signed::First };
+        simulate_rpc_behavior(value);
 
-        std::generate(value.begin(), value.end() - 1, [&]
-            {
-                auto result = counter;
-                counter = static_cast<Signed>(static_cast<int32_t>(counter) + 1);
-                return result;
-            });
+        if (value.size())
+        {
+            Signed counter{ Signed::First };
+
+            std::generate(value.begin(), value.end() - 1, [&]
+                {
+                    auto result = counter;
+                    counter = static_cast<Signed>(static_cast<int32_t>(counter) + 1);
+                    return result;
+                });
+        }
     }
 
     com_array<int32_t> Class::ReturnInt32Array()

--- a/test/test_component/Class.h
+++ b/test/test_component/Class.h
@@ -115,6 +115,16 @@ namespace winrt::test_component::implementation
 
         bool m_fail{};
         event<Windows::Foundation::TypedEventHandler<test_component::Class, test_component::DeferrableEventArgs>> m_deferrableEvent;
+
+        template<typename T>
+        static void simulate_rpc_behavior(array_view<T> const& value)
+        {
+            // RPC requires array pointers to be non-null.
+            if (value.begin() == nullptr)
+            {
+                throw hresult_error(static_cast<hresult>(0x800706f4)); // HRESULT_FROM_WIN32(RPC_X_NULL_REF_POINTER)
+            }
+        }
     };
 
     struct DeferrableEventArgs : DeferrableEventArgsT<DeferrableEventArgs>, deferrable_event_args<DeferrableEventArgs>

--- a/test/test_win7/in_params.cpp
+++ b/test/test_win7/in_params.cpp
@@ -44,6 +44,15 @@ TEST_CASE("in_params")
     REQUIRE(object.InStructArray({ {L"1",L"2"}, {L"3",L"4"} }) == L"1234");
     REQUIRE(object.InEnumArray({ Signed::First, Signed::Second }) == L"FirstSecond");
 
+    // Ensure 0-length arrays are passed as non-null pointers to the ABI,
+    // in order to keep RPC happy.
+    REQUIRE(object.InInt32Array({ }) == L"");
+    REQUIRE(object.InStringArray({ }) == L"");
+    REQUIRE(object.InObjectArray({ }) == L"");
+    REQUIRE(object.InStringableArray({ }) == L"");
+    REQUIRE(object.InStructArray({ }) == L"");
+    REQUIRE(object.InEnumArray({ }) == L"");
+
     // params::hstring optimizations
     REQUIRE(object.InString(L"") == L"");
     REQUIRE(object.InString({}) == L"");

--- a/test/test_win7/out_params.cpp
+++ b/test/test_win7/out_params.cpp
@@ -151,6 +151,16 @@ TEST_CASE("out_params")
         REQUIRE(value[1] == Signed::Second);
         REQUIRE(value[2] == static_cast<Signed>(0));
     }
+    // Ensure 0-length arrays are passed as non-null pointers to the ABI,
+    // in order to keep RPC happy.
+    {
+        REQUIRE_NOTHROW(object.RefInt32Array({}));
+        REQUIRE_NOTHROW(object.RefStringArray({}));
+        REQUIRE_NOTHROW(object.RefObjectArray({}));
+        REQUIRE_NOTHROW(object.RefStringableArray({}));
+        REQUIRE_NOTHROW(object.RefStructArray({}));
+        REQUIRE_NOTHROW(object.RefEnumArray({}));
+    }
 
     object.Fail(true);
 


### PR DESCRIPTION
For array parameters, ensure that nullptr is not passed as the array base, even for empty arrays. If the array is empty, the array base is not used, but RPC still requires it to be a non-null pointer.

We use a properly aligned non-null pointer as our fake array base, in case somebody cares about alignment.

Note that this fix does not address [out] parameters. The workaround for [out] parameters is more expensive (need to CoTaskMemAlloc(0)) and it is necessary only for out-of-process calls, so I don't want to incur the overhead for everybody. People returning empty com_arrays will have to remain vigilant.

Also fix BO in test Class when asked to fill an empty array.