### PR TITLE
make progress_token::operator() const so it can be captured by lambdas

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -304,7 +304,7 @@ namespace winrt::impl
             return *this;
         }
 
-        void operator()(Progress const& result)
+        void operator()(Progress const& result) const
         {
             m_promise->set_progress(result);
         }

--- a/test/test/async_progress.cpp
+++ b/test/test/async_progress.cpp
@@ -19,8 +19,12 @@ namespace
     IAsyncOperationWithProgress<int, int> Operation(HANDLE event)
     {
         co_await resume_on_signal(event);
-        auto progress = co_await get_progress_token();
-        progress(123);
+
+        // Invoke from a lambda to ensure that operator() is const.
+        [progress = co_await get_progress_token()]()
+        {
+            progress(123);
+        }();
         co_return 1;
     }
 


### PR DESCRIPTION
This is useful when you are wrapping another operation's progress, as is common with HTTP filters.

```cpp
auto operation = m_inner.SendRequestAsync(request);
operation.Progress([progress_token = co_await get_progress_token()](auto&&, HttpProgress progress)
{
    progress.Retries += retries_performed;
    progress_token(progress);
});
co_await operation;
```