### PR TITLE
Revert utf-8 encoding of runtime class names

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -353,7 +353,7 @@ namespace cppwinrt
             }
             else
             {
-                w.write(R"(, u8", ")");
+                w.write(R"(, L", ")");
             }
             w.write(", name_v<%>", param.Name());
         }
@@ -366,14 +366,14 @@ namespace cppwinrt
 
         if (empty(generics))
         {
-            auto format = R"(    template <> inline constexpr auto& name_v<%> = u8"%.%";
+            auto format = R"(    template <> inline constexpr auto& name_v<%> = L"%.%";
 )";
 
             w.write(format, type, type_name.name_space, type_name.name);
         }
         else
         {
-            auto format = R"(    template <%> inline constexpr auto name_v<%> = zcombine(u8"%.%<"%, u8">");
+            auto format = R"(    template <%> inline constexpr auto name_v<%> = zcombine(L"%.%<"%, L">");
 )";
 
             w.write(format,

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -106,7 +106,7 @@ namespace cppwinrt
         if (settings.component_opt)
         {
             auto format = R"(
-    if (requal(name, "%.%"))
+    if (requal(name, L"%.%"))
     {
         return winrt_make_%();
     }
@@ -120,7 +120,7 @@ namespace cppwinrt
         else
         {
             auto format = R"(
-    if (requal(name, "%.%"))
+    if (requal(name, L"%.%"))
     {
         return winrt::detach_abi(winrt::make<winrt::@::factory_implementation::%>());
     }
@@ -149,11 +149,9 @@ bool __stdcall %_can_unload_now() noexcept
     return true;
 }
 
-void* __stdcall %_get_activation_factory([[maybe_unused]] std::wstring_view const& wname)
+void* __stdcall %_get_activation_factory([[maybe_unused]] std::wstring_view const& name)
 {
-    auto name = winrt::to_string(wname);
-
-    auto requal = [](std::string_view const& left, std::string_view const& right) noexcept
+    auto requal = [](std::wstring_view const& left, std::wstring_view const& right) noexcept
     {
         return std::equal(left.rbegin(), left.rend(), right.rbegin(), right.rend());
     };
@@ -752,7 +750,7 @@ catch (...) { return winrt::to_hresult(); }
         %
         hstring GetRuntimeClassName() const
         {
-            return name_of<class_type>();
+            return L"%.%";
         }
 %%%%    };
 }
@@ -822,6 +820,8 @@ catch (...) { return winrt::to_hresult(); }
                 type_name,
                 type_name,
                 composable_base_name,
+                type_namespace,
+                type_name,
                 bind<write_component_class_override_constructors>(type),
                 bind<write_component_override_dispatch_base>(type),
                 bind<write_component_base_call>(type),
@@ -839,7 +839,7 @@ catch (...) { return winrt::to_hresult(); }
 
         hstring GetRuntimeClassName() const
         {
-            return name_of<instance_type>();
+            return L"%.%";
         }
 %    };
 }
@@ -849,6 +849,8 @@ catch (...) { return winrt::to_hresult(); }
                 type_namespace,
                 type_name,
                 bind<write_component_factory_interfaces>(factories),
+                type_namespace,
+                type_name,
                 type_namespace,
                 type_name,
                 bind<write_component_forwarders>(factories));

