### PR TITLE
Add support for the WinUI DispatcherQueue

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -3168,6 +3168,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             w.write(strings::base_coroutine_system);
         }
+        else if (namespace_name == "Microsoft.System")
+        {
+            w.write(strings::base_coroutine_system_winui);
+        }
         else if (namespace_name == "Windows.UI.Core")
         {
             w.write(strings::base_coroutine_ui_core);

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -56,6 +56,7 @@
     <ClInclude Include="..\strings\base_coroutine_system.h" />
     <ClInclude Include="..\strings\base_coroutine_threadpool.h" />
     <ClInclude Include="..\strings\base_coroutine_ui_core.h" />
+    <ClInclude Include="..\strings\base_coroutine_system_winui.h" />
     <ClInclude Include="..\strings\base_deferral.h" />
     <ClInclude Include="..\strings\base_delegate.h" />
     <ClInclude Include="..\strings\base_error.h" />

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -157,6 +157,9 @@
     <ClInclude Include="..\strings\base_includes.h">
       <Filter>strings</Filter>
     </ClInclude>
+    <ClInclude Include="..\strings\base_coroutine_system_winui.h">
+      <Filter>strings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="$(OutDir)version.rc" />

--- a/strings/base_coroutine_system_winui.h
+++ b/strings/base_coroutine_system_winui.h
@@ -1,0 +1,50 @@
+
+WINRT_EXPORT namespace winrt
+{
+    [[nodiscard]] inline auto resume_foreground(
+        Microsoft::System::DispatcherQueue const& dispatcher,
+        Microsoft::System::DispatcherQueuePriority const priority = Microsoft::System::DispatcherQueuePriority::Normal) noexcept
+    {
+        struct awaitable
+        {
+            awaitable(Microsoft::System::DispatcherQueue const& dispatcher, Microsoft::System::DispatcherQueuePriority const priority) noexcept :
+                m_dispatcher(dispatcher),
+                m_priority(priority)
+            {
+            }
+
+            bool await_ready() const noexcept
+            {
+                return false;
+            }
+
+            bool await_resume() const noexcept
+            {
+                return m_queued;
+            }
+
+            bool await_suspend(std::experimental::coroutine_handle<> handle)
+            {
+                return m_dispatcher.TryEnqueue(m_priority, [handle, this]
+                    {
+                        m_queued = true;
+                        handle();
+                    });
+            }
+
+        private:
+            Microsoft::System::DispatcherQueue const& m_dispatcher;
+            Microsoft::System::DispatcherQueuePriority const m_priority;
+            bool m_queued{};
+        };
+
+        return awaitable{ dispatcher, priority };
+    };
+
+#ifdef __cpp_coroutines
+    inline auto operator co_await(Microsoft::System::DispatcherQueue const& dispatcher)
+    {
+        return resume_foreground(dispatcher);
+    }
+#endif
+}


### PR DESCRIPTION
Fixes #578 

WinUI 3 has a distinct `DispatcherQueue`. This update provides `resume_foreground` support for it if you're targeting WinUI 3 and include the generated `winrt/Microsoft.System.h` header.