### PR TITLE
Set better defaults for references and project references to keep MdMerge happy.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -43,6 +43,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <ProxyFileName Condition="'%(Midl.ProxyFileName)'==''">nul</ProxyFileName>
             <TypeLibraryName Condition="'%(Midl.TypeLibraryName)'==''"></TypeLibraryName>
         </Midl>
+        <ProjectReference Condition="'$(XamlLanguage)' != 'C++'">
+            <!-- By default, for a C++/WinRT project,
+                 don't copy project reference output to the output directory
+                 of the current project unless this is an exe. -->
+            <Private>false</Private>
+            <Private Condition="'$(ConfigurationType)' == 'Application' or '$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">true</Private>
+        </ProjectReference>
+        <Reference Condition="'$(XamlLanguage)' != 'C++'">
+            <!-- By default, for a C++/WinRT project,
+                 don't copy reference output to the output directory
+                 of the current project unless this is an exe. -->
+            <Private>false</Private>
+            <Private Condition="'$(ConfigurationType)' == 'Application' or '$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">true</Private>
+        </Reference>
     </ItemDefinitionGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Current released versions of MdMerge don't like duplicate definitions. This PR attempts to reduce the duplication by not copying reference output to the output folder by default unless this is an application. An application is always a leaf node and its winmd should never be merged into something else anyway. 

Overrides are still possible since this is defined in the props file which is imported very early in the build process, to allows folks to change the default if needed. Unit test projects are an example where this might be needed, but there is not a good way to detect them. 

A non-C++/WinRT project won't get these defaults and those projects might still require manually setting Private=false, if it is reference by a C++/WinRT project, so this solution isn't perfect but it helps somewhat.

TODO:
- [x] Test razzle build

Fixes #452 