### PR TITLE
Improve com_array construction

### DIFF
--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -257,27 +257,34 @@ WINRT_EXPORT namespace winrt
             std::uninitialized_fill_n(this->m_data, count, value);
         }
 
-        template <typename InIt> com_array(InIt first, InIt last)
+        template <typename InIt, typename = std::void_t<typename std::iterator_traits<InIt>::difference_type>>
+        com_array(InIt first, InIt last)
         {
             alloc(static_cast<size_type>(std::distance(first, last)));
             std::uninitialized_copy(first, last, this->begin());
         }
 
-        explicit com_array(std::vector<value_type> const& value) :
+        template <typename U>
+        explicit com_array(std::vector<U> const& value) :
             com_array(value.begin(), value.end())
         {}
 
-        template <size_t N>
-        explicit com_array(std::array<value_type, N> const& value) :
+        template <typename U, size_t N>
+        explicit com_array(std::array<U, N> const& value) :
             com_array(value.begin(), value.end())
         {}
 
-        template <size_type N>
-        explicit com_array(value_type const(&value)[N]) :
+        template <typename U, size_t N>
+        explicit com_array(U const(&value)[N]) :
             com_array(value, value + N)
         {}
 
         com_array(std::initializer_list<value_type> value) :
+            com_array(value.begin(), value.end())
+        {}
+
+        template <typename U, typename = std::enable_if_t<std::is_convertible_v<U, T>>>
+        com_array(std::initializer_list<U> value) :
             com_array(value.begin(), value.end())
         {}
 
@@ -339,6 +346,14 @@ WINRT_EXPORT namespace winrt
             }
         }
     };
+
+    template <typename C> com_array(uint32_t, C const&) -> com_array<std::decay_t<C>>;
+    template <typename InIt, typename = std::void_t<typename std::iterator_traits<InIt>::difference_type>>
+    com_array(InIt, InIt) -> com_array<std::decay_t<typename std::iterator_traits<InIt>::value_type>>;
+    template <typename C> com_array(std::vector<C> const&) -> com_array<std::decay_t<C>>;
+    template <size_t N, typename C> com_array(std::array<C, N> const&) -> com_array<std::decay_t<C>>;
+    template <size_t N, typename C> com_array(C const(&)[N]) -> com_array<std::decay_t<C>>;
+    template <typename C> com_array(std::initializer_list<C>) -> com_array<std::decay_t<C>>;
 
     namespace impl
     {

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -1282,3 +1282,49 @@ TEST_CASE("array_view,ctad")
 
 #undef REQUIRE_DEDUCED_AS
 }
+
+// Verify various ways of constructing a com_array.
+TEST_CASE("com_array,construct")
+{
+    com_array<int> two_zeroes{ { 0, 0 } };
+
+    REQUIRE(com_array<int>(2) == com_array<int>({ 0, 0 }));
+
+    // Verify these are treated as { size, initial_value } constructors
+    // instead of { first, last } constructors.
+    REQUIRE(com_array<int>(2, 5) == com_array<int>({ 5, 5 }));
+    REQUIRE(com_array<unsigned int>(2, 5) == com_array<unsigned int>({ 5, 5 }));
+}
+
+// Verify that class template argument deduction works for com_array.
+TEST_CASE("com_array,ctad")
+{
+#define REQUIRE_DEDUCED_AS(T, ...) \
+    static_assert(std::is_same_v<com_array<T>, decltype(com_array(__VA_ARGS__))>)
+
+    REQUIRE_DEDUCED_AS(uint8_t, 3, uint8_t(5));
+
+    // Note that this looks like both an array and an initializer_list.
+    REQUIRE_DEDUCED_AS(uint8_t, { uint8_t(5) });
+
+    REQUIRE_DEDUCED_AS(uint8_t, com_array<uint8_t>());
+
+    uint8_t a[3]{};
+    REQUIRE_DEDUCED_AS(uint8_t, &a[0], &a[0]);
+    REQUIRE_DEDUCED_AS(uint8_t, a);
+
+    std::array<uint8_t, 3> ar{};
+    REQUIRE_DEDUCED_AS(uint8_t, ar);
+
+    std::vector<uint8_t> v{};
+    REQUIRE_DEDUCED_AS(uint8_t, v);
+
+    uint8_t const ca[3]{};
+    REQUIRE_DEDUCED_AS(uint8_t, &ca[0], &ca[0]);
+    REQUIRE_DEDUCED_AS(uint8_t, ca);
+
+    std::array<uint8_t const, 3> arc{};
+    REQUIRE_DEDUCED_AS(uint8_t, arc);
+
+#undef REQUIRE_DEDUCED_AS
+}


### PR DESCRIPTION
`com_array<T>` can now be constructed from the following, where `U` is convertible to `T`:
* `std::vector<U>`
* `std::array<U, N>`
* C-style array of `U`.
* `std::initializer_list<U>`

(Initialization from a pair of iterators to `U` was already supported. This change extends the behavior to the other collection types.)

Deduction guides have been added to permit class template argument deduction as follows:

* `com_array(N, U)` deduces `T = std::decay_t<U>`
* `com_array(InIt, InIt)` deduces `T = std::decay_t<std::iterator_traits<InIt>::value_type>`
* `com_array(std::vector<U> const&)` deduces `T = std::decay_t<U>`
* `com_array(std::array<U, N> const&)` deduces `T = std::decay_t<U>`
* `com_array(U const(&)[N])` deduces `T = std::decay_t<U>`
* `com_array(std::initializer_list<U>)` deduces `T = std::decay_t<U>`

We take care to resolve the following ambiguities:

```cpp
struct S { int x, y; };
com_array<S> value = { { 1, 2 }, { 3, 4 } };
```

A non-template constructor for `std::initializer_list<T>` steers the compiler toward treating this as initialization from an `initializer_list<T>` (where `T = S`). Without it, the compiler tries to initialize it as `initializer_list<U>` and can't figure out what `U` is.

```cpp
std::vector<X> v;
com_array<X> value = { v.begin(), v.end() };
```

Since `std::initializer_list`-based constructors have priority, this would normally be interpreted as trying to construct from an initializer list of iterators, which then fails to convert to `X`.

To fix this, we use SFINAE to remove the `initializer_list<U>` constructor if `U` is not convertible to `T`.

Finally, we have this:

```cpp
com_array<uint32_t> v1 = { 3, 42 }; // initializer_list
com_array<uint32_t> v2{ 3, 42 };    // initializer_list
com_array<uint32_t> v3(3, 42);      // size + initializer
```

SFINAE on the two-iterator constructor prevents us from interpreting this as an attempt to initialize from the range [3, 42).