### PR TITLE
Harden operator wstring_view

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -233,7 +233,7 @@ WINRT_EXPORT namespace winrt
             }
             else
             {
-                return {};
+                return { L"", 0 };
             }
         }
 

--- a/test/test/hstring_empty.cpp
+++ b/test/test/hstring_empty.cpp
@@ -13,4 +13,12 @@ TEST_CASE("hstring_empty")
     // Using wcslen to both validate that the strings are empty *and* that they are not null.
     REQUIRE(wcslen(s.c_str()) == 0);
     REQUIRE(wcslen(s.data()) == 0);
+
+    std::wstring_view v = s;
+    REQUIRE(v.empty());
+    REQUIRE(v.size() == 0);
+    REQUIRE(v == L""sv);
+
+    // Some existing code relies on data returning a valid string.
+    REQUIRE(v.data() == L""sv);
 }

--- a/test/test/hstring_empty.cpp
+++ b/test/test/hstring_empty.cpp
@@ -18,7 +18,10 @@ TEST_CASE("hstring_empty")
     REQUIRE(v.empty());
     REQUIRE(v.size() == 0);
     REQUIRE(v == L""sv);
+    REQUIRE(std::distance(v.begin(), v.end()) == 0);
 
-    // Some existing code relies on data returning a valid string.
-    REQUIRE(v.data() == L""sv);
+    // Using wcslen to both validate that the strings are empty *and* that they are not null.
+    // This is not guaranteed for wstring_view, but is assumed by some code that creates a
+    // wstring_view from an hstring.
+    REQUIRE(wcslen(v.data()) == 0);
 }


### PR DESCRIPTION
Some existing code relies on data returning a valid string even when the view is empty. 