### PR TITLE
make_self respects static_lifetime

### DIFF
--- a/test/old_tests/Component/Component.idl
+++ b/test/old_tests/Component/Component.idl
@@ -132,6 +132,8 @@ namespace Component
         [eventadd] HRESULT StaticEvent([in] Windows.Foundation.EventHandler<int>* handler, [out][retval] EventRegistrationToken* cookie);
         [eventremove] HRESULT StaticEvent([in] EventRegistrationToken cookie);
         HRESULT RaiseStaticEvent([in] int value);
+
+        HRESULT TestStaticLifetime([out][retval] boolean* result);
     };
 
     [version(1.0), uuid(6ac35d2c-b2cf-4c36-995c-a9c0764636c9), exclusiveto(Events)]

--- a/test/old_tests/Component/Events.cpp
+++ b/test/old_tests/Component/Events.cpp
@@ -69,4 +69,24 @@ namespace winrt::Component::factory_implementation
     {
         m_static(nullptr, value);
     }
+
+    bool Events::TestStaticLifetime()
+    {
+        // Capture current reference count.
+        AddRef();
+        auto refcount = Release();
+
+        auto self = make_self<Events>();
+        if (self.get() != this)
+        {
+            return false;
+        }
+        self = nullptr;
+
+        // Refcount should be unchanged.
+        AddRef();
+        auto new_refcount = Release();
+
+        return refcount == new_refcount;
+    }
 }

--- a/test/old_tests/Component/Events.h
+++ b/test/old_tests/Component/Events.h
@@ -34,6 +34,7 @@ namespace winrt::Component::factory_implementation
         event_token StaticEvent(Windows::Foundation::EventHandler<int32_t> const& handler);
         void StaticEvent(event_token const& cookie);
         void RaiseStaticEvent(int value);
+        bool TestStaticLifetime();
 
     private:
         event<Windows::Foundation::EventHandler<int32_t>> m_static;

--- a/test/old_tests/UnitTests/factory_cache.cpp
+++ b/test/old_tests/UnitTests/factory_cache.cpp
@@ -57,4 +57,7 @@ TEST_CASE("factory_cache")
     // Make sure 'Events' is unique
 
     REQUIRE(b != get_activation_factory<Component::Events>());
+
+    // Test some stuff that can only be done from within the implementation.
+    REQUIRE(Component::Events::TestStaticLifetime());
 }


### PR DESCRIPTION
`make_self` now respects `static_lifetime`. I suspect this was overlooked when `static_lifetime` was introduced.