### PR TITLE
Make array_view(pointer, size) constructor public

### DIFF
--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -17,6 +17,11 @@ WINRT_EXPORT namespace winrt
 
         array_view() noexcept = default;
 
+        array_view(pointer data, size_type size) noexcept :
+            m_data(data),
+            m_size(size)
+        {}
+
         array_view(pointer first, pointer last) noexcept :
             m_data(first),
             m_size(static_cast<size_type>(last - first))
@@ -191,11 +196,6 @@ WINRT_EXPORT namespace winrt
         }
 
     protected:
-
-        array_view(pointer data, size_type size) noexcept :
-            m_data(data),
-            m_size(size)
-        {}
 
         pointer m_data{ nullptr };
         size_type m_size{ 0 };

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -127,6 +127,24 @@ TEST_CASE("custom,DataReader")
 }
 
 //
+// This test illustrates an array_view<T> (non-const) bound to a raw buffer
+//
+TEST_CASE("buffer,DataReader")
+{
+    auto reader = CreateDataReader({ 1, 2, 3 }).get();
+
+    std::array<byte, 3> a;
+    byte* ptr = a.data();
+    auto size = a.size();
+    reader.ReadBytes({ ptr, static_cast<uint32_t>(size) });
+
+    REQUIRE(3 == a.size());
+    REQUIRE(1 == a[0]);
+    REQUIRE(2 == a[1]);
+    REQUIRE(3 == a[2]);
+}
+
+//
 // This test illustrates receiving an IVector and calling GetMany to fill an array.
 //
 TEST_CASE("array,EBO")

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -1277,6 +1277,7 @@ TEST_CASE("array_view,ctad")
 
     uint8_t a[3]{};
     REQUIRE_DEDUCED_AS(uint8_t, &a[0], &a[0]);
+    REQUIRE_DEDUCED_AS(uint8_t, &a[0], 3);
     REQUIRE_DEDUCED_AS(uint8_t, a);
 
     std::array<uint8_t, 3> ar{};


### PR DESCRIPTION
Addressing #665 by promoting the `array_view(pointer, size)` constructor to be public rather than protected, which is consistent with C++20's `std::span` that `winrt::array_view` is designed to emulate.