### PR TITLE
Improve detection of mismatched header versions

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -25,8 +25,9 @@ namespace cppwinrt
     {
         w.write_root_include("base");
         auto format = R"(static_assert(winrt::check_version(CPPWINRT_VERSION, "%"), "Mismatched C++/WinRT headers.");
+#define CPPWINRT_VERSION "%"
 )";
-        w.write(format, CPPWINRT_VERSION_STRING);
+        w.write(format, CPPWINRT_VERSION_STRING, CPPWINRT_VERSION_STRING);
     }
 
     static void write_include_guard(writer& w)

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="..\strings\base_string_operators.h" />
     <ClInclude Include="..\strings\base_types.h" />
     <ClInclude Include="..\strings\base_version.h" />
+    <ClInclude Include="..\strings\base_version_odr.h" />
     <ClInclude Include="..\strings\base_weak_ref.h" />
     <ClInclude Include="..\strings\base_windows.h" />
     <ClInclude Include="..\strings\base_xaml_typename.h" />

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClInclude Include="..\strings\base_version.h">
       <Filter>strings</Filter>
     </ClInclude>
+    <ClInclude Include="..\strings\base_version_odr.h">
+      <Filter>strings</Filter>
+    </ClInclude>
     <ClInclude Include="..\strings\base_weak_ref.h">
       <Filter>strings</Filter>
     </ClInclude>

--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -6,6 +6,7 @@ namespace cppwinrt
     {
         writer w;
         write_preamble(w);
+        w.write(strings::base_version_odr, CPPWINRT_VERSION_STRING);
         write_open_file_guard(w, "BASE");
 
         w.write(strings::base_includes);
@@ -38,7 +39,7 @@ namespace cppwinrt
         w.write(strings::base_std_hash);
         w.write(strings::base_coroutine_threadpool);
         w.write(strings::base_natvis);
-        w.write(strings::base_version, CPPWINRT_VERSION_STRING);
+        w.write(strings::base_version);
 
         write_endif(w);
         w.flush_to_file(settings.output_folder + "winrt/base.h");

--- a/strings/base_version.h
+++ b/strings/base_version.h
@@ -1,6 +1,4 @@
 
-#define CPPWINRT_VERSION "%"
-
 // WINRT_version is used by Microsoft to analyze C++/WinRT library adoption and inform future product decisions.
 extern "C"
 __declspec(selectany)
@@ -10,6 +8,10 @@ char const * const WINRT_version = "C++/WinRT version:" CPPWINRT_VERSION;
 #pragma comment(linker, "/include:_WINRT_version")
 #else
 #pragma comment(linker, "/include:WINRT_version")
+#endif
+
+#if defined(_MSC_VER)
+#pragma detect_mismatch("C++/WinRT version", CPPWINRT_VERSION)
 #endif
 
 WINRT_EXPORT namespace winrt

--- a/strings/base_version_odr.h
+++ b/strings/base_version_odr.h
@@ -1,0 +1,2 @@
+#define CPPWINRT_VERSION "%"
+


### PR DESCRIPTION
The existing mismatch detection catches the case where a single *.cpp file includes headers from different versions of the C++/WinRT headers. However, the error message isn't very helpful in tracking down the two versions that didn't match.

Move the `#define` of `CPPWINRT_VERSION` outside the header guard and repeat the definition after the `static_assert`.  This makes mismatches easier to diagnose because the compiler will tell you

```
apple\base.h(3) warning: CPPWINRT_VERSION: macro redefinition
banana\base.h(3) note: see previous definition of CPPWINRT_VERSION
```
in the case where you `#include` two incompatible versions of `base.h`, or

```
apple\Windows.UI.h(6) error: Mismatched C++/WinRT headers.
apple\Windows.UI.h(7) warning: CPPWINRT_VERSION: macro redefinition
banana\base.h(3) note: see previous definition of CPPWINRT_VERSION
```

in the case where you use a projection header file that is not compatible with the `base.h` you used.

In both cases, the compiler will give you the path to the conflicting header files, making it easier to diagnose. In this case, you can see that you are mixing headers between apple and banana.

This takes advantage of the fact that it is legal to redefine a macro provided you redefine it to something that exactly matches its existing definition. We have everybody define the `CPPWINRT_VERSION` macro to be the version they expect, and the compiler will call out any discrepancy within a single translation unit.

A more insidious error that had previous gone undetected is the case where you link together *.cpp files that disagree on the C++/WinRT version.

We address this by using MSVC's detect_mismatch pragma to stamp each object file with the version of C++/WinRT it was compiled with, and the linker will complain if object files with different stamps are linked together:

```
file1.obj: error: mismatch detected for 'C++/WinRT version':
value '1.2.3.4' doesn't match value '2.3.4.5' in file2.obj
```