### PR TITLE
Fix concat_hstring for 0-length string

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -423,13 +423,13 @@ namespace winrt::impl
         hstring_builder& operator=(hstring_builder const&) = delete;
 
         explicit hstring_builder(uint32_t const size) :
-            m_handle(size ? impl::precreate_hstring_on_heap(size) : nullptr)
+            m_handle(impl::precreate_hstring_on_heap(size))
         {
         }
 
         wchar_t* data() noexcept
         {
-            return m_handle ? const_cast<wchar_t*>(m_handle.get()->ptr) : reinterpret_cast<wchar_t*>(this);
+            return const_cast<wchar_t*>(m_handle.get()->ptr);
         }
 
         hstring to_hstring()

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -423,13 +423,13 @@ namespace winrt::impl
         hstring_builder& operator=(hstring_builder const&) = delete;
 
         explicit hstring_builder(uint32_t const size) :
-            m_handle(impl::precreate_hstring_on_heap(size))
+            m_handle(size ? impl::precreate_hstring_on_heap(size) : nullptr)
         {
         }
 
         wchar_t* data() noexcept
         {
-            return const_cast<wchar_t*>(m_handle.get()->ptr);
+            return m_handle ? const_cast<wchar_t*>(m_handle.get()->ptr) : reinterpret_cast<wchar_t*>(this);
         }
 
         hstring to_hstring()

--- a/strings/base_string_operators.h
+++ b/strings/base_string_operators.h
@@ -98,7 +98,12 @@ namespace winrt::impl
 {
     inline hstring concat_hstring(std::wstring_view const& left, std::wstring_view const& right)
     {
-        hstring_builder text(static_cast<uint32_t>(left.size() + right.size()));
+        auto size = static_cast<uint32_t>(left.size() + right.size());
+        if (size == 0)
+        {
+            return{};
+        }
+        hstring_builder text(size);
         memcpy_s(text.data(), left.size() * sizeof(wchar_t), left.data(), left.size() * sizeof(wchar_t));
         memcpy_s(text.data() + left.size(), right.size() * sizeof(wchar_t), right.data(), right.size() * sizeof(wchar_t));
         return text.to_hstring();

--- a/test/old_tests/UnitTests/hstring.cpp
+++ b/test/old_tests/UnitTests/hstring.cpp
@@ -570,4 +570,7 @@ TEST_CASE("hstring, concat")
     REQUIRE(hstring() + s == L"abc");
     REQUIRE(s + L"" == L"abc");
     REQUIRE(L"" + s == L"abc");
+
+    REQUIRE(hstring() + hstring() == L"");
+    REQUIRE(get_abi(hstring() + hstring()) == nullptr);
 }


### PR DESCRIPTION
The zero-length string is represented by nullptr, not a heap-allocated string of length zero.