### PR TITLE
Accurate error propagation from RoGetActivationFactory

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -55,6 +55,9 @@ namespace winrt::impl
             return 0;
         }
 
+        com_ptr<IErrorInfo> error_info;
+        WINRT_IMPL_GetErrorInfo(0, error_info.put_void());
+
         std::wstring path{ static_cast<hstring const&>(name) };
         std::size_t count{};
 
@@ -97,7 +100,8 @@ namespace winrt::impl
             }
         }
 
-        return error_class_not_available;
+        WINRT_IMPL_SetErrorInfo(0, error_info.get());
+        return hr;
     }
 }
 

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -376,6 +376,13 @@ WINRT_EXPORT namespace winrt
         hresult_class_not_available(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_available, take_ownership_from_abi) {}
     };
 
+    struct hresult_class_not_registered : hresult_error
+    {
+        hresult_class_not_registered() noexcept : hresult_error(impl::error_class_not_registered) {}
+        hresult_class_not_registered(param::hstring const& message) noexcept : hresult_error(impl::error_class_not_registered, message) {}
+        hresult_class_not_registered(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_registered, take_ownership_from_abi) {}
+    };
+
     struct hresult_changed_state : hresult_error
     {
         hresult_changed_state() noexcept : hresult_error(impl::error_changed_state) {}
@@ -451,6 +458,11 @@ WINRT_EXPORT namespace winrt
         if (result == impl::error_class_not_available)
         {
             throw hresult_class_not_available(take_ownership_from_abi);
+        }
+
+        if (result == impl::error_class_not_registered)
+        {
+            throw hresult_class_not_registered(take_ownership_from_abi);
         }
 
         if (result == impl::error_changed_state)

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -139,6 +139,7 @@ namespace winrt::impl
     constexpr hresult error_out_of_bounds{ static_cast<hresult>(0x8000000B) }; // E_BOUNDS
     constexpr hresult error_no_interface{ static_cast<hresult>(0x80004002) }; // E_NOINTERFACE
     constexpr hresult error_class_not_available{ static_cast<hresult>(0x80040111) }; // CLASS_E_CLASSNOTAVAILABLE
+    constexpr hresult error_class_not_registered{ static_cast<hresult>(0x80040154) }; // REGDB_E_CLASSNOTREG
     constexpr hresult error_changed_state{ static_cast<hresult>(0x8000000C) }; // E_CHANGED_STATE
     constexpr hresult error_illegal_method_call{ static_cast<hresult>(0x8000000E) }; // E_ILLEGAL_METHOD_CALL
     constexpr hresult error_illegal_state_change{ static_cast<hresult>(0x8000000D) }; // E_ILLEGAL_STATE_CHANGE

--- a/test/old_tests/UnitTests/get_activation_factory.cpp
+++ b/test/old_tests/UnitTests/get_activation_factory.cpp
@@ -23,15 +23,7 @@ TEST_CASE("get_activation_factory")
     }
 
     // Calling get_activation_factory with an invalid class name
-    try
-    {
-        get_activation_factory(L"Composable.DoesNotExist");
-        REQUIRE(false);
-    }
-    catch (hresult_class_not_available const& e)
-    {
-        REQUIRE(e.message() == L"Composable.DoesNotExist");
-    }
+    REQUIRE_THROWS_AS(get_activation_factory(L"Composable.DoesNotExist"), hresult_class_not_registered);
 }
 
 TEST_CASE("try_get_activation_factory")
@@ -72,6 +64,6 @@ TEST_CASE("try_get_activation_factory")
         auto factory = try_get_activation_factory<Component::IErrors>(e);
         REQUIRE(factory == nullptr);
         REQUIRE(get_error_info() == nullptr);
-        REQUIRE(e.code() == CLASS_E_CLASSNOTAVAILABLE);
+        REQUIRE(e.code() == REGDB_E_CLASSNOTREG);
     }
 }

