### PR TITLE
Fix ABI conformance of IMap::Remove, add TryRemove

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1305,7 +1305,7 @@ namespace cppwinrt
         else if (type_name == "Windows.Foundation.Collections.IMapView`2")
         {
             w.write(R"(
-        auto TryLookup(param_type<K> const& key) const noexcept
+        auto TryLookup(param_type<K> const& key) const
         {
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
@@ -1331,7 +1331,7 @@ namespace cppwinrt
         else if (type_name == "Windows.Foundation.Collections.IMap`2")
         {
             w.write(R"(
-        auto TryLookup(param_type<K> const& key) const noexcept
+        auto TryLookup(param_type<K> const& key) const
         {
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
@@ -1353,7 +1353,7 @@ namespace cppwinrt
             }
         }
 
-        auto TryRemove(param_type<K> const& key) const noexcept
+        auto TryRemove(param_type<K> const& key) const
         {
             return 0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Remove(get_abi(key)));
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1310,7 +1310,7 @@ namespace cppwinrt
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
-                WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMapView<K, V>)->Lookup(get_abi(key), put_abi(result));
+                impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMapView<K, V>)->Lookup(get_abi(key), put_abi(result)));
                 return result;
             }
             else
@@ -1318,7 +1318,7 @@ namespace cppwinrt
                 std::optional<V> result;
                 V value{ empty_value<V>() };
 
-                if (0 == WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMapView<K, V>)->Lookup(get_abi(key), put_abi(value)))
+                if (0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMapView<K, V>)->Lookup(get_abi(key), put_abi(value))))
                 {
                     result = std::move(value);
                 }
@@ -1336,7 +1336,7 @@ namespace cppwinrt
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
-                WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Lookup(get_abi(key), put_abi(result));
+                impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Lookup(get_abi(key), put_abi(result)));
                 return result;
             }
             else
@@ -1344,13 +1344,18 @@ namespace cppwinrt
                 std::optional<V> result;
                 V value{ empty_value<V>() };
 
-                if (0 == WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Lookup(get_abi(key), put_abi(value)))
+                if (0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Lookup(get_abi(key), put_abi(value))))
                 {
                     result = std::move(value);
                 }
 
                 return result;
             }
+        }
+
+        auto TryRemove(param_type<K> const& key) const noexcept
+        {
+            return 0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Remove(get_abi(key)));
         }
 )");
         }

--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -1,4 +1,3 @@
-
 WINRT_EXPORT namespace winrt
 {
     template <typename D, typename T, typename Version = impl::no_collection_version>
@@ -415,8 +414,14 @@ WINRT_EXPORT namespace winrt
 
         void Remove(K const& key)
         {
+            auto& container = static_cast<D&>(*this).get_container();
+            auto found = container.find(static_cast<D const&>(*this).wrap_value(key));
+            if (found == container.end())
+            {
+                throw hresult_out_of_bounds();
+            }
             this->increment_version();
-            static_cast<D&>(*this).get_container().erase(static_cast<D const&>(*this).wrap_value(key));
+            container.erase(found);
         }
 
         void Clear() noexcept

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -579,3 +579,15 @@ WINRT_EXPORT namespace winrt
         abort();
     }
 }
+
+namespace winrt::impl
+{
+    inline hresult check_hresult_allow_bounds(hresult const result)
+    {
+        if (result != impl::error_out_of_bounds)
+        {
+            check_hresult(result);
+        }
+        return result;
+    }
+}

--- a/test/old_tests/UnitTests/TryLookup.cpp
+++ b/test/old_tests/UnitTests/TryLookup.cpp
@@ -90,3 +90,20 @@ TEST_CASE("TryLookup")
         REQUIRE(map.TryLookup(123).value() == 456);
     }
 }
+
+TEST_CASE("TryRemove")
+{
+    auto map = single_threaded_map<int, IStringable>(std::map<int, IStringable>{
+            { 123, nullptr },
+            { 124, make<stringable>(L"remove") },
+            { 125, make<stringable>(L"keep") },
+        });
+
+    REQUIRE(map.TryRemove(122) == false);
+    REQUIRE(map.TryRemove(123) == true);
+    REQUIRE(map.TryRemove(124) == true);
+
+    // Should still have one item left.
+    REQUIRE(map.Size() == 1);
+    REQUIRE(map.Lookup(125).ToString() == L"keep");
+}

