### PR TITLE
Fix holes in IObservableVector<IInspectable>

### DIFF
--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -102,7 +102,7 @@ namespace winrt::impl
         {
             try
             {
-                return IndexOf(extract_value(value), index);
+                return IndexOf(unbox_value<T>(value), index);
             }
             catch (hresult_no_interface const&)
             {
@@ -154,21 +154,21 @@ namespace winrt::impl
 
         void SetAt(uint32_t const index, Windows::Foundation::IInspectable const& value)
         {
-            SetAt(index, extract_value(value));
+            SetAt(index, unbox_value<T>(value));
         }
 
         using base_type::InsertAt;
 
         void InsertAt(uint32_t const index, Windows::Foundation::IInspectable const& value)
         {
-            InsertAt(index, extract_value(value));
+            InsertAt(index, unbox_value<T>(value));
         }
 
         using base_type::Append;
 
         void Append(Windows::Foundation::IInspectable const& value)
         {
-            Append(extract_value(value));
+            Append(unbox_value<T>(value));
         }
 
         using base_type::ReplaceAll;
@@ -180,7 +180,7 @@ namespace winrt::impl
 
             std::transform(values.begin(), values.end(), std::back_inserter(new_values), [&](auto && value)
                 {
-                    return extract_value(value);
+                    return unbox_value<T>(value);
                 });
 
             base_type::ReplaceAll(std::move(new_values));
@@ -197,18 +197,6 @@ namespace winrt::impl
         }
 
     private:
-
-        static auto extract_value(Windows::Foundation::IInspectable const& value)
-        {
-            if constexpr (!std::is_base_of_v<Windows::Foundation::IInspectable, T>)
-            {
-                if (!value)
-                {
-                    throw hresult_no_interface();
-                }
-            }
-            return unbox_value<T>(value);
-        }
 
         struct iterator :
             impl::collection_version::iterator_type,

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -100,7 +100,15 @@ namespace winrt::impl
 
         bool IndexOf(Windows::Foundation::IInspectable const& value, uint32_t& index) const
         {
-            return IndexOf(unbox_value<T>(value), index);
+            try
+            {
+                return IndexOf(extract_value(value), index);
+            }
+            catch (hresult_no_interface const&)
+            {
+                index = 0;
+                return false;
+            }
         }
 
         using base_type::GetMany;
@@ -146,37 +154,36 @@ namespace winrt::impl
 
         void SetAt(uint32_t const index, Windows::Foundation::IInspectable const& value)
         {
-            SetAt(index, unbox_value<T>(value));
+            SetAt(index, extract_value(value));
         }
 
         using base_type::InsertAt;
 
         void InsertAt(uint32_t const index, Windows::Foundation::IInspectable const& value)
         {
-            InsertAt(index, unbox_value<T>(value));
+            InsertAt(index, extract_value(value));
         }
 
         using base_type::Append;
 
         void Append(Windows::Foundation::IInspectable const& value)
         {
-            Append(unbox_value<T>(value));
+            Append(extract_value(value));
         }
 
         using base_type::ReplaceAll;
 
         void ReplaceAll(array_view<Windows::Foundation::IInspectable const> values)
         {
-            this->increment_version();
-            m_values.clear();
-            m_values.reserve(values.size());
+            Container new_values;
+            new_values.reserve(values.size());
 
-            std::transform(values.begin(), values.end(), std::back_inserter(m_values), [&](auto && value)
+            std::transform(values.begin(), values.end(), std::back_inserter(new_values), [&](auto && value)
                 {
-                    return unbox_value<T>(value);
+                    return extract_value(value);
                 });
 
-            this->call_changed(Windows::Foundation::Collections::CollectionChange::Reset, 0);
+            base_type::ReplaceAll(std::move(new_values));
         }
 
         using base_type::VectorChanged;
@@ -190,6 +197,18 @@ namespace winrt::impl
         }
 
     private:
+
+        static auto extract_value(Windows::Foundation::IInspectable const& value)
+        {
+            if constexpr (!std::is_base_of_v<Windows::Foundation::IInspectable, T>)
+            {
+                if (!value)
+                {
+                    throw hresult_no_interface();
+                }
+            }
+            return unbox_value<T>(value);
+        }
 
         struct iterator :
             impl::collection_version::iterator_type,

--- a/strings/base_reference_produce.h
+++ b/strings/base_reference_produce.h
@@ -288,26 +288,33 @@ WINRT_EXPORT namespace winrt
         {
             return value.as<T>();
         }
-        else if constexpr (std::is_enum_v<T>)
-        {
-            if (auto temp = value.try_as<Windows::Foundation::IReference<T>>())
-            {
-                return temp.Value();
-            }
-            else
-            {
-                return static_cast<T>(value.as<Windows::Foundation::IReference<std::underlying_type_t<T>>>().Value());
-            }
-        }
-#ifdef WINRT_IMPL_IUNKNOWN_DEFINED
-        else if constexpr (std::is_same_v<T, GUID>)
-        {
-            return value.as<Windows::Foundation::IReference<guid>>().Value();
-        }
-#endif
         else
         {
-            return value.as<Windows::Foundation::IReference<T>>().Value();
+            if (!value)
+            {
+                throw hresult_no_interface();
+            }
+            if constexpr (std::is_enum_v<T>)
+            {
+                if (auto temp = value.try_as<Windows::Foundation::IReference<T>>())
+                {
+                    return temp.Value();
+                }
+                else
+                {
+                    return static_cast<T>(value.as<Windows::Foundation::IReference<std::underlying_type_t<T>>>().Value());
+                }
+            }
+#ifdef WINRT_IMPL_IUNKNOWN_DEFINED
+            else if constexpr (std::is_same_v<T, GUID>)
+            {
+                return value.as<Windows::Foundation::IReference<guid>>().Value();
+            }
+#endif
+            else
+            {
+                return value.as<Windows::Foundation::IReference<T>>().Value();
+            }
         }
     }
 


### PR DESCRIPTION
ReplaceAll did not provide the strong exception guarantee: If not all the elements could be converted to T, the code left the vector in a partially-replaced state. Now it leaves the vector unchanged if the operation fails. (Note that vector_base::assign does not provide the strong exception guarantee if wrapping is required, so we can't quite declare victory yet.)

If the underlying vector is a vector of value types, then attempting to insert nullptr now fails with E_NOINTERFACE rather than crashing.

If the object's runtime type is not T, then IndexOf should report "not found" rather than reporting the index of the first nullptr (if T is a reference type) or crashing (if T is a value type). This fixes issue #518.

Fixed use-after-free bug in test, where we forgot to unregister event handlers, leaving them with references to destroyed local variables.