### PR TITLE
Don't destroy the IAsyncInfo from inside Completed handler

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -140,6 +140,7 @@ namespace winrt::impl
 
         void await_suspend(std::experimental::coroutine_handle<> handle)
         {
+            auto extend_lifetime = async;
             async.Completed([this, handler = disconnect_aware_handler{ handle }](auto&&, auto operation_status) mutable
             {
                 status = operation_status;

--- a/test/test/async_completed.cpp
+++ b/test/test/async_completed.cpp
@@ -1,0 +1,66 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    //
+    // Checks that awaiting an already-completed async operation
+    // does not destroy the operation from within the Completed handler.
+    // The Completed handler may run synchronously, and destroying the
+    // operation from within the Completed handler pulls the rug out
+    // from under the operation!
+    //
+    struct already_completed : implements<already_completed, IAsyncAction, IAsyncInfo>
+    {
+        void Completed(AsyncActionCompletedHandler const& complete)
+        {
+            auto self = get_weak();
+            complete(*this, AsyncStatus::Completed);
+            REQUIRE(self.get() != nullptr);
+        }
+
+        auto Completed() const noexcept
+        {
+            return nullptr;
+        }
+
+        uint32_t Id() const noexcept
+        {
+            return 1;
+        }
+
+        AsyncStatus Status() const noexcept
+        {
+            return AsyncStatus::Completed;
+        }
+
+        hresult ErrorCode() const noexcept
+        {
+            return 0;
+        }
+
+        void GetResults() const noexcept
+        {
+        }
+
+        void Cancel() const noexcept
+        {
+        }
+
+        void Close() const noexcept
+        {
+        }
+    };
+
+    IAsyncAction TestCompleted()
+    {
+        co_await make<already_completed>();
+    }
+}
+
+TEST_CASE("async_completed")
+{
+    TestCompleted().get();
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -293,6 +293,7 @@
     <ClCompile Include="async_auto_cancel.cpp" />
     <ClCompile Include="async_cancel_callback.cpp" />
     <ClCompile Include="async_check_cancel.cpp" />
+    <ClCompile Include="async_completed.cpp" />
     <ClCompile Include="box_guid.cpp" />
     <ClCompile Include="capture.cpp" />
     <ClCompile Include="coro_foundation.cpp">


### PR DESCRIPTION
If the Completed handler runs synchronously, that would cause us to destroy the operation while a method on the operation is still running. That's not very nice.

This stems from the fact that synchronous completion causes the coroutine to resume before put_Completed returns. Resuming the coroutine causes it to get the result and then destroy the async operation. If the Completed handler is called synchronously from within put_Completed (which will happen if the operation has already completed), the operation will be destroyed while the put_Completed call is still outstanding. To avoid this problem, await_suspend extends the lifetime of the async operation across the call to put_Completed, so that the synchronous completion doesn't destroy the async operation prematurely.

If the operation completes asynchronously, then the destruction happens at coroutine resumption, which is fine. The put_Completed method returned a long time ago.

We make a copy of the async operation to ensure it is not destroyed while put_Completed is running. This costs us an AddRef/Release pair, but avoiding the AddRef/Release will cost us a few atomic operations (some of which require memory barriers), so it's basically a wash.

A more advanced solution would steal the async operation into await_suspend, and then use the IAsyncAction/IAsyncOperation passed to the completion handler to get the results. We'll use the simple solution for now.
