### PR TITLE
Fix unbox_value_or problems with explicit type and implicit hstring

### DIFF
--- a/strings/base_reference_produce.h
+++ b/strings/base_reference_produce.h
@@ -318,7 +318,7 @@ WINRT_EXPORT namespace winrt
         }
     }
 
-    template <typename T>
+    template <typename T = hstring, std::enable_if_t<std::is_same_v<T, hstring>, int> = 0>
     hstring unbox_value_or(Windows::Foundation::IInspectable const& value, param::hstring const& default_value)
     {
         if (value)

--- a/test/old_tests/UnitTests/Boxing2.cpp
+++ b/test/old_tests/UnitTests/Boxing2.cpp
@@ -214,4 +214,10 @@ TEST_CASE("Boxing")
         REQUIRE(unbox_value_or<UnsignedEnum>(box_value(static_cast<int32_t>(UnsignedEnum::Second)), UnsignedEnum::First) == UnsignedEnum::First);
         REQUIRE(unbox_value_or<UnsignedEnum>(box_value(static_cast<uint16_t>(UnsignedEnum::Second)), UnsignedEnum::First) == UnsignedEnum::First);
     }
+
+    {
+        // Test some cases where the compiler has to choose between multiple overloads.
+        REQUIRE(unbox_value_or<IInspectable>(nullptr, {}) == IInspectable{});
+        REQUIRE(unbox_value_or(nullptr, hstring{}) == hstring{});
+    }
 }


### PR DESCRIPTION
In a call to `unbox_value_or<T>(obj, def)`, if the second parameter happens to be a valid constructor parameter for `param::hstring`, then the hstring version of `unbox_value_or` will be used, even though the user clearly wants `T`.

```cpp
// expected to unbox obj to an IPropertyValue,
// but actually unboxes to an hstring!
auto pv = unbox_value_or<IPropertyValue>(obj, {});
```

Add an explicit `enable_if` to remove the hstring version if the template parameter is not `hstring`.

There's the converse problem, where you want `unbox_value_or` to infer `hstring`, but it can't:

```cpp
// Doesn't compile due to inability to infer T.
auto str = unbox_value_or(obj, hstring{});
```

Add a default type `hstring` for `T` in the hstring version of `unbox_value_or`.