### PR TITLE
Weak references are objects too

### DIFF
--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -2,16 +2,10 @@
 namespace winrt::impl
 {
     template <typename T, typename H>
-    struct implements_delegate : abi_t<T>, H
+    struct implements_delegate : abi_t<T>, H, update_module_lock
     {
         implements_delegate(H&& handler) : H(std::forward<H>(handler))
         {
-            ++get_module_lock();
-        }
-
-        ~implements_delegate() noexcept
-        {
-            --get_module_lock();
         }
 
         int32_t __stdcall QueryInterface(guid const& id, void** result) noexcept final
@@ -98,16 +92,10 @@ namespace winrt::impl
     };
 
     template <typename H, typename R, typename... Args>
-    struct variadic_delegate final : variadic_delegate_abi<R, Args...>, H
+    struct variadic_delegate final : variadic_delegate_abi<R, Args...>, H, update_module_lock
     {
         variadic_delegate(H&& handler) : H(std::forward<H>(handler))
         {
-            ++get_module_lock();
-        }
-
-        ~variadic_delegate() noexcept
-        {
-            --get_module_lock();
         }
 
         R invoke(Args const& ... args) final

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -56,18 +56,12 @@ namespace winrt::impl
         return ((int32_t)((x) | 0x10000000));
     }
 
-    struct error_info_fallback final : IErrorInfo, IRestrictedErrorInfo
+    struct error_info_fallback final : IErrorInfo, IRestrictedErrorInfo, update_module_lock
     {
         error_info_fallback(int32_t code, void* message) noexcept :
             m_code(code),
             m_message(*reinterpret_cast<winrt::hstring*>(&message))
         {
-            ++get_module_lock();
-        }
-
-        ~error_info_fallback() noexcept
-        {
-            --get_module_lock();
         }
 
         int32_t __stdcall QueryInterface(guid const& id, void** object) noexcept final


### PR DESCRIPTION
If the source contributes to the module object count, then the weak reference also contributes, so that we do not unload prematurely.

Factored out module lock updating into helper base class `module_lock_updater` with specialization `update_module_lock`. This avoids a lot of code duplication.