### PR TITLE
Add SDK to NuGet package

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CppWinRT.nuspec
@@ -25,6 +25,8 @@
     <file src="Microsoft.Windows.CppWinRT.props" target="build\native"/>
     <file src="Microsoft.Windows.CppWinRT.targets" target="build\native"/>
     <file src="CppWinrtRules.Project.xml" target="build\native"/>
+    <file src="Sdk\Sdk.props" target="Sdk" />
+    <file src="Sdk\Sdk.targets" target="Sdk" />
     <file src="readme.txt"/>
   </files>
 </package>

--- a/nuget/Microsoft.Windows.CppWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CppWinRT.nuspec
@@ -14,6 +14,9 @@
     <license type="file">LICENSE</license>
     <projectUrl>https://github.com/Microsoft/cppwinrt</projectUrl>
     <iconUrl>https://aka.ms/cppwinrt.ico</iconUrl>
+    <packageTypes>
+      <packageType name="MSBuildSdk" />
+    </packageTypes>
   </metadata>
   <files>
     <file src="..\LICENSE"/>

--- a/nuget/Sdk/Sdk.props
+++ b/nuget/Sdk/Sdk.props
@@ -1,3 +1,7 @@
 <Project>
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'>
+    <CppWinRTDisableAutoNuGetReference>true</CppWinRTDisableAutoNuGetReference>
+  </PropertyGroup>
+
   <Import Project="..\build\native\Microsoft.Windows.CppWinRT.props" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
 </Project>

--- a/nuget/Sdk/Sdk.props
+++ b/nuget/Sdk/Sdk.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'>
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
     <CppWinRTDisableAutoNuGetReference>true</CppWinRTDisableAutoNuGetReference>
   </PropertyGroup>
 

--- a/nuget/Sdk/Sdk.props
+++ b/nuget/Sdk/Sdk.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\native\Microsoft.Windows.CppWinRT.props" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
+</Project>

--- a/nuget/Sdk/Sdk.targets
+++ b/nuget/Sdk/Sdk.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\native\Microsoft.Windows.CppWinRT.targets" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
+</Project>

--- a/nuget/Sdk/Sdk.targets
+++ b/nuget/Sdk/Sdk.targets
@@ -1,3 +1,7 @@
 <Project>
   <Import Project="..\build\native\Microsoft.Windows.CppWinRT.targets" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
+
+  <Target Name="_WarnCppWinRT" BeforeTargets="BeforeBuild" Condition="'$(MSBuildProjectExtension)' != '.vcxproj' and '$(CppWinRTNoWarn)' == ''">
+    <Warning Text="The Microsoft.Windows.CppWinRT NuGet SDK is ignored in non-C++ projects. Define the CppWinRTNoWarn property to silence this warning." />
+  </Target>
 </Project>


### PR DESCRIPTION
This is a crude, but effective, workaround for the lack of `PackageReference` support in Visual C++ projects. If this PR is merged, users can add the below code to their vcxproj file (or to imported props/targets), and MSBuild will download and cache the specified version of C++/WinRT automatically during build or when loading the project in VS. After that, the package will behave exactly as if it was referenced using packages.config.

Since C++/WinRT is not applicable to non-C++ projects, I added a warning if the SDK is imported in any other type of project. This warning can be suppressed, which makes referencing the SDK from props/targets files in a mixed-language repository easier.

```xml
<!-- At top of project, or in .props file -->
<Import Project="Sdk.props" Sdk="Microsoft.Windows.CppWinRT" Version="..." />

<!-- At bottom of project, or in .targets file -->
<Import Project="Sdk.targets" Sdk="Microsoft.Windows.CppWinRT" Version="..." />
```

Fixes #519.