### PR TITLE
Edge cases in when_all

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -712,7 +712,8 @@ WINRT_EXPORT namespace winrt
     template <typename... T>
     Windows::Foundation::IAsyncAction when_all(T... async)
     {
-        (co_await async, ...);
+        ((co_await async, void()), ...);
+        co_return;
     }
 
     template <typename T, typename... Rest>

--- a/test/test/when.cpp
+++ b/test/test/when.cpp
@@ -5,6 +5,12 @@ using namespace concurrency;
 using namespace winrt;
 using namespace Windows::Foundation;
 
+struct CommaStruct
+{
+    // If the comma operator is invoked, we will get a build failure.
+    CommaStruct operator,(CommaStruct) = delete;
+};
+
 task<void> ppl(bool& done)
 {
     co_await resume_background();
@@ -45,6 +51,12 @@ TEST_CASE("when")
         IAsyncAction result = when_any(done(), done());
         result.get();
     }
+
+    // Verify edge case of empty parameter list.
+    when_all().get();
+
+    // Verify edge case of overloaded comma operator (shame on you).
+    when_all(create_task([] { return CommaStruct{}; }), create_task([] { return CommaStruct{}; })).get();
     {
         handle first_event{ check_pointer(CreateEventW(nullptr, true, false, nullptr)) };
         handle second_event{ check_pointer(CreateEventW(nullptr, true, false, nullptr)) };


### PR DESCRIPTION
* Fix the case where you call `when_all` with coroutines whose return values have an overloaded comma operator. The existing code would accidentally comma the coroutine results together instead of discarding them as intended. Fix by explicitly comma-ing with void. You cannot overload   the comma operator when void is one of the parameters, so this forces the built-in comma operator to be used.

* Fix the case where you call `when_all` with no parameter. The existing code would end up with an empty body, which   lacked any `co_await` or `co_return` statements and therefore   wasn't a coroutine any more. Fix by adding a `co_return`.