### PR TITLE
Disable warning 4458 in delegates

### DIFF
--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -1,6 +1,11 @@
 
 namespace winrt::impl
 {
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4458) // declaration hides class member (okay because we do not use named members of base class)
+#endif
+
     template <typename T, typename H>
     struct implements_delegate : abi_t<T>, H, update_module_lock
     {
@@ -187,6 +192,10 @@ namespace winrt::impl
             return { static_cast<void*>(new variadic_delegate<H, R, Args...>(std::forward<H>(handler))), take_ownership_from_abi };
         }
     };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 }
 
 WINRT_EXPORT namespace winrt

--- a/test/test/pch.h
+++ b/test/test/pch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#pragma warning(4: 4458) // ensure we compile clean with this warning enabled
+
 #define WINRT_LEAN_AND_MEAN
 #include <unknwn.h>
 #include "winrt/Windows.Foundation.Collections.h"


### PR DESCRIPTION
Delegates derive from app-provided classes, which means that any function parameter in the delegate methods could potentially hide a member from the app-provided class. Delegates don't actually care because the only thing from the base class they use is the function call operator, which isn't a named member.

Disable the warning to avoid triggering false alarms in projects that build with all warnings enabled.