--- a/strings/base_foundation.h
+++ b/strings/base_foundation.h
@@ -102,9 +102,9 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
 
 namespace winrt::impl
 {
-    template <> inline constexpr auto& name_v<Windows::Foundation::Point> = u8"Windows.Foundation.Point";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Size> = u8"Windows.Foundation.Size";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Rect> = u8"Windows.Foundation.Rect";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Point> = L"Windows.Foundation.Point";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Size> = L"Windows.Foundation.Size";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Rect> = L"Windows.Foundation.Rect";
 
     template <> struct category<Windows::Foundation::Point>
     {
@@ -123,13 +123,13 @@ namespace winrt::impl
 
 #ifdef WINRT_IMPL_NUMERICS
 
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float2> = u8"Windows.Foundation.Numerics.Vector2";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3> = u8"Windows.Foundation.Numerics.Vector3";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4> = u8"Windows.Foundation.Numerics.Vector4";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3x2> = u8"Windows.Foundation.Numerics.Matrix3x2";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4x4> = u8"Windows.Foundation.Numerics.Matrix4x4";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::quaternion> = u8"Windows.Foundation.Numerics.Quaternion";
-    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::plane> = u8"Windows.Foundation.Numerics.Plane";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float2> = L"Windows.Foundation.Numerics.Vector2";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3> = L"Windows.Foundation.Numerics.Vector3";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4> = L"Windows.Foundation.Numerics.Vector4";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float3x2> = L"Windows.Foundation.Numerics.Matrix3x2";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::float4x4> = L"Windows.Foundation.Numerics.Matrix4x4";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::quaternion> = L"Windows.Foundation.Numerics.Quaternion";
+    template <> inline constexpr auto& name_v<Windows::Foundation::Numerics::plane> = L"Windows.Foundation.Numerics.Plane";
 
     template <> struct category<Windows::Foundation::Numerics::float2>
     {

--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -19,12 +19,6 @@ WINRT_EXPORT namespace winrt
 
 namespace winrt::impl
 {
-#ifdef __cpp_char8_t
-    using char_type = char8_t;
-#else
-    using char_type = char;
-#endif
-
     template <size_t Size, typename T, size_t... Index>
     constexpr std::array<T, Size> to_array(T const* value, std::index_sequence<Index...> const) noexcept
     {
@@ -38,7 +32,7 @@ namespace winrt::impl
     }
 
     template <size_t Size>
-    constexpr auto to_array(char_type const(&value)[Size]) noexcept
+    constexpr auto to_array(char const(&value)[Size]) noexcept
     {
         return to_array<Size - 1>(value, std::make_index_sequence<Size - 1>());
     }
@@ -433,7 +427,7 @@ namespace winrt::impl
     }
 
     template <size_t Size>
-    constexpr guid generate_guid(std::array<char_type, Size> const& value) noexcept
+    constexpr guid generate_guid(std::array<char, Size> const& value) noexcept
     {
         guid namespace_guid = { 0xd57af411, 0x737b, 0xc042,{ 0xab, 0xae, 0x87, 0x8b, 0x1e, 0x16, 0xad, 0xee } };
 
@@ -447,7 +441,7 @@ namespace winrt::impl
     template <typename TArg, typename... TRest>
     struct arg_collection
     {
-        constexpr static auto data{ combine(to_array(signature<TArg>::data), u8";", arg_collection<TRest...>::data) };
+        constexpr static auto data{ combine(to_array(signature<TArg>::data), ";", arg_collection<TRest...>::data) };
     };
 
     template <typename TArg>
@@ -473,8 +467,8 @@ namespace winrt::impl
     {
         combine
         (
-            to_array<char_type>(guid_of<T>()),
-            std::array<char_type, 1>{ '\0' }
+            to_array<wchar_t>(guid_of<T>()),
+            std::array<wchar_t, 1>{ L'\0' }
         )
     };
 
@@ -493,48 +487,98 @@ namespace winrt::impl
         return 3;
     }
 
+    constexpr size_t to_utf8(wchar_t const value, char* buffer) noexcept
+    {
+        if (value <= 0x7F)
+        {
+            *buffer = static_cast<char>(value);
+            return 1;
+        }
+
+        if (value <= 0x7FF)
+        {
+            *buffer = static_cast<char>(0xC0 | (value >> 6));
+            *(buffer + 1) = 0x80 | (value & 0x3F);
+            return 2;
+        }
+
+        *buffer = 0xE0 | (value >> 12);
+        *(buffer + 1) = 0x80 | ((value >> 6) & 0x3F);
+        *(buffer + 2) = 0x80 | (value & 0x3F);
+        return 3;
+    }
+
+    template <typename T>
+    constexpr size_t to_utf8_size() noexcept
+    {
+        auto input = to_array(name_v<T>);
+        size_t length = 0;
+
+        for (wchar_t const element : input)
+        {
+            length += to_utf8_size(element);
+        }
+
+        return length;
+    }
+
+    template <typename T>
+    constexpr auto to_utf8() noexcept
+    {
+        auto input = to_array(name_v<T>);
+        std::array<char, to_utf8_size<T>()> output{};
+        size_t offset{};
+
+        for (wchar_t const element : input)
+        {
+            offset += to_utf8(element, &output[offset]);
+        }
+
+        return output;
+    }
+
     template <typename T>
     constexpr guid generic_guid_v{};
 
     template <typename T>
-    constexpr auto& basic_signature_v = u8"";
+    constexpr auto& basic_signature_v = "";
 
-    template <> inline constexpr auto& basic_signature_v<bool> = u8"b1";
-    template <> inline constexpr auto& basic_signature_v<int8_t> = u8"i1";
-    template <> inline constexpr auto& basic_signature_v<int16_t> = u8"i2";
-    template <> inline constexpr auto& basic_signature_v<int32_t> = u8"i4";
-    template <> inline constexpr auto& basic_signature_v<int64_t> = u8"i8";
-    template <> inline constexpr auto& basic_signature_v<uint8_t> = u8"u1";
-    template <> inline constexpr auto& basic_signature_v<uint16_t> = u8"u2";
-    template <> inline constexpr auto& basic_signature_v<uint32_t> = u8"u4";
-    template <> inline constexpr auto& basic_signature_v<uint64_t> = u8"u8";
-    template <> inline constexpr auto& basic_signature_v<float> = u8"f4";
-    template <> inline constexpr auto& basic_signature_v<double> = u8"f8";
-    template <> inline constexpr auto& basic_signature_v<char16_t> = u8"c2";
-    template <> inline constexpr auto& basic_signature_v<guid> = u8"g16";
-    template <> inline constexpr auto& basic_signature_v<hstring> = u8"string";
-    template <> inline constexpr auto& basic_signature_v<Windows::Foundation::IInspectable> = u8"cinterface(IInspectable)";
+    template <> inline constexpr auto& basic_signature_v<bool> = "b1";
+    template <> inline constexpr auto& basic_signature_v<int8_t> = "i1";
+    template <> inline constexpr auto& basic_signature_v<int16_t> = "i2";
+    template <> inline constexpr auto& basic_signature_v<int32_t> = "i4";
+    template <> inline constexpr auto& basic_signature_v<int64_t> = "i8";
+    template <> inline constexpr auto& basic_signature_v<uint8_t> = "u1";
+    template <> inline constexpr auto& basic_signature_v<uint16_t> = "u2";
+    template <> inline constexpr auto& basic_signature_v<uint32_t> = "u4";
+    template <> inline constexpr auto& basic_signature_v<uint64_t> = "u8";
+    template <> inline constexpr auto& basic_signature_v<float> = "f4";
+    template <> inline constexpr auto& basic_signature_v<double> = "f8";
+    template <> inline constexpr auto& basic_signature_v<char16_t> = "c2";
+    template <> inline constexpr auto& basic_signature_v<guid> = "g16";
+    template <> inline constexpr auto& basic_signature_v<hstring> = "string";
+    template <> inline constexpr auto& basic_signature_v<Windows::Foundation::IInspectable> = "cinterface(IInspectable)";
 
-    template <> inline constexpr auto& name_v<bool> = u8"Boolean";
-    template <> inline constexpr auto& name_v<int8_t> = u8"Int8";
-    template <> inline constexpr auto& name_v<int16_t> = u8"Int16";
-    template <> inline constexpr auto& name_v<int32_t> = u8"Int32";
-    template <> inline constexpr auto& name_v<int64_t> = u8"Int64";
-    template <> inline constexpr auto& name_v<uint8_t> = u8"UInt8";
-    template <> inline constexpr auto& name_v<uint16_t> = u8"UInt16";
-    template <> inline constexpr auto& name_v<uint32_t> = u8"UInt32";
-    template <> inline constexpr auto& name_v<uint64_t> = u8"UInt64";
-    template <> inline constexpr auto& name_v<float> = u8"Single";
-    template <> inline constexpr auto& name_v<double> = u8"Double";
-    template <> inline constexpr auto& name_v<char16_t> = u8"Char16";
-    template <> inline constexpr auto& name_v<guid> = u8"Guid";
-    template <> inline constexpr auto& name_v<hstring> = u8"String";
-    template <> inline constexpr auto& name_v<hresult> = u8"Windows.Foundation.HResult";
-    template <> inline constexpr auto& name_v<event_token> = u8"Windows.Foundation.EventRegistrationToken";
-    template <> inline constexpr auto& name_v<Windows::Foundation::IInspectable> = u8"Object";
-    template <> inline constexpr auto& name_v<Windows::Foundation::TimeSpan> = u8"Windows.Foundation.TimeSpan";
-    template <> inline constexpr auto& name_v<Windows::Foundation::DateTime> = u8"Windows.Foundation.DateTime";
-    template <> inline constexpr auto& name_v<IAgileObject> = u8"IAgileObject";
+    template <> inline constexpr auto& name_v<bool> = L"Boolean";
+    template <> inline constexpr auto& name_v<int8_t> = L"Int8";
+    template <> inline constexpr auto& name_v<int16_t> = L"Int16";
+    template <> inline constexpr auto& name_v<int32_t> = L"Int32";
+    template <> inline constexpr auto& name_v<int64_t> = L"Int64";
+    template <> inline constexpr auto& name_v<uint8_t> = L"UInt8";
+    template <> inline constexpr auto& name_v<uint16_t> = L"UInt16";
+    template <> inline constexpr auto& name_v<uint32_t> = L"UInt32";
+    template <> inline constexpr auto& name_v<uint64_t> = L"UInt64";
+    template <> inline constexpr auto& name_v<float> = L"Single";
+    template <> inline constexpr auto& name_v<double> = L"Double";
+    template <> inline constexpr auto& name_v<char16_t> = L"Char16";
+    template <> inline constexpr auto& name_v<guid> = L"Guid";
+    template <> inline constexpr auto& name_v<hstring> = L"String";
+    template <> inline constexpr auto& name_v<hresult> = L"Windows.Foundation.HResult";
+    template <> inline constexpr auto& name_v<event_token> = L"Windows.Foundation.EventRegistrationToken";
+    template <> inline constexpr auto& name_v<Windows::Foundation::IInspectable> = L"Object";
+    template <> inline constexpr auto& name_v<Windows::Foundation::TimeSpan> = L"Windows.Foundation.TimeSpan";
+    template <> inline constexpr auto& name_v<Windows::Foundation::DateTime> = L"Windows.Foundation.DateTime";
+    template <> inline constexpr auto& name_v<IAgileObject> = L"IAgileObject";
 
     template <> struct category<bool> { using type = basic_category; };
     template <> struct category<int8_t> { using type = basic_category; };
@@ -565,36 +609,57 @@ namespace winrt::impl
     struct category_signature<enum_category, T>
     {
         using enum_type = std::underlying_type_t<T>;
-        constexpr static auto data{ combine(u8"enum(", name_v<T>, u8";", signature<enum_type>::data, u8")") };
+        constexpr static auto data{ combine("enum(", to_utf8<T>(), ";", signature<enum_type>::data, ")") };
     };
 
     template <typename... Fields, typename T>
     struct category_signature<struct_category<Fields...>, T>
     {
-        constexpr static auto data{ combine(u8"struct(", name_v<T>, u8";", arg_collection<Fields...>::data, u8")") };
+        constexpr static auto data{ combine("struct(", to_utf8<T>(), ";", arg_collection<Fields...>::data, ")") };
     };
 
     template <typename T>
     struct category_signature<class_category, T>
     {
-        constexpr static auto data{ combine(u8"rc(", name_v<T>, u8";", signature<winrt::default_interface<T>>::data, u8")") };
+        constexpr static auto data{ combine("rc(", to_utf8<T>(), ";", signature<winrt::default_interface<T>>::data, ")") };
     };
 
     template <typename... Args, typename T>
     struct category_signature<generic_category<Args...>, T>
     {
-        constexpr static auto data{ combine(u8"pinterface(", to_array<char_type>(generic_guid_v<T>), u8";", arg_collection<Args...>::data, u8")") };
+        constexpr static auto data{ combine("pinterface(", to_array<char>(generic_guid_v<T>), ";", arg_collection<Args...>::data, ")") };
     };
 
     template <typename T>
     struct category_signature<interface_category, T>
     {
-        constexpr static auto data{ to_array<char_type>(guid_of<T>()) };
+        constexpr static auto data{ to_array<char>(guid_of<T>()) };
     };
 
     template <typename T>
     struct category_signature<delegate_category, T>
     {
-        constexpr static auto data{ combine(u8"delegate(", to_array<char_type>(guid_of<T>()), u8")") };
+        constexpr static auto data{ combine("delegate(", to_array<char>(guid_of<T>()), ")") };
     };
+
+    template <size_t Size>
+    constexpr std::wstring_view to_wstring_view(std::array<wchar_t, Size> const& value) noexcept
+    {
+        return { value.data(), Size - 1 };
+    }
+
+    template <size_t Size>
+    constexpr std::wstring_view to_wstring_view(wchar_t const (&value)[Size]) noexcept
+    {
+        return { value, Size - 1 };
+    }
+}
+
+WINRT_EXPORT namespace winrt
+{
+    template <typename T>
+    constexpr auto name_of() noexcept
+    {
+        return impl::to_wstring_view(impl::name_v<T>);
+    }
 }

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -419,7 +419,7 @@ namespace winrt::impl
     {
         static hstring get()
         {
-            return name_of<I>();
+            return hstring{ name_of<I>() };
         }
     };
 

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -638,27 +638,3 @@ WINRT_EXPORT namespace winrt
         return result;
     }
 }
