### PR TITLE
[ARM64] Fix CFG helper calling convention and simplify flow of call target address.

### DIFF
--- a/fast_fwd/arm64/thunks.asm
+++ b/fast_fwd/arm64/thunks.asm
@@ -11,10 +11,9 @@
     NESTED_ENTRY InvokeForwarder 
 
     ; Save enregistered args 
-    PROLOG_SAVE_REG_PAIR fp, lr, #-64!
-    PROLOG_SAVE_REG_PAIR x19, x20, #16
-    PROLOG_NOP stp x0, x1, [sp, #32]
-    PROLOG_NOP stp x2, x3, [sp, #48]
+    PROLOG_SAVE_REG_PAIR fp, lr, #-48!
+    PROLOG_NOP stp x0, x1, [sp, #16]
+    PROLOG_NOP stp x2, x3, [sp, #32]
 
     ; Replace forwarder abi with owner abi 
     ldr     x1, [x0, #8]
@@ -26,23 +25,20 @@
 
     ; Get method address from owner abi vtable 
     ldr     x0, [x1]  
-    ldr     x19, [x0, x12, lsl #3]
-    mov     x0, x19
+    ldr     x15, [x0, x12, lsl #3]
     
     ; Verify indirect call target
     adrp    x12, __guard_check_icall_fptr
     ldr     x12, [x12, __guard_check_icall_fptr]
     blr     x12
 
-    ; Restore method address, return address, and args
-    mov     x12, x19
-    EPILOG_NOP ldp x2, x3, [sp, #48]
-    EPILOG_NOP ldp x0, x1, [sp, #32]
-    EPILOG_RESTORE_REG_PAIR x19, x20, #16
-    EPILOG_RESTORE_REG_PAIR fp, lr, #64! 
+    ; Restore return address, and args
+    EPILOG_NOP ldp x2, x3, [sp, #32]
+    EPILOG_NOP ldp x0, x1, [sp, #16]
+    EPILOG_RESTORE_REG_PAIR fp, lr, #48! 
 
     ; Jump to method
-    EPILOG_NOP br x12 
+    EPILOG_NOP br x15
 
     NESTED_END InvokeForwarder 
 


### PR DESCRIPTION
Unlike other architectures, on ARM64 __guard_check_icall_fptr follows a custom calling convention. X15 takes the address of the target method and that value is preserved across the call.

As a result, there is no need to enlist the help of the x19 non-volatile register. In turn, no need to spill/fill it.