### PR TITLE
Add VS extension support for #632

### DIFF
--- a/vsix/AssemblyInfo.cs
+++ b/vsix/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CppWinRT Visual Studio Extension")]
+[assembly: AssemblyTitle("C++/WinRT Visual Studio Extension")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/vsix/AssemblyInfo.cs
+++ b/vsix/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CppWinRT Visual Studio Extension")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0")]
+[assembly: AssemblyFileVersion("1.0")]
+[assembly: ComVisible(false)]

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.TemplateWizard;
@@ -57,11 +58,30 @@ namespace Microsoft.Windows.CppWinRT
 
             if (addNuGetReference)
             {
-                Assembly asm = Assembly.Load("NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-                Type wizardType = asm.GetType("NuGet.VisualStudio.TemplateWizard");
+                try
+                {
+                    Assembly asm = Assembly.Load("NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                    Type wizardType = asm.GetType("NuGet.VisualStudio.TemplateWizard");
 
-                IWizard nugetWizard = (IWizard)Activator.CreateInstance(wizardType);
-                nugetWizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+                    IWizard nugetWizard = (IWizard)Activator.CreateInstance(wizardType);
+                    nugetWizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+                }
+                catch (Exception ex)
+                {
+#if DEBUG
+                    string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "exception.txt");
+                    using (Stream stream = File.Open(path, FileMode.Create))
+                    using (StreamWriter writer = new StreamWriter(stream))
+                    {
+                        writer.WriteLine($"Caught exception: {ex.GetType().FullName}");
+                        writer.WriteLine(ex.Message);
+                        writer.WriteLine();
+                        writer.WriteLine(ex.StackTrace);
+                    }
+#endif
+
+                    throw new WizardCancelledException();
+                }
             }
         }
 

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -12,24 +12,26 @@ namespace Microsoft.Windows.CppWinRT
 {
     internal sealed class CppWinRTPackageTemplateWizard : IWizard
     {
+        private IWizard wizardImpl = null;
+
         public void BeforeOpeningFile(DTEProjectItem projectItem)
         {
-            // Not needed.
+            wizardImpl?.BeforeOpeningFile(projectItem);
         }
 
         public void ProjectFinishedGenerating(DTEProject project)
         {
-            // Not needed.
+            wizardImpl?.ProjectFinishedGenerating(project);
         }
 
         public void ProjectItemFinishedGenerating(DTEProjectItem projectItem)
         {
-            // Not needed.
+            wizardImpl?.ProjectItemFinishedGenerating(projectItem);
         }
 
         public void RunFinished()
         {
-            // Not needed.
+            wizardImpl?.RunFinished();
         }
 
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
@@ -63,8 +65,8 @@ namespace Microsoft.Windows.CppWinRT
                     Assembly asm = Assembly.Load("NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
                     Type wizardType = asm.GetType("NuGet.VisualStudio.TemplateWizard");
 
-                    IWizard nugetWizard = (IWizard)Activator.CreateInstance(wizardType);
-                    nugetWizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+                    wizardImpl = (IWizard)Activator.CreateInstance(wizardType);
+                    wizardImpl.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
                 }
                 catch (Exception ex)
                 {
@@ -87,8 +89,8 @@ namespace Microsoft.Windows.CppWinRT
 
         public bool ShouldAddProjectItem(string filePath)
         {
-            // Not needed.
-            return true;
+            if (wizardImpl != null) return wizardImpl.ShouldAddProjectItem(filePath);
+            else return true;
         }
     }
 }

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -35,10 +35,27 @@ namespace Microsoft.Windows.CppWinRT
         {
             VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 
-            DTEProject automationProject = (DTEProject)automationObject;
-            Project project = new Project(automationProject.FullName);
+            bool addNuGetReference;
+            try
+            {
+                DTEProject automationProject = (DTEProject)automationObject;
+                Project project = new Project(automationProject.FullName);
+                if (project.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    addNuGetReference = false;
+                }
+                else
+                {
+                    addNuGetReference = true;
+                }
+            }
+            catch
+            {
+                // If the property could not be read, use the default value, which is to add the reference.
+                addNuGetReference = true;
+            }
 
-            if (!project.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
+            if (addNuGetReference)
             {
                 Assembly asm = Assembly.Load("NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
                 Type wizardType = asm.GetType("NuGet.VisualStudio.TemplateWizard");

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using EnvDTE;
+using Microsoft.VisualStudio.TemplateWizard;
+
+namespace Microsoft.Windows.CppWinRT
+{
+    internal sealed class CppWinRTPackageTemplateWizard : IWizard
+    {
+        public void BeforeOpeningFile(ProjectItem projectItem)
+        {
+            // Not needed.
+        }
+
+        public void ProjectFinishedGenerating(Project project)
+        {
+            // Not needed.
+        }
+
+        public void ProjectItemFinishedGenerating(ProjectItem projectItem)
+        {
+            // Not needed.
+        }
+
+        public void RunFinished()
+        {
+            // Not needed.
+        }
+
+        public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
+        {
+            VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+
+            Project project = (Project)automationObject;
+            throw new NotImplementedException();
+        }
+
+        public bool ShouldAddProjectItem(string filePath)
+        {
+            // Not needed.
+            return true;
+        }
+    }
+}

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -40,13 +40,18 @@ namespace Microsoft.Windows.CppWinRT
 
             try
             {
-                var msbuildProject = new Project(project.FullName);
+                VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 
-                // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
-                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))
+                Project msbuildProject = new Project(project.FullName);
+                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Don't forward this call to the NuGet wizard, as it has been explicitly disabled.
+                }
+                else
                 {
                     wizardImpl?.ProjectFinishedGenerating(project);
                 }
+
                 ProjectCollection.GlobalProjectCollection.UnloadProject(msbuildProject);
             }
             catch (Exception ex)
@@ -61,10 +66,13 @@ namespace Microsoft.Windows.CppWinRT
 
             try
             {
-                var msbuildProject = new Project(projectItem.ContainingProject.FullName);
-
-                // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
-                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))
+                Project msbuildProject = new Project(projectItem.ContainingProject.FullName);
+                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Don't forward this call to the NuGet wizard, as it has been explicitly disabled.
+                    // NuGet packages are also installed in ProjectItemFinishedGenerating().
+                }
+                else
                 {
                     wizardImpl?.ProjectItemFinishedGenerating(projectItem);
                 }

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -116,13 +116,13 @@ namespace Microsoft.Windows.CppWinRT
             try
             {
                 if (wizardImpl != null) return wizardImpl.ShouldAddProjectItem(filePath);
-                else return true;
             }
             catch (Exception ex)
             {
                 ShowExceptionDialog(ex);
-                throw; // technically not reached
             }
