### PR TITLE
Improve performance of make_factory with static_lifetime

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1222,11 +1222,18 @@ namespace winrt::impl
             check_hresult(lifetime_factory->GetCollection(put_abi(collection)));
             auto const map = collection.as<IStaticLifetimeCollection>();
             param::hstring const name{ name_of<typename D::instance_type>() };
+            void* result{};
+            map->Lookup(get_abi(name), &result);
+
+            if (result)
+            {
+                return { result, take_ownership_from_abi };
+            }
+
             result_type object{ to_abi<result_type>(new heap_implements<D>), take_ownership_from_abi };
 
             static slim_mutex lock;
             slim_lock_guard const guard{ lock };
-            void* result{};
             map->Lookup(get_abi(name), &result);
 
             if (result)

--- a/test/old_tests/Component/Events.cpp
+++ b/test/old_tests/Component/Events.cpp
@@ -70,11 +70,16 @@ namespace winrt::Component::factory_implementation
         m_static(nullptr, value);
     }
 
+    std::atomic<int> Events::s_constructorCount;
+
     bool Events::TestStaticLifetime()
     {
         // Capture current reference count.
         AddRef();
         auto refcount = Release();
+
+        // Reset constructor count.
+        s_constructorCount = 0;
 
         auto self = make_self<Events>();
         if (self.get() != this)
@@ -84,9 +89,10 @@ namespace winrt::Component::factory_implementation
         self = nullptr;
 
         // Refcount should be unchanged.
+        // Should not have been constructed spuriously.
         AddRef();
         auto new_refcount = Release();
 
-        return refcount == new_refcount;
+        return refcount == new_refcount && s_constructorCount == 0;
     }
 }

--- a/test/old_tests/Component/Events.h
+++ b/test/old_tests/Component/Events.h
@@ -31,6 +31,7 @@ namespace winrt::Component::factory_implementation
 {
     struct Events : EventsT<Events, implementation::Events, static_lifetime>
     {
+        Events() { ++s_constructorCount; }
         event_token StaticEvent(Windows::Foundation::EventHandler<int32_t> const& handler);
         void StaticEvent(event_token const& cookie);
         void RaiseStaticEvent(int value);
@@ -38,5 +39,6 @@ namespace winrt::Component::factory_implementation
 
     private:
         event<Windows::Foundation::EventHandler<int32_t>> m_static;
+        static std::atomic<int32_t> s_constructorCount;
     };
 }


### PR DESCRIPTION
Previous code constructed a new object each time, even though only the first call will actually need the constructed object. The second and subsequent calls just throw the object away and return the existing object.

Construct the object only if we have a reasonable chance of actually using it. This is a big win for static-lifetime objects that are expensive to construct.