### PR TITLE
weak_ref<T> can be compared for equality

### DIFF
--- a/strings/base_weak_ref.h
+++ b/strings/base_weak_ref.h
@@ -56,20 +56,51 @@ WINRT_EXPORT namespace winrt
             return static_cast<bool>(m_ref);
         }
 
-        bool operator==(weak_ref const& other) const noexcept
-        {
-            return m_ref == other.m_ref;
-        }
-
-        bool operator!=(weak_ref const& other) const noexcept
-        {
-            return !(*this == other);
-        }
-
     private:
 
         com_ptr<impl::IWeakReference> m_ref;
     };
+
+    template<typename T>
+    struct impl::abi<weak_ref<T>> : impl::abi<com_ptr<impl::IWeakReference>>
+    {
+    };
+
+    template <typename T>
+    inline bool operator==(weak_ref<T> const& left, weak_ref<T> const& right) noexcept
+    {
+        return get_abi(left) == get_abi(right);
+    }
+
+    template <typename T>
+    inline bool operator==(weak_ref<T> const& left, std::nullptr_t) noexcept
+    {
+        return get_abi(left) == nullptr;
+    }
+
+    template <typename T>
+    inline bool operator==(std::nullptr_t, weak_ref<T> const& right) noexcept
+    {
+        return nullptr == get_abi(right);
+    }
+
+    template <typename T>
+    inline bool operator!=(weak_ref<T> const& left, weak_ref<T> const& right) noexcept
+    {
+        return !(left == right);
+    }
+
+    template <typename T>
+    inline bool operator!=(weak_ref<T> const& left, std::nullptr_t) noexcept
+    {
+        return !(left == nullptr);
+    }
+
+    template <typename T>
+    inline bool operator!=(std::nullptr_t, weak_ref<T> const& right) noexcept
+    {
+        return !(nullptr == right);
+    }
 
     template <typename T>
     weak_ref<impl::wrapped_type_t<T>> make_weak(T const& object)

--- a/strings/base_weak_ref.h
+++ b/strings/base_weak_ref.h
@@ -56,6 +56,16 @@ WINRT_EXPORT namespace winrt
             return static_cast<bool>(m_ref);
         }
 
+        bool operator==(weak_ref const& other) const noexcept
+        {
+            return m_ref == other.m_ref;
+        }
+
+        bool operator!=(weak_ref const& other) const noexcept
+        {
+            return !(*this == other);
+        }
+
     private:
 
         com_ptr<impl::IWeakReference> m_ref;

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -287,9 +287,15 @@ TEST_CASE("weak,comparison")
     weak_ref<IStringable> refNothing = nullptr;
 
     REQUIRE(refA1 == refA2);
+    REQUIRE(!(refA1 != refA2));
     REQUIRE(refA1 != refB);
+    REQUIRE(!(refA1 == refB));
     REQUIRE(refA1 != refNothing);
+    REQUIRE(!(refA1 == refNothing));
     REQUIRE(refA1 != nullptr);
+    REQUIRE(nullptr != refA1);
+    REQUIRE(refNothing == nullptr);
+    REQUIRE(nullptr == refNothing);
 
     // Comparisons are against the weak reference itself,
     // not the thing it refers to.
@@ -299,7 +305,6 @@ TEST_CASE("weak,comparison")
     REQUIRE(refA1 == refA2);
     REQUIRE(refA1 != refB);
     REQUIRE(refA1 != refNothing);
-    REQUIRE(refA1 != nullptr);
 }
 
 TEST_CASE("weak,module_lock")

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -277,6 +277,31 @@ TEST_CASE("weak,lifetime")
     }
 }
 
+TEST_CASE("weak,comparison")
+{
+    IStringable objectA = make<Weak>();
+    IStringable objectB = make<Weak>();
+    weak_ref<IStringable> refA1 = objectA;
+    weak_ref<IStringable> refA2 = refA1;
+    weak_ref<IStringable> refB = objectB;
+    weak_ref<IStringable> refNothing = nullptr;
+
+    REQUIRE(refA1 == refA2);
+    REQUIRE(refA1 != refB);
+    REQUIRE(refA1 != refNothing);
+    REQUIRE(refA1 != nullptr);
+
+    // Comparisons are against the weak reference itself,
+    // not the thing it refers to.
+    objectA = nullptr;
+    objectB = nullptr;
+
+    REQUIRE(refA1 == refA2);
+    REQUIRE(refA1 != refB);
+    REQUIRE(refA1 != refNothing);
+    REQUIRE(refA1 != nullptr);
+}
+
 TEST_CASE("weak,module_lock")
 {
     uint32_t object_count = get_module_lock();


### PR DESCRIPTION
This compares whether the weak references are copies of each other, not whether they refer to the same object.