### PR TITLE
Deduction guides for array_view

### DIFF
--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -216,6 +216,12 @@ WINRT_EXPORT namespace winrt
         }
     };
 
+    template <typename C, size_t N> array_view(C(&value)[N]) -> array_view<C>;
+    template <typename C> array_view(std::vector<C>& value) -> array_view<C>;
+    template <typename C> array_view(std::vector<C> const& value) -> array_view<C const>;
+    template <typename C, size_t N> array_view(std::array<C, N>& value) -> array_view<C>;
+    template <typename C, size_t N> array_view(std::array<C, N> const& value) -> array_view<C const>;
+
     template <typename T>
     struct com_array : array_view<T>
     {

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -1247,6 +1247,9 @@ TEST_CASE("array_view,ctad")
     std::array<uint8_t, 3> const car{};
     REQUIRE_DEDUCED_AS(uint8_t const, car);
 
+    std::array<uint8_t const, 3> arc{};
+    REQUIRE_DEDUCED_AS(uint8_t const, arc);
+
     std::vector<uint8_t> const cv{};
     REQUIRE_DEDUCED_AS(uint8_t const, cv);
 

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -1223,3 +1223,32 @@ TEST_CASE("array_view,compare,array_view")
     REQUIRE(result.greater_equal);
     REQUIRE(!result.less_equal);
 }
+
+// Verify that class template argument deduction works for array_view.
+TEST_CASE("array_view,ctad")
+{
+#define REQUIRE_DEDUCED_AS(T, ...) \
+    static_assert(std::is_same_v<array_view<T>, decltype(array_view(__VA_ARGS__))>)
+
+    uint8_t a[3]{};
+    REQUIRE_DEDUCED_AS(uint8_t, &a[0], &a[0]);
+    REQUIRE_DEDUCED_AS(uint8_t, a);
+
+    std::array<uint8_t, 3> ar{};
+    REQUIRE_DEDUCED_AS(uint8_t, ar);
+
+    std::vector<uint8_t> v{};
+    REQUIRE_DEDUCED_AS(uint8_t, v);
+
+    uint8_t const ca[3]{};
+    REQUIRE_DEDUCED_AS(uint8_t const, &ca[0], &ca[0]);
+    REQUIRE_DEDUCED_AS(uint8_t const, ca);
+
+    std::array<uint8_t, 3> const car{};
+    REQUIRE_DEDUCED_AS(uint8_t const, car);
+
+    std::vector<uint8_t> const cv{};
+    REQUIRE_DEDUCED_AS(uint8_t const, cv);
+
+#undef REQUIRE_DEDUCED_AS
+}


### PR DESCRIPTION
Add deduction guides for `array_view`.

* If you pass two pointers, then it deduces as the type of the dereferenced pointers.
* If you pass a C-style array, then it deduces as the underlying type of the array, preserving const.
* If you pass a `std::vector`, then it deduces as the value type of the vector, preserving const.
* If you pass a `std::array`, then it deduces as the value type of the array, preserving const.

Curiously, the pre-existing CTAD behavior for initializer-list deduces as the **non-const** value type, even though initializer lists are const. I didn't try to fix that, but maybe we should consider it.

Example: We want to see if a WiFi-Direct OUI is the one assigned to Microsoft.

```cpp
constexpr std::array<uint8_t, 3> MsftOui{ 0x00, 0x50, 0xF2 };

com_array<uint8_t> ouiArray;
CryptographicBuffer::CopyToByteArray(informationElement.Oui(), ouiArray);

if (array_view(ouiConstArray) == array_view(MsftOui)) // <<<<<
```

Without the deduction guide, we would have to specialize the `array_view`:
```cpp
if (array_view<uint8_t>(ouiConstArray) == array_view<uint8_t const>(MsftOui))
```