### PR TITLE
Accommodate other "key not found" errors

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -584,7 +584,7 @@ namespace winrt::impl
 {
     inline hresult check_hresult_allow_bounds(hresult const result)
     {
-        if (result != impl::error_out_of_bounds)
+        if (result != impl::error_out_of_bounds && result != impl::error_fail && result != impl::error_file_not_found)
         {
             check_hresult(result);
         }

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -147,4 +147,5 @@ namespace winrt::impl
     constexpr hresult error_canceled{ static_cast<hresult>(0x800704C7) }; // HRESULT_FROM_WIN32(ERROR_CANCELLED)
     constexpr hresult error_bad_alloc{ static_cast<hresult>(0x8007000E) }; // E_OUTOFMEMORY
     constexpr hresult error_not_initialized{ static_cast<hresult>(0x800401F0) }; // CO_E_NOTINITIALIZED
+    constexpr hresult error_file_not_found{ static_cast<hresult>(0x80070002) }; // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
 }


### PR DESCRIPTION
XAML's ResourceDictionary has a custom implementation of `IMap` that returns `E_FAIL` and `HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)` to indicate that the key is not present. Accommodate this nonstandard behavior.

Fixes #685 