### PR TITLE
Add hresult_class_not_registered for improved interop with combase

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -376,6 +376,13 @@ WINRT_EXPORT namespace winrt
         hresult_class_not_available(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_available, take_ownership_from_abi) {}
     };
 
+    struct hresult_class_not_registered : hresult_error
+    {
+        hresult_class_not_registered() noexcept : hresult_error(impl::error_class_not_registered) {}
+        hresult_class_not_registered(param::hstring const& message) noexcept : hresult_error(impl::error_class_not_registered, message) {}
+        hresult_class_not_registered(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_registered, take_ownership_from_abi) {}
+    };
+
     struct hresult_changed_state : hresult_error
     {
         hresult_changed_state() noexcept : hresult_error(impl::error_changed_state) {}
@@ -451,6 +458,11 @@ WINRT_EXPORT namespace winrt
         if (result == impl::error_class_not_available)
         {
             throw hresult_class_not_available(take_ownership_from_abi);
+        }
+
+        if (result == impl::error_class_not_registered)
+        {
+            throw hresult_class_not_registered(take_ownership_from_abi);
         }
 
         if (result == impl::error_changed_state)

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -139,6 +139,7 @@ namespace winrt::impl
     constexpr hresult error_out_of_bounds{ static_cast<hresult>(0x8000000B) }; // E_BOUNDS
     constexpr hresult error_no_interface{ static_cast<hresult>(0x80004002) }; // E_NOINTERFACE
     constexpr hresult error_class_not_available{ static_cast<hresult>(0x80040111) }; // CLASS_E_CLASSNOTAVAILABLE
+    constexpr hresult error_class_not_registered{ static_cast<hresult>(0x80040154) }; // REGDB_E_CLASSNOTREG
     constexpr hresult error_changed_state{ static_cast<hresult>(0x8000000C) }; // E_CHANGED_STATE
     constexpr hresult error_illegal_method_call{ static_cast<hresult>(0x8000000E) }; // E_ILLEGAL_METHOD_CALL
     constexpr hresult error_illegal_state_change{ static_cast<hresult>(0x8000000D) }; // E_ILLEGAL_STATE_CHANGE

--- a/test/test/hresult_class_not_registered.cpp
+++ b/test/test/hresult_class_not_registered.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    IAsyncAction Async()
+    {
+        // This is just a simple way of testing all of the ABI and projection 
+        // error propagation in one go.
+        throw hresult_class_not_registered(L"test message");
+    }
+}
+TEST_CASE("hresult_class_not_registered")
+{
+    REQUIRE(hresult_class_not_registered().message() == L"Class not registered");
+    REQUIRE(hresult_class_not_registered().code() == REGDB_E_CLASSNOTREG);
+
+    try
+    {
+        Async().get();
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_class_not_registered const& e)
+    {
+        REQUIRE(e.message() == L"test message");
+        REQUIRE(e.code() == REGDB_E_CLASSNOTREG);
+    }
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -330,6 +330,7 @@
     <ClCompile Include="delegates.cpp" />
     <ClCompile Include="disconnected.cpp" />
     <ClCompile Include="enum.cpp" />
+    <ClCompile Include="hresult_class_not_registered.cpp" />
     <ClCompile Include="error_info.cpp" />
     <ClCompile Include="event_deferral.cpp" />
     <ClCompile Include="async_local.cpp" />


### PR DESCRIPTION
This is part of the fix for #552 where combase uses `REGDB_E_CLASSNOTREG` and we need to more accurately propagate this. Having first-class support for this `HRESULT` helps simplify the factory activation logic coming up next.