### PR TITLE
Improve async cancellation interop

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -38,19 +38,32 @@ namespace winrt::impl
         WINRT_ASSERT(!is_sta());
     }
 
-    template <typename Async>
-    void wait_for_completed(Async const& async, uint32_t const timeout)
+    template <typename T, typename H>
+    std::pair<T, H*> make_delegate_with_shared_state(H&& handler)
     {
-        void* event = check_pointer(WINRT_IMPL_CreateEventW(nullptr, true, false, nullptr));
+        auto d = make_delegate<T, H>(std::forward<H>(handler));
+        return { std::move(d), reinterpret_cast<delegate<T, H>*>(get_abi(d)) };
+    }
 
-        // The delegate is a local to ensure that the event outlives the call to WaitForSingleObject.
-        async_completed_handler_t<Async> delegate = [event = handle(event)](auto && ...)
+    template <typename Async>
+    auto wait_for_completed(Async const& async, uint32_t const timeout)
+    {
+        struct shared_type
         {
-            WINRT_VERIFY(WINRT_IMPL_SetEvent(event.get()));
+            handle event{ check_pointer(WINRT_IMPL_CreateEventW(nullptr, true, false, nullptr)) };
+            Windows::Foundation::AsyncStatus status{ Windows::Foundation::AsyncStatus::Started };
+
+            void operator()(Async const&, Windows::Foundation::AsyncStatus operation_status) noexcept
+            {
+                status = operation_status;
+                WINRT_VERIFY(WINRT_IMPL_SetEvent(event.get()));
+            }
         };
 
+        auto [delegate, shared] = make_delegate_with_shared_state<async_completed_handler_t<Async>>(shared_type{});
         async.Completed(delegate);
-        WINRT_IMPL_WaitForSingleObject(event, timeout);
+        WINRT_IMPL_WaitForSingleObject(shared->event.get(), timeout);
+        return shared->status;
     }
 
     template <typename Async>
@@ -59,8 +72,15 @@ namespace winrt::impl
         check_sta_blocking_wait();
         auto const milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
         WINRT_ASSERT((milliseconds >= 0) && (static_cast<uint64_t>(milliseconds) < 0xFFFFFFFFull)); // Within uint32_t range and not INFINITE
-        wait_for_completed(async, static_cast<uint32_t>(milliseconds));
-        return async.Status();
+        return wait_for_completed(async, static_cast<uint32_t>(milliseconds));
+    }
+
+    inline void check_status_canceled(Windows::Foundation::AsyncStatus status)
+    {
+        if (status == Windows::Foundation::AsyncStatus::Canceled)
+        {
+            throw hresult_canceled();
+        }
     }
 
     template <typename Async>
@@ -68,10 +88,12 @@ namespace winrt::impl
     {
         check_sta_blocking_wait();
 
-        if (async.Status() == Windows::Foundation::AsyncStatus::Started)
+        auto status = async.Status();
+        if (status == Windows::Foundation::AsyncStatus::Started)
         {
-            wait_for_completed(async, 0xFFFFFFFF); // INFINITE
+            status = wait_for_completed(async, 0xFFFFFFFF); // INFINITE
         }
+        check_status_canceled(status);
 
         return async.GetResults();
     }
@@ -90,7 +112,7 @@ namespace winrt::impl
             if (m_handle) Complete();
         }
 
-        void operator()(Windows::Foundation::IAsyncInfo const&, Windows::Foundation::AsyncStatus)
+        void operator()()
         {
             Complete();
         }
@@ -109,19 +131,25 @@ namespace winrt::impl
     struct await_adapter
     {
         Async const& async;
+        Windows::Foundation::AsyncStatus status = Windows::Foundation::AsyncStatus::Started;
 
         bool await_ready() const noexcept
         {
             return false;
         }
 
-        void await_suspend(std::experimental::coroutine_handle<> handle) const
+        void await_suspend(std::experimental::coroutine_handle<> handle)
         {
-            async.Completed(disconnect_aware_handler{ handle });
+            async.Completed([this, handler = disconnect_aware_handler{ handle }](auto&&, auto operation_status) mutable
+            {
+                status = operation_status;
+                handler();
+            });
         }
 
         auto await_resume() const
         {
+            check_status_canceled(status);
             return async.GetResults();
         }
     };
@@ -691,28 +719,33 @@ WINRT_EXPORT namespace winrt
         struct shared_type
         {
             handle event{ check_pointer(WINRT_IMPL_CreateEventW(nullptr, true, false, nullptr)) };
+            Windows::Foundation::AsyncStatus status{ Windows::Foundation::AsyncStatus::Started };
             T result;
+
+            void operator()(T const& sender, Windows::Foundation::AsyncStatus operation_status) noexcept
+            {
+                auto sender_abi = *(impl::unknown_abi**)&sender;
+
+                if (nullptr == _InterlockedCompareExchangePointer(reinterpret_cast<void**>(&result), sender_abi, nullptr))
+                {
+                    sender_abi->AddRef();
+                    status = operation_status;
+                    WINRT_VERIFY(WINRT_IMPL_SetEvent(event.get()));
+                }
+            }
         };
 
-        auto shared = std::make_shared<shared_type>();
+        auto [delegate, shared] = impl::make_delegate_with_shared_state<impl::async_completed_handler_t<T>>(shared_type{});
 
         auto completed = [&](T const& async)
         {
-            async.Completed([shared](T const& sender, Windows::Foundation::AsyncStatus) noexcept
-                {
-                    auto sender_abi = *(impl::unknown_abi**)&sender;
-
-                    if (nullptr == _InterlockedCompareExchangePointer(reinterpret_cast<void**>(&shared->result), sender_abi, nullptr))
-                    {
-                        sender_abi->AddRef();
-                        WINRT_VERIFY(WINRT_IMPL_SetEvent(shared->event.get()));
-                    }
-                });
+            async.Completed(delegate);
         };
 
         completed(first);
         (completed(rest), ...);
         co_await resume_on_signal(shared->event.get());
+        impl::check_status_canceled(shared->status);
         co_return shared->result.GetResults();
     }
 }


### PR DESCRIPTION
Other projections report cancellation via the Status property and Completed delegate, rather than by GetResults. Switch from GetResults to Status and Completed to detect cancellation, to improve interop.

To avoid unnecessary fetches of the Status property (which are virtual calls), we cache the status passed to the Completed delegate. This applies to `co_await`, `get()`, and `when_any()`. `when_all` is built out of `co_await`, so it gets cancellation interop for free.

Factored cancellation checking into helper function `check_status_canceled`. And factored "create a delegate but give me access to the functor that the delegate is wrapping" into helper function `make_delegate_with_shared_state`. This saves an allocation in `when_any`. Would be nice if this functionality were exposed in the public API surface, since it's a handy pattern.

`wait_for_completed` now returns the status, so the caller can avoid a virtual call to the Status property. There is a tiny data race in `wait_for_completed` if the operation completes immediately after our wait timed out. In that case, we may return `Started` even though the operation has completed, but this is an inherent race condition (TOCTTOU), so it's unavoidable. Unfortunately, I couldn't figure out an easy way to get rid of the language-lawyer data race. Changing `status` to a `std::atomic` doesn't work because `std::atomic` is not movable. And `_InterlockedExchange_nf` is supported only on ARM64.

Having `wait_for_completed` return the status allows `wait_for` to avoid a virtual call to the Status property.

Fixes #641