### PR TITLE
Random-access iterators over IVector/IVectorView

### DIFF
--- a/strings/base_collections.h
+++ b/strings/base_collections.h
@@ -76,7 +76,7 @@ namespace winrt::impl
             return m_collection->GetAt(m_index);
         }
 
-        reference operator[](difference_type n) const noexcept
+        reference operator[](difference_type n) const
         {
             return m_collection->GetAt(m_index + static_cast<uint32_t>(n));
         }

--- a/test/test/fast_iterator.cpp
+++ b/test/test/fast_iterator.cpp
@@ -3,6 +3,7 @@
 TEST_CASE("fast_iterator")
 {
     {
+        // Forward iteration.
         auto v = winrt::single_threaded_vector<int>({ 1, 2, 3 });
 
         std::vector<int> result;
@@ -12,6 +13,7 @@ TEST_CASE("fast_iterator")
         REQUIRE((result == std::vector{ 1, 2, 3 }));
     }
     {
+        // Reverse iteration.
         auto v = winrt::single_threaded_vector<int>({ 1, 2, 3 });
 
         std::vector<int> result;
@@ -19,5 +21,31 @@ TEST_CASE("fast_iterator")
         std::copy(rbegin(v), rend(v), std::back_inserter(result));
 
         REQUIRE((result == std::vector{ 3, 2, 1 }));
+    }
+    {
+        // Value-initialization.
+        auto v = winrt::single_threaded_vector<int>({ 9, 5, 4, 1, 1, 3 });
+        decltype(begin(v)) dummy;
+        decltype(begin(v)) dummy2;
+        // Must be able to default-construct the iterator,
+        // but the only thing you can do with it is compare
+        // with another one.
+        REQUIRE(dummy == dummy2);
+    }
+    {
+        // Read-only random access.
+        auto v = winrt::single_threaded_vector<int>({ 9, 5, 4, 1, 1, 3 });
+        REQUIRE(std::is_heap(begin(v), end(v)));
+
+        auto vbegin = begin(v);
+        auto value = *vbegin++;
+        REQUIRE(value == 9);
+        value = *--vbegin;
+        REQUIRE(value == 9);
+        REQUIRE(vbegin[2] == 4);
+        REQUIRE(vbegin + 2 > vbegin);
+        REQUIRE(vbegin < vbegin + 2);
+        REQUIRE(vbegin + 2 - 2 == vbegin);
+        REQUIRE(end(v) - begin(v) == v.Size());
     }
 }


### PR DESCRIPTION
The built-in iterators for IVector and IVectorView (and more generally anything that has a GetAt method) now support random-access operations. They do not meet all the requirements of a random-access iterator, most notably:
* `reference` is not `value_type&` or `value_type const&`.
* `operator->` is not supported.

Design notes:
* The `value_type` had been misdeclared as `T` (e.g. `IVector<Something>`) rather than the element type (`Something`).
* The `reference` is not actually a reference because the return value of `operator*` must be convertible to `reference`.
* The element index is unsigned so that the relational operators like `<` produce correct results on large containers.
* The `difference_type` is `ptrdiff_t` so that `b-a` and related operations work on large containers.
* Return types for iterator operations are explicit to ensure they conform to iterator requirements.
* We now rely on `std::reverse_iterator` to implement our reverse iterator.