--- a/test/old_tests/UnitTests/produce_map.cpp
+++ b/test/old_tests/UnitTests/produce_map.cpp
@@ -93,7 +93,7 @@ TEST_CASE("produce_IMap_int32_t_hstring")
     REQUIRE(m.Size() == 2);
     m.Remove(1); // existing
     REQUIRE(m.Size() == 1);
-    m.Remove(3); // not existing
+    REQUIRE_THROWS_AS(m.Remove(3), hresult_out_of_bounds); // not existing
     REQUIRE(m.Size() == 1);
 
     m.Clear();
@@ -177,7 +177,8 @@ TEST_CASE("produce_IMap_hstring_int32_t")
     REQUIRE(m.Size() == 2);
     m.Remove(L"one"); // existing
     REQUIRE(m.Size() == 1);
-    m.Remove(L"three"); // not existing
+    REQUIRE_THROWS_AS(m.Remove(L"three"), hresult_out_of_bounds); // not existing
+    REQUIRE(!m.TryRemove(L"three")); // not existing
     REQUIRE(m.Size() == 1);
 
     m.Clear();

--- a/test/old_tests/UnitTests/single_threaded_map.cpp
+++ b/test/old_tests/UnitTests/single_threaded_map.cpp
@@ -28,6 +28,7 @@ namespace
         values.Insert(2,20);
         values.Insert(3,30);
         IIterator<IKeyValuePair<int, int>> first = values.First();
+        REQUIRE(!values.TryRemove(999)); // failed removal does not invalidate
         REQUIRE(first.HasCurrent());
         [[maybe_unused]] auto pair = first.Current();
         REQUIRE(first.MoveNext());
@@ -52,7 +53,8 @@ namespace
         REQUIRE(!values.Insert(2, 20));
         compare(values, { { 1,100 }, {2,20} });
 
-        values.Remove(3);
+        REQUIRE_THROWS_AS(values.Remove(3), hresult_out_of_bounds);
+        REQUIRE(!values.TryRemove(3));
         compare(values, { { 1,100 },{ 2,20 } });
         values.Remove(2);
         compare(values, { { 1,100 } });
@@ -65,7 +67,7 @@ namespace
         compare(values, {});
 
         test_invalidation(values, [&] { values.Clear(); });
-        test_invalidation(values, [&] { values.Remove(10); });
+        test_invalidation(values, [&] { values.Remove(1); });
         test_invalidation(values, [&] { values.Insert(1,10); });
     }
 }


### PR DESCRIPTION
`single_threaded_map()`'s IMap::Remove did not throw `hresult_out_of_range` on attempts to remove a nonexistent key. Now it throws.

Note that this is a breaking change. Code that assumed nonexistent objects could be harmlessly removed will encounter exceptions when run against C++/WinRT implementations when they hadn't before this change. This was, however, a pre-existing bug, because implementations from other projections (C#, C++/CX, WRL) always throw under those conditions.

Added a TryRemove() method for people who want the nonthrowing version.

Note that fixing the ABI conformance is required in order for TryRemove to return the correct result, because TryRemove relies on the call to Remove failing if the key doesn't exist.

(JavaScript doesn't project objects as maps, so there is nothing to validate there.)

Tightened the behavior of TryLookup and TryRemove so they swallow only "key not found" and propagate other errors. The inability to remove the item could be due to the server being unavailable, or the app accessing the map from the wrong thread, and that's not the same as the item not existing in the collection. Previous code treated these errors the same as "The item doesn't exist", which is not true: The item could exist, we simply don't know since the call never got off the ground.

Failure to remove a nonexistent key no longer invalidates iterators, because nothing actually changed. This brings the map implementation in line with the implementations in C# and WRL. (C++/CX invalidates prematurely. JavaScript never invalidates iterators.)