-
-namespace winrt::impl
-{
-    template <size_t Size>
-    hstring literal_to_hstring(std::array<char_type, Size> const& value) noexcept
-    {
-        return to_hstring(std::string_view(reinterpret_cast<char const*>(value.data()), Size - 1));
-    }
-
-    template <size_t Size>
-    hstring literal_to_hstring(char_type const (&value)[Size]) noexcept
-    {
-        return to_hstring(std::string_view(reinterpret_cast<char const*>(value), Size - 1));
-    }
-}
-
-WINRT_EXPORT namespace winrt
-{
-    template <typename T>
-    hstring name_of() noexcept
-    {
-        return impl::literal_to_hstring(impl::name_v<T>);
-    }
-}

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -26,9 +26,6 @@ WINRT_EXPORT namespace winrt
     struct hstring;
     struct clock;
 
-    template <typename T>
-    hstring name_of() noexcept;
-
     struct hresult
     {
         int32_t value{};

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -11,8 +11,8 @@ namespace winrt::impl
 
     struct diagnostics_info
     {
-        std::map<hstring, uint32_t> queries;
-        std::map<hstring, factory_diagnostics_info> factories;
+        std::map<std::wstring_view, uint32_t> queries;
+        std::map<std::wstring_view, factory_diagnostics_info> factories;
     };
 
     struct diagnostics_cache

--- a/strings/base_xaml_typename.h
+++ b/strings/base_xaml_typename.h
@@ -4,7 +4,7 @@ namespace winrt::impl
     template <typename T>
     struct xaml_typename_name
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
             return name_of<T>();
         }
