### PR TITLE
Can clear a specific factory from static lifetime store

### DIFF
--- a/strings/base_abi.h
+++ b/strings/base_abi.h
@@ -70,8 +70,8 @@ namespace winrt::impl
         virtual int32_t __stdcall unused2() noexcept = 0;
         virtual int32_t __stdcall unused3() noexcept = 0;
         virtual int32_t __stdcall Insert(void*, void*, bool*) noexcept = 0;
+        virtual int32_t __stdcall Remove(void*) noexcept = 0;
         virtual int32_t __stdcall unused4() noexcept = 0;
-        virtual int32_t __stdcall unused5() noexcept = 0;
     };
 
     struct __declspec(novtable) IWeakReference : unknown_abi


### PR DESCRIPTION
Services need to clean up all their COM objects without running down COM. Provide a way to remove a specific factory or factories from the static lifetime store.

```cpp
clear_factory_static_lifetime<Class1, Class2, Class3>();
```

The classes must be factory classes (in the `factory_implementation` namespace), to match `make_self`. We use the `instance_class` subtype to verify this.

This fixes issue #651 