### PR TITLE
Support for LLVM 10

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -118,8 +118,8 @@ namespace winrt::impl
         }
 
     private:
-        std::experimental::coroutine_handle<> m_handle;
         resume_apartment_context m_context;
+        std::experimental::coroutine_handle<> m_handle;
 
         void Complete()
         {
@@ -743,7 +743,7 @@ WINRT_EXPORT namespace winrt
 
         auto [delegate, shared] = impl::make_delegate_with_shared_state<impl::async_completed_handler_t<T>>(shared_type{});
 
-        auto completed = [&](T const& async)
+        auto completed = [delegate = std::move(delegate)](T const& async)
         {
             async.Completed(delegate);
         };


### PR DESCRIPTION
Fixes #659

Note that full Clang support is currently hampered by the fact that Clang doesn't like the current VC libraries and fails to compile them. Other than that, this update fixes two minor issues that Clang didn't like about recent changes to C++/WinRT.

```C++
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\xutility(63,5): error : non-void constexpr function '_Bit_cast' should return a value [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1196,15): error : no matching function for call to '_Bit_cast' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1291,9): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1353,21): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1269,15): error : no matching function for call to '_Bit_cast' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1512,13): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1629,12): error : no matching function for call to '_Assemble_floating_point_value' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1392,16): error : no matching function for call to '_Assemble_floating_point_value' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1414,16): error : no matching function for call to '_Assemble_floating_point_value' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1442,12): error : no matching function for call to '_Assemble_floating_point_value' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1939,5): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(2003,14): error : no matching function for call to '_Bit_cast' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\xutility(63,5): error : non-void constexpr function '_Bit_cast' should return a value [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1196,15): error : no matching function for call to '_Bit_cast' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1291,9): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1353,21): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1269,15): error : no matching function for call to '_Bit_cast' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1512,13): error : no matching function for call to '_Assemble_floating_point_infinity' [C:\git\cppwinrt\scratch\scratch.vcxproj]
         C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.27.29009\include\charconv(1629,12): error : no matching function for call to '_Assemble_floating_point_value' [C:\git\cppwinrt\scratch\scratch.vcxproj]
```