### PR TITLE
Reserve Memory for type

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -2581,6 +2581,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 
         std::vector<complex_struct> structs;
 
+        structs.reserve(types.size());
         for (auto&& type : types)
         {
             structs.emplace_back(w, type);

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -2580,8 +2580,8 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         };
 
         std::vector<complex_struct> structs;
-
         structs.reserve(types.size());
+
         for (auto&& type : types)
         {
             structs.emplace_back(w, type);


### PR DESCRIPTION
In code-writers, we are looping through a range of type in types, and we emplace_back using that value.

For this reason, we should preallocate memory for the struct using reserve.