@@ -12,41 +12,41 @@ namespace winrt::impl
     template <>
     struct xaml_typename_name<Windows::Foundation::Point>
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
-            return L"Point";
+            return L"Point"sv;
         }
     };
     template <>
     struct xaml_typename_name<Windows::Foundation::Size>
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
-            return L"Size";
+            return L"Size"sv;
         }
     };
     template <>
     struct xaml_typename_name<Windows::Foundation::Rect>
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
-            return L"Rect";
+            return L"Rect"sv;
         }
     };
     template <>
     struct xaml_typename_name<Windows::Foundation::DateTime>
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
-            return L"DateTime";
+            return L"DateTime"sv;
         }
     };
     template <>
     struct xaml_typename_name<Windows::Foundation::TimeSpan>
     {
-        static hstring value() noexcept
+        static constexpr std::wstring_view value() noexcept
         {
-            return L"TimeSpan";
+            return L"TimeSpan"sv;
         }
     };
 
@@ -133,7 +133,7 @@ WINRT_EXPORT namespace winrt
     inline Windows::UI::Xaml::Interop::TypeName xaml_typename()
     {
         static_assert(impl::has_category_v<T>, "T must be WinRT type.");
-        static const Windows::UI::Xaml::Interop::TypeName name{ impl::xaml_typename_name<T>::value(), impl::xaml_typename_kind<T>::value };
+        static const Windows::UI::Xaml::Interop::TypeName name{ hstring{ impl::xaml_typename_name<T>::value() }, impl::xaml_typename_kind<T>::value };
         return name;
     }
 }

