### PR TITLE
Replace old headers with modern ones

### DIFF
--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 #include <array>
 #include <limits>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <map>

--- a/cppwinrt/main.cpp
+++ b/cppwinrt/main.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include <time.h>
+#include <ctime>
 #include "strings.h"
 #include "settings.h"
 #include "type_writers.h"

--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <sstream>

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -10291,8 +10291,8 @@ namespace Catch {
 
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#  include <cassert>
-#  include <cstdbool>
+#  include <assert.h>
+#  include <stdbool.h>
 #  include <sys/types.h>
 #  include <unistd.h>
 #  include <cstddef>

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -10291,7 +10291,7 @@ namespace Catch {
 
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#  include <assert.h>
+#  include <cassert>
 #  include <stdbool.h>
 #  include <sys/types.h>
 #  include <unistd.h>

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -10291,8 +10291,8 @@ namespace Catch {
 
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#  include <assert.h>
-#  include <stdbool.h>
+#  include <cassert>
+#  include <cstdbool>
 #  include <sys/types.h>
 #  include <unistd.h>
 #  include <cstddef>

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -10291,7 +10291,7 @@ namespace Catch {
 
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#  include <cassert>
+#  include <assert.h>
 #  include <stdbool.h>
 #  include <sys/types.h>
 #  include <unistd.h>


### PR DESCRIPTION
Most files already have switched to use the modern variation, such as "<ctime>", "<cassert>", etc. However, a few files do not, so this PR fixes that.