### PR TITLE
Detect RPC server crash when co_await'ing

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -97,11 +97,11 @@ namespace winrt::impl
 
     private:
         std::experimental::coroutine_handle<> m_handle;
-        impl::com_ref<impl::IContextCallback> m_context = apartment_context();
+        com_ptr<IContextCallback> m_context = apartment_context();
 
         void Complete()
         {
-            impl::resume_apartment(m_context, std::exchange(m_handle, {}));
+            resume_apartment(m_context, std::exchange(m_handle, {}));
         }
     };
 

--- a/test/test/disconnected.cpp
+++ b/test/test/disconnected.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <ctxtcall.h>
 
 using namespace std::literals;
 using namespace winrt;
@@ -33,7 +34,7 @@ namespace
     }
 }
 
-TEST_CASE("disconnected")
+TEST_CASE("disconnected,handler")
 {
     {
         event<EventHandler<int>> source;
@@ -121,4 +122,74 @@ TEST_CASE("disconnected")
 
         WaitForSingleObject(signal.get(), INFINITE);
     }
+}
+
+// Custom action to simulate an out-of-process server that crashes before it can complete.
+struct non_agile_abandoned_action : implements<non_agile_abandoned_action, IAsyncAction, IAsyncInfo, non_agile>
+{
+    non_agile_abandoned_action(void* event_handle) : m_awaited(event_handle) {}
+
+    void Completed(AsyncActionCompletedHandler const& handler) {
+        m_handler = handler;
+        // Tell the test to disconnect the IAsyncAction, which simulates the server crash.
+        SetEvent(m_awaited);
+    }
+    auto Completed() { return m_handler; }
+    void GetResults() {}
+
+    auto Id() { return 0U; }
+    auto Status() { return AsyncStatus::Completed; }
+    auto ErrorCode() { return hresult(0); }
+    void Cancel() {}
+    void Close() {}
+
+    AsyncActionCompletedHandler m_handler;
+    HANDLE m_awaited;
+};
+
+namespace
+{
+    template<typename TLambda>
+    void InvokeInContext(IContextCallback* context, TLambda&& lambda)
+    {
+        ComCallData data;
+        data.pUserDefined = &lambda;
+        check_hresult(context->ContextCallback([](ComCallData* data) -> HRESULT
+            {
+                auto& lambda = *reinterpret_cast<TLambda*>(data->pUserDefined);
+                lambda();
+                return S_OK;
+            }, &data, IID_ICallbackWithNoReentrancyToApplicationSTA, 5, nullptr));
+    }
+
+    fire_and_forget disconnect_on_signal(com_ptr<IContextCallback> context, void* signal)
+    {
+        co_await resume_on_signal(signal);
+        InvokeInContext(context.get(), []()
+            {
+                // This disconnects the IAsyncAction, simulating a server crash.
+                CoDisconnectContext(INFINITE);
+            });
+    }
+}
+
+TEST_CASE("disconnected,action")
+{
+    auto private_context = create_instance<IContextCallback>(CLSID_ContextSwitcher);
+    handle signal{ CreateEventW(nullptr, true, false, nullptr) };
+    disconnect_on_signal(private_context, signal.get());
+
+    agile_ref<IAsyncAction> action;
+    InvokeInContext(private_context.get(), [&]()
+        {
+            action = make<non_agile_abandoned_action>(signal.get());
+        });
+
+    auto result = [](IAsyncAction action) -> IAsyncAction
+        {
+            co_await action;
+            co_return;
+        }(action.get());
+
+    REQUIRE_THROWS_AS(result.get(), hresult_error);
 }

--- a/test/test/disconnected.cpp
+++ b/test/test/disconnected.cpp
@@ -188,7 +188,6 @@ TEST_CASE("disconnected,action")
     auto result = [](IAsyncAction action) -> IAsyncAction
         {
             co_await action;
-            co_return;
         }(action.get());
 
     REQUIRE_THROWS_AS(result.get(), hresult_error);


### PR DESCRIPTION
During a `co_await` of an `IAsyncAction` or `IAsyncOperation`, if the completion delegate is released without ever being invoked, then assume that the remote server crashed. Resume the coroutine, and the RPC error will be raised when `await_resume()` calls `GetResults()`.

Note that this behavior applies only to `co_await`. If you manually attach a `Completed` handler, then it is your responsibility to detect server death.

The `disconnect_aware_handler` is basically the same as the lambda we had been using, just with the additional behavior of resuming the coroutine if it is destructed without ever having been invoked. We null out the coroutine handle on invoke. That lets us detect the error case in our destructor.

This fixes issue #600