### PR TITLE
Add SDKReference-sourced WinMDs when building

### DIFF
--- a/build_nuget.cmd
+++ b/build_nuget.cmd
@@ -10,4 +10,4 @@ call msbuild /m /p:Configuration=Release,Platform=arm64,CppWinRTBuildVersion=%ta
 
 call msbuild /m /p:Configuration=Release,Platform=x86,CppWinRTBuildVersion=%target_version% cppwinrt.sln /t:cppwinrt
 
-nuget pack nuget\Microsoft.Windows.CppWinRT.nuspec -Properties cppwinrt_exe=%cd%\_build\x86\Release\cppwinrt.exe;cppwinrt_fast_fwd_x86=%cd%\_build\x86\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_x64=%cd%\_build\x64\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm=%cd%\_build\arm\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm64=%cd%\_build\arm64\Release\cppwinrt_fast_forwarder.lib 
+nuget pack nuget\Microsoft.Windows.CppWinRT.nuspec -Properties target_version=%target_version%;cppwinrt_exe=%cd%\_build\x86\Release\cppwinrt.exe;cppwinrt_fast_fwd_x86=%cd%\_build\x86\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_x64=%cd%\_build\x64\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm=%cd%\_build\arm\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm64=%cd%\_build\arm64\Release\cppwinrt_fast_forwarder.lib 

--- a/nuget/Microsoft.Windows.CppWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CppWinRT.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Microsoft.Windows.CppWinRT</id>
-    <version>1.0.0.0</version>
+    <version>$target_version$</version>
     <title>C++/WinRT Build Support</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -248,11 +248,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!--Get direct WinMD references (including Nuget packages) for projections, IDL processing, and AppX packaging-->
     <Target Name="GetCppWinRTDirectWinMDReferences"
-            DependsOnTargets="ResolveAssemblyReferences;$(GetCppWinRTDirectWinMDReferencesDependsOn)"
+            DependsOnTargets="ExpandSDKReferences;ResolveAssemblyReferences;$(GetCppWinRTDirectWinMDReferencesDependsOn)"
             Returns="@(CppWinRTDirectWinMDReferences)">
         <ItemGroup>
             <_CppWinRTDirectWinMDReferences Remove="@(_CppWinRTDirectWinMDReferences)" />
             <_CppWinRTDirectWinMDReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.IsSystemReference)' != 'true' and '%(ReferencePath.WinMDFile)' == 'true' and '%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference'" />
+            <_CppWinRTDirectWinMDReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.WinMDFile)' == 'true' and '%(ReferencePath.ReferenceSourceTarget)' == 'ExpandSDKReference'" />
             <CppWinRTDirectWinMDReferences Remove="@(CppWinRTDirectWinMDReferences)"/>
             <CppWinRTDirectWinMDReferences Include="@(_CppWinRTDirectWinMDReferences)">
                 <WinMDPath>%(FullPath)</WinMDPath>

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -94,3 +94,14 @@ Example:
 
 For more complex analysis of build errors, the [MSBuild Binary and Structured Log Viewer](http://msbuildlog.com/) is highly recommended.
 
+## Building, Testing
+
+Be sure to get the latest nuget.exe from [nuget.org](https://www.nuget.org/downloads) and place it in your path.
+
+Build the package by running [build_nuget.cmd](../build_nuget.cmd) from a developer environment command line. For testing pass a version number that is much higher than your currently installed, like:
+
+```
+c:\repos\cppwinrt> .\build_nuget.cmd 5.0.0.0
+```
+
+Add the cppwinrt repo directory as a nuget source location and update your projects' references to point at it, update project references, then rebuild a test/sample project.


### PR DESCRIPTION
This resolves #677 by:

* Including WinMDs found from `ExpandSDKReference`
* Adding some instructions on build & test for the nuget packages
* Ensuring nuget packages are built with the passed-in version  number