--- a/test/test/hresult_class_not_registered.cpp
+++ b/test/test/hresult_class_not_registered.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    IAsyncAction Async()
+    {
+        // This is just a simple way of testing all of the ABI and projection 
+        // error propagation in one go.
+        throw hresult_class_not_registered(L"test message");
+    }
+}
+TEST_CASE("hresult_class_not_registered")
+{
+    REQUIRE(hresult_class_not_registered().message() == L"Class not registered");
+    REQUIRE(hresult_class_not_registered().code() == REGDB_E_CLASSNOTREG);
+
+    try
+    {
+        Async().get();
+        FAIL(L"Previous line should throw");
+    }
+    catch (hresult_class_not_registered const& e)
+    {
+        REQUIRE(e.message() == L"test message");
+        REQUIRE(e.code() == REGDB_E_CLASSNOTREG);
+    }
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -330,6 +330,7 @@
     <ClCompile Include="delegates.cpp" />
     <ClCompile Include="disconnected.cpp" />
     <ClCompile Include="enum.cpp" />
+    <ClCompile Include="hresult_class_not_registered.cpp" />
     <ClCompile Include="error_info.cpp" />
     <ClCompile Include="event_deferral.cpp" />
     <ClCompile Include="async_local.cpp" />

--- a/test/test/velocity.cpp
+++ b/test/test/velocity.cpp
@@ -17,24 +17,24 @@ TEST_CASE("velocity")
     REQUIRE(b == nullptr);
 
     // Class1 is always disabled and thus will not activate.
-    REQUIRE_THROWS_AS(Class1(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class1(), hresult_class_not_registered);
 
     // Class2 is always enabled so should activate just fine.
     Class2 c;
     c.Class2_Method();
 
     // Class3 is always disabled and thus will not activate.
-    REQUIRE_THROWS_AS(Class3(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class3(), hresult_class_not_registered);
 
     // Class4 is not feature-controlled but uses feature interfaces.
     Class4 d;
     d.Class4_Method();
 
     // The single argument constructor is always disabled.
-    REQUIRE_THROWS_AS(Class4(1), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class4(1), hresult_class_not_registered);
 
     // The Class4_Static1 static is always disabled.
-    REQUIRE_THROWS_AS(Class4::Class4_Static1(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class4::Class4_Static1(), hresult_class_not_registered);
 
     // The two argument constructor is always enabled.
     Class4 e(1, 2);

--- a/test/test_win7/velocity.cpp
+++ b/test/test_win7/velocity.cpp
@@ -17,24 +17,24 @@ TEST_CASE("velocity")
     REQUIRE(b == nullptr);
 
     // Class1 is always disabled and thus will not activate.
-    REQUIRE_THROWS_AS(Class1(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class1(), hresult_class_not_registered);
 
     // Class2 is always enabled so should activate just fine.
     Class2 c;
     c.Class2_Method();
 
     // Class3 is always disabled and thus will not activate.
-    REQUIRE_THROWS_AS(Class3(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class3(), hresult_class_not_registered);
 
     // Class4 is not feature-controlled but uses feature interfaces.
     Class4 d;
     d.Class4_Method();
 
     // The single argument constructor is always disabled.
-    REQUIRE_THROWS_AS(Class4(1), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class4(1), hresult_class_not_registered);
 
     // The Class4_Static1 static is always disabled.
-    REQUIRE_THROWS_AS(Class4::Class4_Static1(), hresult_class_not_available);
+    REQUIRE_THROWS_AS(Class4::Class4_Static1(), hresult_class_not_registered);
 
     // The two argument constructor is always enabled.
     Class4 e(1, 2);


### PR DESCRIPTION
Fixes #552 to properly capture and propagate error information from RoGetActivationFactory when fallback fails.

RoGetActivationFactory returns REGDB_E_CLASSNOTREG rather than CLASS_E_CLASSNOTAVAILABLE when activation fails. The target DLL may return CLASS_E_CLASSNOTAVAILABLE from DllGetActivationFactory. That's why a few of the tests needed updating since those tests were relying on the previous behavior where RoGetActivationFactory was sidestepped entirely. 