### PR TITLE
Simply when_all implementation and test

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -712,7 +712,7 @@ WINRT_EXPORT namespace winrt
     template <typename... T>
     Windows::Foundation::IAsyncAction when_all(T... async)
     {
-        ((co_await async, void()), ...);
+        (void(co_await async), ...);
         co_return;
     }
 

--- a/test/test/when.cpp
+++ b/test/test/when.cpp
@@ -5,10 +5,13 @@ using namespace concurrency;
 using namespace winrt;
 using namespace Windows::Foundation;
 
-struct CommaStruct
+struct CommaStruct : std::experimental::suspend_never
 {
     // If the comma operator is invoked, we will get a build failure.
     CommaStruct operator,(CommaStruct) = delete;
+
+    // Awaiting the object just returns itself.
+    auto await_resume() const { return *this; }
 };
 
 task<void> ppl(bool& done)
@@ -56,7 +59,7 @@ TEST_CASE("when")
     when_all().get();
 
     // Verify edge case of overloaded comma operator (shame on you).
-    when_all(create_task([] { return CommaStruct{}; }), create_task([] { return CommaStruct{}; })).get();
+    when_all(CommaStruct{}, CommaStruct{}).get();
     {
         handle first_event{ check_pointer(CreateEventW(nullptr, true, false, nullptr)) };
         handle second_event{ check_pointer(CreateEventW(nullptr, true, false, nullptr)) };


### PR DESCRIPTION
Can just cast to void() instead of having to comma with void.

Comma-avoidance test no longer requires PPL.