### PR TITLE
Support coroutines returning references

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -166,7 +166,7 @@ namespace winrt::impl
             return free_await_adapter_impl<T>{ static_cast<T&&>(awaitable) }.suspend(handle);
         }
 
-        auto await_resume()
+        decltype(auto) await_resume()
         {
             return free_await_adapter_impl<T>{ static_cast<T&&>(awaitable) }.resume();
         }
@@ -188,7 +188,7 @@ namespace winrt::impl
             return awaitable.await_suspend(handle);
         }
 
-        auto await_resume()
+        decltype(auto) await_resume()
         {
             return awaitable.await_resume();
         }
@@ -243,7 +243,7 @@ namespace winrt::impl
             return awaitable.await_suspend(handle);
         }
 
-        auto await_resume()
+        decltype(auto) await_resume()
         {
             if (winrt_resume_handler)
             {

--- a/test/test/async_ref_result.cpp
+++ b/test/test/async_ref_result.cpp
@@ -1,0 +1,65 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    //
+    // Checks that references returned by awaitables
+    // are not accidentally decayed.
+    //
+    // This test "runs" at compile time via static_assert.
+
+    template <typename T>
+    struct awaitable : std::experimental::suspend_never
+    {
+        std::decay_t<T> value;
+        T await_resume() { return static_cast<T>(value); }
+    };
+
+    template <typename T>
+    struct awaitable_member_awaiter : std::experimental::suspend_never
+    {
+        decltype(auto) get_awaiter() { return *this; }
+        std::decay_t<T> value;
+        T await_resume() { return static_cast<T>(value); }
+    };
+
+    template <typename T>
+    struct awaitable_free_awaiter : std::experimental::suspend_never
+    {
+        std::decay_t<T> value;
+        T await_resume() { return static_cast<T>(value); }
+    };
+    template<typename T>
+    decltype(auto) get_awaiter(awaitable_free_awaiter<T>&& value) { return std::move(value); }
+
+    template<template<typename> typename A, typename T>
+    IAsyncAction Check()
+    {
+        decltype(auto) value = co_await A<T>();
+        static_assert(std::is_same_v<decltype(value), T>);
+    }
+
+    template<template<typename> typename A>
+    IAsyncAction Check()
+    {
+        co_await Check<A, hstring>();
+        co_await Check<A, hstring&>();
+        co_await Check<A, hstring&&>();
+        co_await Check<A, hstring const&>();
+    }
+
+    IAsyncAction Test()
+    {
+        co_await Check<awaitable>();
+        co_await Check<awaitable_member_awaiter>();
+        co_await Check<awaitable_free_awaiter>();
+    }
+}
+
+TEST_CASE("async_ref_result")
+{
+    Test().get();
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="async_cancel_callback.cpp" />
     <ClCompile Include="async_check_cancel.cpp" />
     <ClCompile Include="async_completed.cpp" />
+    <ClCompile Include="async_ref_result.cpp" />
     <ClCompile Include="box_guid.cpp" />
     <ClCompile Include="capture.cpp" />
     <ClCompile Include="coro_foundation.cpp">


### PR DESCRIPTION
`auto await_resume()` will decay the return value, causing references to turn into values. Use `declspec(auto)` to preserve references when wrapping other coroutines.