--- a/test/old_tests/UnitTests/constexpr.cpp
+++ b/test/old_tests/UnitTests/constexpr.cpp
@@ -38,7 +38,7 @@ TEST_CASE("constexpr")
 
     REQUIRE(winrt::name_of<winrt_container>() == midl_container::z_get_rc_name_impl());
 
-    auto name = winrt::name_of<winrt::guid>();
+    constexpr auto name = winrt::name_of<winrt::guid>();
     REQUIRE(name == L"Guid");
 
     check_terminated(winrt::name_of<winrt::IInspectable>());

--- a/test/old_tests/UnitTests/string_view_compare.h
+++ b/test/old_tests/UnitTests/string_view_compare.h
@@ -3,7 +3,7 @@
 #include <string_view>
 
 template <typename CharT>
-bool string_view_equal(std::basic_string_view<CharT> left, std::basic_string_view<CharT> right) noexcept
+inline constexpr bool string_view_equal(std::basic_string_view<CharT> left, std::basic_string_view<CharT> right) noexcept
 {
     if (left.size() != right.size())
     {

--- a/test/old_tests/UnitTests/xaml_typename.cpp
+++ b/test/old_tests/UnitTests/xaml_typename.cpp
@@ -7,6 +7,27 @@ using namespace winrt;
 using namespace Windows::UI::Xaml::Interop;
 using namespace std::string_view_literals;
 
+static_assert(string_view_equal(impl::xaml_typename_name<bool>::value(), L"Boolean"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<char16_t>::value(), L"Char16"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<uint8_t>::value(), L"UInt8"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<int8_t>::value(), L"Int8"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<uint16_t>::value(), L"UInt16"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<int16_t>::value(), L"Int16"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<uint32_t>::value(), L"UInt32"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<int32_t>::value(), L"Int32"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<uint64_t>::value(), L"UInt64"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<int64_t>::value(), L"Int64"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<float>::value(), L"Single"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<double>::value(), L"Double"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<hstring>::value(), L"String"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<guid>::value(), L"Guid"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::DateTime>::value(), L"DateTime"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::TimeSpan>::value(), L"TimeSpan"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::Point>::value(), L"Point"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::Size>::value(), L"Size"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::Rect>::value(), L"Rect"sv));
+static_assert(string_view_equal(impl::xaml_typename_name<Windows::Foundation::IInspectable>::value(), L"Object"sv));
+
 static_assert(impl::xaml_typename_kind<bool>::value == Windows::UI::Xaml::Interop::TypeKind::Primitive);
 static_assert(impl::xaml_typename_kind<char16_t>::value == Windows::UI::Xaml::Interop::TypeKind::Primitive);
 static_assert(impl::xaml_typename_kind<uint8_t>::value == Windows::UI::Xaml::Interop::TypeKind::Primitive);
@@ -38,6 +59,7 @@ namespace
 
 TEST_CASE("xaml_typename")
 {
+    // We've static asserted all the impl values, but let's verify that the public runtime API behaves as expected
     REQUIRE(equals(TypeName{ hstring(L"Boolean"sv), TypeKind::Primitive }, xaml_typename<bool>()));
     REQUIRE(equals(TypeName{ hstring(L"Char16"sv), TypeKind::Primitive }, xaml_typename<char16_t>()));
     REQUIRE(equals(TypeName{ hstring(L"UInt8"sv), TypeKind::Primitive }, xaml_typename<uint8_t>()));

--- a/test/test/enum.cpp
+++ b/test/test/enum.cpp
@@ -9,8 +9,8 @@ TEST_CASE("enum")
     STATIC_REQUIRE(std::is_same_v<std::underlying_type_t<Signed>, int32_t>);
     STATIC_REQUIRE(std::is_same_v<std::underlying_type_t<Unsigned>, uint32_t>);
 
-    REQUIRE(name_of<Signed>() == L"test_component.Signed"sv);
-    REQUIRE(name_of<Unsigned>() == L"test_component.Unsigned"sv);
+    STATIC_REQUIRE(name_of<Signed>() == L"test_component.Signed"sv);
+    STATIC_REQUIRE(name_of<Unsigned>() == L"test_component.Unsigned"sv);
 
     REQUIRE(((Unsigned::First | Unsigned::Second | Unsigned::Third) & Unsigned::Second) == Unsigned::Second);
 

--- a/test/test/generic_types.h
+++ b/test/test/generic_types.h
@@ -7,7 +7,7 @@ using namespace Windows::Foundation::Numerics;
 using namespace std::literals;
 
 #define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(make_guid(left), guid_of<__VA_ARGS__>()));
-#define REQUIRE_EQUAL_NAME(left, ...) REQUIRE(left == name_of<__VA_ARGS__>());
+#define REQUIRE_EQUAL_NAME(left, ...) STATIC_REQUIRE(left == name_of<__VA_ARGS__>());
 
 namespace
 {

--- a/test/test/names.cpp
+++ b/test/test/names.cpp
@@ -10,7 +10,7 @@ void check_terminated(winrt::param::hstring const&)
 TEST_CASE("names")
 {
     REQUIRE(name_of<Windows::Foundation::IUnknown>() == L"{00000000-0000-0000-c000-000000000046}"sv);
-    REQUIRE(name_of<IInspectable>() == L"Object"sv);
+    STATIC_REQUIRE(name_of<IInspectable>() == L"Object"sv);
 
     check_terminated(name_of<Windows::Foundation::IUnknown>());
     check_terminated(name_of<IInspectable>());

--- a/test/test_win7/enum.cpp
+++ b/test/test_win7/enum.cpp
@@ -9,8 +9,8 @@ TEST_CASE("enum")
     STATIC_REQUIRE(std::is_same_v<std::underlying_type_t<Signed>, int32_t>);
     STATIC_REQUIRE(std::is_same_v<std::underlying_type_t<Unsigned>, uint32_t>);
 
-    REQUIRE(name_of<Signed>() == L"test_component.Signed"sv);
-    REQUIRE(name_of<Unsigned>() == L"test_component.Unsigned"sv);
+    STATIC_REQUIRE(name_of<Signed>() == L"test_component.Signed"sv);
+    STATIC_REQUIRE(name_of<Unsigned>() == L"test_component.Unsigned"sv);
 
     REQUIRE(((Unsigned::First | Unsigned::Second | Unsigned::Third) & Unsigned::Second) == Unsigned::Second);
 

--- a/test/test_win7/generic_types.h
+++ b/test/test_win7/generic_types.h
@@ -7,7 +7,7 @@ using namespace Windows::Foundation::Numerics;
 using namespace std::literals;
 
 #define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(make_guid(left), guid_of<__VA_ARGS__>()));
-#define REQUIRE_EQUAL_NAME(left, ...) REQUIRE(left == name_of<__VA_ARGS__>());
+#define REQUIRE_EQUAL_NAME(left, ...) STATIC_REQUIRE(left == name_of<__VA_ARGS__>());
 
 namespace
 {

--- a/test/test_win7/names.cpp
+++ b/test/test_win7/names.cpp
@@ -10,7 +10,7 @@ void check_terminated(winrt::param::hstring const&)
 TEST_CASE("names")
 {
     REQUIRE(name_of<Windows::Foundation::IUnknown>() == L"{00000000-0000-0000-c000-000000000046}"sv);
-    REQUIRE(name_of<IInspectable>() == L"Object"sv);
+    STATIC_REQUIRE(name_of<IInspectable>() == L"Object"sv);
 
     check_terminated(name_of<Windows::Foundation::IUnknown>());
     check_terminated(name_of<IInspectable>());


### PR DESCRIPTION
Although beneficial for almost all projects, Xaml depends heavily on utf-16 strings and this change ends up hurting WinUI's binary size. 

This change merely reverts the two PRs that carried the utf-8 optimizations #610 and #617