+
+            return true;
         }
     }
 }

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Windows.CppWinRT
 
             try
             {
-                VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-
                 Project msbuildProject = new Project(project.FullName);
                 if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
                 {

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Windows.CppWinRT
 
         public void ProjectFinishedGenerating(DTEProject project)
         {
+            VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+
             try
             {
-                VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-
                 Project msbuildProject = new Project(project.FullName);
 
                 // Forward the call to the NuGet wizard, unless it has been explicitly disabled.

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.CppWinRT
 
             try
             {
-                Project msbuildProject = new Project(project.FullName);
+                var msbuildProject = new Project(project.FullName);
 
                 // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
                 if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.CppWinRT
 
             try
             {
-                Project msbuildProject = new Project(projectItem.ContainingProject.FullName);
+                var msbuildProject = new Project(projectItem.ContainingProject.FullName);
 
                 // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
                 if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Windows.Forms;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.TemplateWizard;
-using System.Windows.Forms;
 
 using DTEProject = EnvDTE.Project;
 using DTEProjectItem = EnvDTE.ProjectItem;
@@ -15,7 +15,7 @@ namespace Microsoft.Windows.CppWinRT
     {
         private IWizard wizardImpl = null;
 
-        private void ShowExceptionDialog(Exception ex)
+        private static void ShowExceptionDialog(Exception ex)
         {
             string text = $"{ex.GetType().FullName}: {ex.Message}\r\n\r\n{ex.StackTrace}";
             MessageBox.Show(text, "Caught Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -121,7 +121,7 @@ namespace Microsoft.Windows.CppWinRT
             catch (Exception ex)
             {
                 ShowExceptionDialog(ex);
-                return true; // technically not reached
+                throw; // technically not reached
             }
         }
     }

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -41,15 +41,12 @@ namespace Microsoft.Windows.CppWinRT
                 VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 
                 Project msbuildProject = new Project(project.FullName);
-                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
-                {
-                    // Don't forward this call to the NuGet wizard, as it has been explicitly disabled.
-                }
-                else
+
+                // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
+                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))
                 {
                     wizardImpl?.ProjectFinishedGenerating(project);
                 }
-
                 ProjectCollection.GlobalProjectCollection.UnloadProject(msbuildProject);
             }
             catch (Exception ex)
@@ -65,12 +62,9 @@ namespace Microsoft.Windows.CppWinRT
             try
             {
                 Project msbuildProject = new Project(projectItem.ContainingProject.FullName);
-                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
-                {
-                    // Don't forward this call to the NuGet wizard, as it has been explicitly disabled.
-                    // NuGet packages are also installed in ProjectItemFinishedGenerating().
-                }
-                else
+
+                // Forward the call to the NuGet wizard, unless it has been explicitly disabled.
+                if (msbuildProject.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("false", StringComparison.OrdinalIgnoreCase))
                 {
                     wizardImpl?.ProjectItemFinishedGenerating(projectItem);
                 }

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.CppWinRT
         {
             string text = $"{ex.GetType().FullName}: {ex.Message}\r\n\r\n{ex.StackTrace}";
             MessageBox.Show(text, "Caught Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            throw new WizardBackoutException();
+            throw new WizardCancelledException();
         }
 
         public void BeforeOpeningFile(DTEProjectItem projectItem)

--- a/vsix/CppWinRTPackageTemplateWizard.cs
+++ b/vsix/CppWinRTPackageTemplateWizard.cs
@@ -1,26 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using EnvDTE;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.TemplateWizard;
+
+using DTEProject = EnvDTE.Project;
+using DTEProjectItem = EnvDTE.ProjectItem;
 
 namespace Microsoft.Windows.CppWinRT
 {
     internal sealed class CppWinRTPackageTemplateWizard : IWizard
     {
-        public void BeforeOpeningFile(ProjectItem projectItem)
+        public void BeforeOpeningFile(DTEProjectItem projectItem)
         {
             // Not needed.
         }
 
-        public void ProjectFinishedGenerating(Project project)
+        public void ProjectFinishedGenerating(DTEProject project)
         {
             // Not needed.
         }
 
-        public void ProjectItemFinishedGenerating(ProjectItem projectItem)
+        public void ProjectItemFinishedGenerating(DTEProjectItem projectItem)
         {
             // Not needed.
         }
@@ -34,8 +35,17 @@ namespace Microsoft.Windows.CppWinRT
         {
             VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 
-            Project project = (Project)automationObject;
-            throw new NotImplementedException();
+            DTEProject automationProject = (DTEProject)automationObject;
+            Project project = new Project(automationProject.FullName);
+
+            if (!project.GetPropertyValue("CppWinRTDisableAutoNuGetReference").Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                Assembly asm = Assembly.Load("NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                Type wizardType = asm.GetType("NuGet.VisualStudio.TemplateWizard");
+
+                IWizard nugetWizard = (IWizard)Activator.CreateInstance(wizardType);
+                nugetWizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+            }
         }
 
         public bool ShouldAddProjectItem(string filePath)

--- a/vsix/ItemTemplates/BlankPage/cppwinrt_BlankPage.vstemplate
+++ b/vsix/ItemTemplates/BlankPage/cppwinrt_BlankPage.vstemplate
@@ -17,8 +17,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.xaml\$fileinputname$.idl" ReplaceParameters="true">BlankPage.idl</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.CppWinRTPackageTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/ItemTemplates/BlankUserControl/cppwinrt_BlankUserControl.vstemplate
+++ b/vsix/ItemTemplates/BlankUserControl/cppwinrt_BlankUserControl.vstemplate
@@ -17,8 +17,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.xaml\$fileinputname$.idl" ReplaceParameters="true">BlankUserControl.idl</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.CppWinRTPackageTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/ItemTemplates/ViewModel/cppwinrt_ViewModel.vstemplate
+++ b/vsix/ItemTemplates/ViewModel/cppwinrt_ViewModel.vstemplate
@@ -16,8 +16,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.idl\$fileinputname$.h" ReplaceParameters="true">ViewModel.h</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.CppWinRTPackageTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/LICENSE
+++ b/vsix/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/vsix/packages.config
+++ b/vsix/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="16.0.2258" targetFramework="net461" developmentDependency="true" />
-</packages>

--- a/vsix/source.extension.vsixmanifest
+++ b/vsix/source.extension.vsixmanifest
@@ -27,6 +27,7 @@
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="ItemTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="ProjectTemplates" />
     <Asset Type="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" Source="File" Path="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" VsixSubPath="Packages" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -149,6 +149,9 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CppWinRTPackageTemplateWizard.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="PrepareBuild;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <NuGetPackageImportStamp>
@@ -135,23 +134,15 @@
     <Content Include="cppwinrt.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="x64\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.42" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets'))" />
-  </Target>
-  <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />
   <Target Name="PrepareBuild" BeforeTargets="PrepareForBuild">
     <Error Condition="'$(CppWinRTVersion)' == ''" Text="The project must be supplied with a CppWinRTVersion property value" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -40,7 +40,7 @@
     <AssemblyName>Microsoft.Windows.CppWinRT</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -5,6 +5,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -37,7 +38,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Windows.CppWinRT</RootNamespace>
     <AssemblyName>Microsoft.Windows.CppWinRT</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -140,6 +141,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.42" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -144,6 +144,9 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" />
     <PackageReference Include="VSSDK.TemplateWizardInterface" Version="12.0.4" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CppWinRTPackageTemplateWizard.cs" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -142,6 +142,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.42" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" />
+    <PackageReference Include="VSSDK.TemplateWizardInterface" Version="12.0.4" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -143,6 +143,7 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.42" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" />
     <PackageReference Include="VSSDK.TemplateWizardInterface" Version="12.0.4" />
+    <PackageReference Include="Microsoft.Build" Version="16.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CppWinRTPackageTemplateWizard.cs" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -146,6 +146,7 @@
     <PackageReference Include="Microsoft.Build" Version="16.4.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CppWinRTPackageTemplateWizard.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -146,7 +146,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />
-  <Target Name="PrepareBuild" BeforeTargets="PrepareForBuild">
+  <Target Name="PrepareBuild" BeforeTargets="PrepareForBuild" Condition="'$(DesignTimeBuild)' != 'true'">
     <Error Condition="'$(CppWinRTVersion)' == ''" Text="The project must be supplied with a CppWinRTVersion property value" />
     <Error Condition="'$(NatvisDirx86)' == ''" Text="The project must be supplied with a NatvisDirx86 property value" />
     <Error Condition="'$(NatvisDirx64)' == ''" Text="The project must be supplied with a NatvisDirx64 property value" />


### PR DESCRIPTION
This PR is a redo of #536. I have since rebased it on top of master and fixed the problem described here: https://github.com/microsoft/cppwinrt/pull/536#issuecomment-589748242. The problem there was a bug in VS wherein a template adding nested files to a vcxproj would fail if the vcxproj already has filters in it. If I remove the three default filters from the project, then the templates work as expected.