### PR TITLE
Cancellation token improvements

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -272,7 +272,7 @@ namespace winrt::impl
             return m_promise->Status() == Windows::Foundation::AsyncStatus::Canceled;
         }
 
-        void callback(winrt::delegate<>&& cancel) noexcept
+        void callback(winrt::delegate<>&& cancel) const noexcept
         {
             m_promise->cancellation_callback(std::move(cancel));
         }

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -558,7 +558,10 @@ namespace winrt::impl
                 }
             }
 
-            cancel();
+            if (cancel)
+            {
+                cancel();
+            }
         }
 
 #if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)

--- a/test/test/async_auto_cancel.cpp
+++ b/test/test/async_auto_cancel.cpp
@@ -39,6 +39,19 @@ namespace
         co_return 1;
     }
 
+    IAsyncAction ActionForceAutoCancel(HANDLE event)
+    {
+        co_await resume_on_signal(event);
+
+        // Null out the callback to indicate that we want to cancel
+        // any existing cancellation callback and rely on auto-cancel.
+        auto cancel = co_await get_cancellation_token();
+        cancel.callback(nullptr);
+
+        co_await std::experimental::suspend_never();
+        REQUIRE(false);
+    }
+
     template <typename F>
     void Check(F make)
     {
@@ -70,4 +83,5 @@ TEST_CASE("async_auto_cancel")
     Check(ActionWithProgress);
     Check(Operation);
     Check(OperationWithProgress);
+    Check(ActionForceAutoCancel);
 }

--- a/test/test/async_cancel_callback.cpp
+++ b/test/test/async_cancel_callback.cpp
@@ -11,6 +11,8 @@ namespace
 
     IAsyncAction Action(HANDLE event, bool& canceled)
     {
+        // Put the cancellation token into a lambda just to make
+        // sure it's possible.
         [cancel = co_await get_cancellation_token(), &canceled]
         {
             cancel.callback([&]

--- a/test/test/async_cancel_callback.cpp
+++ b/test/test/async_cancel_callback.cpp
@@ -11,13 +11,14 @@ namespace
 
     IAsyncAction Action(HANDLE event, bool& canceled)
     {
-        auto cancel = co_await get_cancellation_token();
-
-        cancel.callback([&]
-            {
-                REQUIRE(!canceled);
-                canceled = true;
-            });
+        [cancel = co_await get_cancellation_token(), &canceled]
+        {
+            cancel.callback([&]
+                {
+                    REQUIRE(!canceled);
+                    canceled = true;
+                });
+        }();
 
         co_await resume_on_signal(event);
         co_await std::experimental::suspend_never();


### PR DESCRIPTION
Allow revoking cancellation callback by setting it to null. This is important if a late callback could end up accessing an already-destructed object. Previously, the only way to revoke a cancellation callback was to replace it with a nop delegate `[]()`, which is clunky.

Make the token's callback method const. This makes it easier to capture a token into a lambda.