### PR TITLE
Add multi-threaded collections

### DIFF
--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -1,45 +1,45 @@
+namespace winrt::impl
+{
+    template <typename D, typename = void>
+    struct has_exclusive_op : std::false_type {};
+
+    template <typename D>
+    struct has_exclusive_op<D, std::void_t<decltype(std::declval<D*>()->exclusive_op(std::true_type{}))>> : std::true_type {};
+
+    template <typename D, typename = void>
+    struct has_shared_op : std::false_type {};
+
+    template <typename D>
+    struct has_shared_op<D, std::void_t<decltype(std::declval<D*>()->shared_op(std::true_type{}))>> : std::true_type {};
+
+    struct single_threaded_collection_base
+    {
+    };
+
+    struct multi_threaded_collection_base
+    {
+        template <typename Func>
+        auto exclusive_op(Func&& fn) const
+        {
+            slim_lock_guard lock(m_mutex);
+            return fn();
+        }
+
+        template <typename Func>
+        auto shared_op(Func&& fn) const
+        {
+            slim_shared_lock_guard lock(m_mutex);
+            return fn();
+        }
+
+    private:
+
+        mutable slim_mutex m_mutex;
+    };
+}
+
 WINRT_EXPORT namespace winrt
 {
-    namespace impl
-    {
-        template <typename D, typename = void>
-        struct has_exclusive_op : std::false_type {};
-
-        template <typename D>
-        struct has_exclusive_op<D, std::void_t<decltype(std::declval<D*>()->exclusive_op(std::true_type{}))>> : std::true_type {};
-
-        template <typename D, typename = void>
-        struct has_shared_op : std::false_type {};
-
-        template <typename D>
-        struct has_shared_op<D, std::void_t<decltype(std::declval<D*>()->shared_op(std::true_type{}))>> : std::true_type {};
-
-        struct single_threaded_collection_base
-        {
-        };
-
-        struct multi_threaded_collection_base
-        {
-            template <typename Func>
-            auto exclusive_op(Func&& fn) const
-            {
-                slim_lock_guard lock(m_mutex);
-                return fn();
-            }
-
-            template <typename Func>
-            auto shared_op(Func&& fn) const
-            {
-                slim_shared_lock_guard lock(m_mutex);
-                return fn();
-            }
-
-        private:
-
-            mutable slim_mutex m_mutex;
-        };
-    }
-
     template <typename D, typename T, typename Version = impl::no_collection_version>
     struct iterable_base : Version
     {

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -23,8 +23,8 @@ namespace winrt::impl
             return m_values;
         }
 
-        using ThreadingBase::perform_shared;
-        using ThreadingBase::perform_exclusive;
+        using ThreadingBase::acquire_shared;
+        using ThreadingBase::acquire_exclusive;
 
     private:
 

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -23,6 +23,9 @@ namespace winrt::impl
             return m_values;
         }
 
+        using ThreadingBase::perform_shared;
+        using ThreadingBase::perform_exclusive;
+
     private:
 
         Container m_values;

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -1,14 +1,15 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container>
-    struct input_map :
-        implements<input_map<K, V, Container>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_base<input_map<K, V, Container>, K, V>
+    template <typename K, typename V, typename Container, typename ThreadingBase>
+    struct map_impl :
+        implements<map_impl<K, V, Container, ThreadingBase>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_base<map_impl<K, V, Container, ThreadingBase>, K, V>,
+        ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit input_map(Container&& values) : m_values(std::forward<Container>(values))
+        explicit map_impl(Container&& values) : m_values(std::forward<Container>(values))
         {
         }
 
@@ -26,6 +27,9 @@ namespace winrt::impl
 
         Container m_values;
     };
+
+    template <typename K, typename V, typename Container>
+    using input_map = map_impl<K, V, Container, single_threaded_collection_base>;
 
     template <typename K, typename V, typename Container>
     auto make_input_map(Container&& values)

--- a/strings/base_collections_input_vector.h
+++ b/strings/base_collections_input_vector.h
@@ -23,8 +23,8 @@ namespace winrt::impl
             return m_values;
         }
 
-        using ThreadingBase::perform_shared;
-        using ThreadingBase::perform_exclusive;
+        using ThreadingBase::acquire_shared;
+        using ThreadingBase::acquire_exclusive;
 
     private:
 

--- a/strings/base_collections_input_vector.h
+++ b/strings/base_collections_input_vector.h
@@ -23,6 +23,9 @@ namespace winrt::impl
             return m_values;
         }
 
+        using ThreadingBase::perform_shared;
+        using ThreadingBase::perform_exclusive;
+
     private:
 
         Container m_values;

--- a/strings/base_collections_input_vector.h
+++ b/strings/base_collections_input_vector.h
@@ -1,14 +1,15 @@
 
 namespace winrt::impl
 {
-    template <typename T, typename Container>
-    struct input_vector :
-        implements<input_vector<T, Container>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
-        vector_base<input_vector<T, Container>, T>
+    template <typename T, typename Container, typename ThreadingBase>
+    struct vector_impl :
+        implements<vector_impl<T, Container, ThreadingBase>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
+        vector_base<vector_impl<T, Container, ThreadingBase>, T>,
+        ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit input_vector(Container&& values) : m_values(std::forward<Container>(values))
+        explicit vector_impl(Container&& values) : m_values(std::forward<Container>(values))
         {
         }
 
@@ -26,6 +27,9 @@ namespace winrt::impl
 
         Container m_values;
     };
+
+    template <typename T, typename Container>
+    using input_vector = vector_impl<T, Container, single_threaded_collection_base>;
 }
 
 WINRT_EXPORT namespace winrt::param

--- a/strings/base_collections_input_vector.h
+++ b/strings/base_collections_input_vector.h
@@ -1,14 +1,14 @@
 
 namespace winrt::impl
 {
-    template <typename D, typename T, typename Container>
-    struct input_vector_base :
-        implements<D, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
-        vector_base<D, T>
+    template <typename T, typename Container>
+    struct input_vector :
+        implements<input_vector<T, Container>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
+        vector_base<input_vector<T, Container>, T>
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit input_vector_base(Container&& values) : m_values(std::forward<Container>(values))
+        explicit input_vector(Container&& values) : m_values(std::forward<Container>(values))
         {
         }
 
@@ -25,36 +25,6 @@ namespace winrt::impl
     private:
 
         Container m_values;
-    };
-
-    template <typename T, typename Container>
-    struct input_vector : input_vector_base<input_vector<T, Container>, T, Container>
-    {
-        using input_vector_base<input_vector<T, Container>, T, Container>::input_vector_base;
-    };
-
-    template <typename T, typename Container>
-    struct multi_threaded_input_vector : input_vector_base<multi_threaded_input_vector<T, Container>, T, Container>
-    {
-        using input_vector_base<multi_threaded_input_vector<T, Container>, T, Container>::input_vector_base;
-
-        template <typename Func>
-        auto perform_exclusive(Func&& fn) const
-        {
-            slim_lock_guard lock(m_mutex);
-            return fn();
-        }
-
-        template <typename Func>
-        auto perform_shared(Func&& fn) const
-        {
-            slim_lock_guard_shared lock(m_mutex);
-            return fn();
-        }
-
-    private:
-
-        mutable slim_mutex m_mutex;
     };
 }
 

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -26,6 +26,9 @@ namespace winrt::impl
             return m_values;
         }
 
+        using ThreadingBase::perform_shared;
+        using ThreadingBase::perform_exclusive;
+
     private:
 
         Container m_values;

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -2,6 +2,36 @@
 namespace winrt::impl
 {
     template <typename K, typename V, typename Container>
+    struct multi_threaded_map :
+        implements<multi_threaded_map<K, V, Container>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_base<multi_threaded_map<K, V, Container>, K, V>,
+        multi_threaded_collection_base
+    {
+        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
+
+        explicit multi_threaded_map(Container&& values) : m_values(std::forward<Container>(values))
+        {
+        }
+
+        auto& get_container() noexcept
+        {
+            return m_values;
+        }
+
+        auto& get_container() const noexcept
+        {
+            return m_values;
+        }
+
+        using multi_threaded_collection_base::perform_exclusive;
+        using multi_threaded_collection_base::perform_shared;
+
+    private:
+
+        Container m_values;
+    };
+
+    template <typename K, typename V, typename Container>
     struct observable_map :
         implements<observable_map<K, V, Container>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
         observable_map_base<observable_map<K, V, Container>, K, V>
@@ -46,6 +76,24 @@ WINRT_EXPORT namespace winrt
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
         return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map()
+    {
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -2,43 +2,17 @@
 namespace winrt::impl
 {
     template <typename K, typename V, typename Container>
-    struct multi_threaded_map :
-        implements<multi_threaded_map<K, V, Container>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_base<multi_threaded_map<K, V, Container>, K, V>,
-        multi_threaded_collection_base
+    using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base>;
+
+    template <typename K, typename V, typename Container, typename ThreadingBase>
+    struct observable_map_impl :
+        implements<observable_map_impl<K, V, Container, ThreadingBase>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        observable_map_base<observable_map_impl<K, V, Container, ThreadingBase>, K, V>,
+        ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit multi_threaded_map(Container&& values) : m_values(std::forward<Container>(values))
-        {
-        }
-
-        auto& get_container() noexcept
-        {
-            return m_values;
-        }
-
-        auto& get_container() const noexcept
-        {
-            return m_values;
-        }
-
-        using multi_threaded_collection_base::perform_exclusive;
-        using multi_threaded_collection_base::perform_shared;
-
-    private:
-
-        Container m_values;
-    };
-
-    template <typename K, typename V, typename Container>
-    struct observable_map :
-        implements<observable_map<K, V, Container>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        observable_map_base<observable_map<K, V, Container>, K, V>
-    {
-        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
-
-        explicit observable_map(Container&& values) : m_values(std::forward<Container>(values))
+        explicit observable_map_impl(Container&& values) : m_values(std::forward<Container>(values))
         {
         }
 
@@ -58,34 +32,10 @@ namespace winrt::impl
     };
 
     template <typename K, typename V, typename Container>
-    struct multi_threaded_observable_map :
-        implements<multi_threaded_observable_map<K, V, Container>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        observable_map_base<multi_threaded_observable_map<K, V, Container>, K, V>,
-        multi_threaded_collection_base
-    {
-        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
+    using observable_map = observable_map_impl<K, V, Container, single_threaded_collection_base>;
 
-        explicit multi_threaded_observable_map(Container&& values) : m_values(std::forward<Container>(values))
-        {
-        }
-
-        auto& get_container() noexcept
-        {
-            return m_values;
-        }
-
-        auto& get_container() const noexcept
-        {
-            return m_values;
-        }
-
-        using multi_threaded_collection_base::perform_exclusive;
-        using multi_threaded_collection_base::perform_shared;
-
-    private:
-
-        Container m_values;
-    };
+    template <typename K, typename V, typename Container>
+    using multi_threaded_observable_map = observable_map_impl<K, V, Container, multi_threaded_collection_base>;
 }
 
 WINRT_EXPORT namespace winrt

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -56,6 +56,36 @@ namespace winrt::impl
 
         Container m_values;
     };
+
+    template <typename K, typename V, typename Container>
+    struct multi_threaded_observable_map :
+        implements<multi_threaded_observable_map<K, V, Container>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        observable_map_base<multi_threaded_observable_map<K, V, Container>, K, V>,
+        multi_threaded_collection_base
+    {
+        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
+
+        explicit multi_threaded_observable_map(Container&& values) : m_values(std::forward<Container>(values))
+        {
+        }
+
+        auto& get_container() noexcept
+        {
+            return m_values;
+        }
+
+        auto& get_container() const noexcept
+        {
+            return m_values;
+        }
+
+        using multi_threaded_collection_base::perform_exclusive;
+        using multi_threaded_collection_base::perform_shared;
+
+    private:
+
+        Container m_values;
+    };
 }
 
 WINRT_EXPORT namespace winrt
@@ -112,6 +142,24 @@ WINRT_EXPORT namespace winrt
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
         return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map()
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 }
 

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -26,8 +26,8 @@ namespace winrt::impl
             return m_values;
         }
 
-        using ThreadingBase::perform_shared;
-        using ThreadingBase::perform_exclusive;
+        using ThreadingBase::acquire_shared;
+        using ThreadingBase::acquire_exclusive;
 
     private:
 

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -2,34 +2,7 @@
 namespace winrt::impl
 {
     template <typename T, typename Container>
-    struct multi_threaded_vector :
-        implements<input_vector<T, Container>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
-        vector_base<input_vector<T, Container>, T>,
-        multi_threaded_collection_base
-    {
-        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
-
-        explicit multi_threaded_vector(Container&& values) : m_values(std::forward<Container>(values))
-        {
-        }
-
-        auto& get_container() noexcept
-        {
-            return m_values;
-        }
-
-        auto& get_container() const noexcept
-        {
-            return m_values;
-        }
-
-        using multi_threaded_collection_base::perform_exclusive;
-        using multi_threaded_collection_base::perform_shared;
-
-    private:
-
-        Container m_values;
-    };
+    using multi_threaded_vector = vector_impl<T, Container, multi_threaded_collection_base>;
 
     template <typename Container>
     struct inspectable_observable_vector :

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -40,7 +40,8 @@ namespace winrt::impl
         observable_vector_base<convertible_observable_vector<T, Container, ThreadingBase>, T>,
         implements<convertible_observable_vector<T, Container, ThreadingBase>,
         wfc::IObservableVector<T>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>,
-        wfc::IObservableVector<Windows::Foundation::IInspectable>, wfc::IVector<Windows::Foundation::IInspectable>, wfc::IVectorView<Windows::Foundation::IInspectable>, wfc::IIterable<Windows::Foundation::IInspectable>>
+        wfc::IObservableVector<Windows::Foundation::IInspectable>, wfc::IVector<Windows::Foundation::IInspectable>, wfc::IVectorView<Windows::Foundation::IInspectable>, wfc::IIterable<Windows::Foundation::IInspectable>>,
+        ThreadingBase
     {
         static_assert(!std::is_same_v<T, Windows::Foundation::IInspectable>);
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -27,6 +27,9 @@ namespace winrt::impl
             return m_values;
         }
 
+        using ThreadingBase::perform_shared;
+        using ThreadingBase::perform_exclusive;
+
     private:
 
         Container m_values;
@@ -62,6 +65,9 @@ namespace winrt::impl
         {
             return m_values;
         }
+
+        using ThreadingBase::perform_shared;
+        using ThreadingBase::perform_exclusive;
 
         auto First()
         {

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -1,6 +1,36 @@
 
 namespace winrt::impl
 {
+    template <typename T, typename Container>
+    struct multi_threaded_vector :
+        implements<input_vector<T, Container>, wfc::IVector<T>, wfc::IVectorView<T>, wfc::IIterable<T>>,
+        vector_base<input_vector<T, Container>, T>,
+        multi_threaded_collection_base
+    {
+        static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
+
+        explicit multi_threaded_vector(Container&& values) : m_values(std::forward<Container>(values))
+        {
+        }
+
+        auto& get_container() noexcept
+        {
+            return m_values;
+        }
+
+        auto& get_container() const noexcept
+        {
+            return m_values;
+        }
+
+        using multi_threaded_collection_base::perform_exclusive;
+        using multi_threaded_collection_base::perform_shared;
+
+    private:
+
+        Container m_values;
+    };
+
     template <typename Container>
     struct inspectable_observable_vector :
         observable_vector_base<inspectable_observable_vector<Container>, Windows::Foundation::IInspectable>,
@@ -275,7 +305,7 @@ WINRT_EXPORT namespace winrt
     template <typename T, typename Allocator = std::allocator<T>>
     Windows::Foundation::Collections::IVector<T> multi_threaded_vector(std::vector<T, Allocator>&& values = {})
     {
-        return make<impl::multi_threaded_input_vector<T, std::vector<T, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_vector<T, std::vector<T, Allocator>>>(std::move(values));
     }
 
     template <typename T, typename Allocator = std::allocator<T>>

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -273,6 +273,12 @@ WINRT_EXPORT namespace winrt
     }
 
     template <typename T, typename Allocator = std::allocator<T>>
+    Windows::Foundation::Collections::IVector<T> multi_threaded_vector(std::vector<T, Allocator>&& values = {})
+    {
+        return make<impl::multi_threaded_input_vector<T, std::vector<T, Allocator>>>(std::move(values));
+    }
+
+    template <typename T, typename Allocator = std::allocator<T>>
     Windows::Foundation::Collections::IObservableVector<T> single_threaded_observable_vector(std::vector<T, Allocator>&& values = {})
     {
         if constexpr (std::is_same_v<T, Windows::Foundation::IInspectable>)

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -118,8 +118,8 @@ namespace winrt::impl
         }
 
     private:
-        std::experimental::coroutine_handle<> m_handle;
         resume_apartment_context m_context;
+        std::experimental::coroutine_handle<> m_handle;
 
         void Complete()
         {
@@ -743,7 +743,7 @@ WINRT_EXPORT namespace winrt
 
         auto [delegate, shared] = impl::make_delegate_with_shared_state<impl::async_completed_handler_t<T>>(shared_type{});
 
-        auto completed = [&](T const& async)
+        auto completed = [delegate = std::move(delegate)](T const& async)
         {
             async.Completed(delegate);
         };

--- a/strings/base_lock.h
+++ b/strings/base_lock.h
@@ -58,6 +58,8 @@ WINRT_EXPORT namespace winrt
             m_mutex.lock();
         }
 
+        slim_lock_guard(slim_lock_guard const&) = delete;
+
         ~slim_lock_guard() noexcept
         {
             m_mutex.unlock();
@@ -74,6 +76,8 @@ WINRT_EXPORT namespace winrt
         {
             m_mutex.lock_shared();
         }
+
+        slim_shared_lock_guard(slim_shared_lock_guard const&) = delete;
 
         ~slim_shared_lock_guard() noexcept
         {

--- a/strings/base_lock.h
+++ b/strings/base_lock.h
@@ -67,6 +67,23 @@ WINRT_EXPORT namespace winrt
         slim_mutex& m_mutex;
     };
 
+    struct slim_lock_guard_shared
+    {
+        explicit slim_lock_guard_shared(slim_mutex& m) noexcept :
+            m_mutex(m)
+        {
+            m_mutex.lock_shared();
+        }
+
+        ~slim_lock_guard_shared() noexcept
+        {
+            m_mutex.unlock_shared();
+        }
+
+    private:
+        slim_mutex& m_mutex;
+    };
+
     struct slim_condition_variable
     {
         slim_condition_variable(slim_condition_variable const&) = delete;

--- a/strings/base_lock.h
+++ b/strings/base_lock.h
@@ -67,15 +67,15 @@ WINRT_EXPORT namespace winrt
         slim_mutex& m_mutex;
     };
 
-    struct slim_lock_guard_shared
+    struct slim_shared_lock_guard
     {
-        explicit slim_lock_guard_shared(slim_mutex& m) noexcept :
+        explicit slim_shared_lock_guard(slim_mutex& m) noexcept :
             m_mutex(m)
         {
             m_mutex.lock_shared();
         }
 
-        ~slim_lock_guard_shared() noexcept
+        ~slim_shared_lock_guard() noexcept
         {
             m_mutex.unlock_shared();
         }

--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <thread>
+
+struct unique_thread
+{
+    std::thread thread;
+    std::exception_ptr ex;
+
+    unique_thread() = default;
+
+    template <typename Func, typename... Args>
+    unique_thread(Func&& fn, Args&&... args)
+    {
+        thread = std::thread([this, fn = std::forward<Func>(fn)](auto&&... args)
+        {
+            try
+            {
+                fn(std::forward<decltype(args)>(args)...);
+            }
+            catch (...)
+            {
+                ex = std::current_exception();
+            }
+        }, std::forward<Args>(args)...);
+    }
+
+    ~unique_thread() noexcept(false)
+    {
+        if (thread.joinable())
+        {
+            join();
+        }
+    }
+
+    unique_thread(unique_thread&&) = default;
+    unique_thread& operator=(unique_thread&&) = default;
+
+    void join()
+    {
+        thread.join();
+        if (ex)
+        {
+            std::rethrow_exception(ex);
+        }
+    }
+};
+
+template <typename T> // int or IInspectable
+T conditional_box(int value)
+{
+    if constexpr (std::is_same_v<T, int>)
+    {
+        return value;
+    }
+    else
+    {
+        return winrt::box_value(value);
+    }
+}
+
+template <typename T>
+int conditional_unbox(T const& value)
+{
+    if constexpr (std::is_same_v<T, int>)
+    {
+        return value;
+    }
+    else
+    {
+        return winrt::unbox_value<int>(value);
+    }
+}

--- a/test/test/multi_threaded_map.cpp
+++ b/test/test/multi_threaded_map.cpp
@@ -221,6 +221,13 @@ static void test_multi_writer(IMap<int, T> const& map)
     // sum(i = 1 -> N){i} = N * (N + 1) / 2
     auto sum = std::accumulate(begin(map), end(map), 0, [](int curr, auto&& pair) { return curr + conditional_unbox(pair.Value()); });
     REQUIRE(sum == ((threadCount * (size - 1) * size) / 2));
+
+    // Since we know that the underlying collection type is std::map, the keys should be ordered
+    int expect = 0;
+    for (auto&& pair : map)
+    {
+        REQUIRE(pair.Key() == expect++);
+    }
 }
 
 template <typename K, typename V>

--- a/test/test/multi_threaded_map.cpp
+++ b/test/test/multi_threaded_map.cpp
@@ -218,10 +218,6 @@ static void test_multi_writer(IMap<int, T> const& map)
 
     REQUIRE(map.Size() == (size * threadCount));
 
-    // sum(i = 1 -> N){i} = N * (N + 1) / 2
-    auto sum = std::accumulate(begin(map), end(map), 0, [](int curr, auto&& pair) { return curr + conditional_unbox(pair.Value()); });
-    REQUIRE(sum == ((threadCount * (size - 1) * size) / 2));
-
     // Since we know that the underlying collection type is std::map, the keys should be ordered
     int expect = 0;
     for (auto&& pair : map)

--- a/test/test/multi_threaded_vector.cpp
+++ b/test/test/multi_threaded_vector.cpp
@@ -1,67 +1,14 @@
 #include "pch.h"
 
 #include <numeric>
-#include <thread>
+
+#include "multi_threaded_common.h"
 
 using namespace winrt;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
 // Vector correctness tests exist elsewhere. These tests are strictly geared toward testing multi threaded functionality
-
-struct unique_thread
-{
-    std::thread thread;
-
-    unique_thread() = default;
-
-    template <typename Func, typename... Args>
-    unique_thread(Func&& fn, Args&&... args) : thread(std::forward<Func>(fn), std::forward<Args>(args)...)
-    {
-    }
-
-    ~unique_thread()
-    {
-        if (thread.joinable())
-        {
-            thread.join();
-        }
-    }
-
-    unique_thread(unique_thread&&) = default;
-    unique_thread& operator=(unique_thread&&) = default;
-
-    void join()
-    {
-        thread.join();
-    }
-};
-
-template <typename T> // int or IInspectable
-static T conditional_box(int value)
-{
-    if constexpr (std::is_same_v<T, int>)
-    {
-        return value;
-    }
-    else
-    {
-        return box_value(value);
-    }
-}
-
-template <typename T>
-static int conditional_unbox(T const& value)
-{
-    if constexpr (std::is_same_v<T, int>)
-    {
-        return value;
-    }
-    else
-    {
-        return unbox_value<int>(value);
-    }
-}
 
 template <typename T>
 static void test_single_reader_single_writer(IVector<T> const& v)

--- a/test/test/multi_threaded_vector.cpp
+++ b/test/test/multi_threaded_vector.cpp
@@ -9,44 +9,41 @@ using namespace Windows::Foundation::Collections;
 
 // Vector correctness tests exist elsewhere. These tests are strictly geared toward testing multi threaded functionality
 
-struct signal
+template <typename T> // int or IInspectable
+static T conditional_box(int value)
 {
-    HANDLE m_handle;
-
-    signal() : m_handle(::CreateEventW(nullptr, true, false, nullptr))
+    if constexpr (std::is_same_v<T, int>)
     {
-        REQUIRE(m_handle != nullptr);
+        return value;
     }
-
-    ~signal()
+    else
     {
-        if (m_handle)
-        {
-            ::CloseHandle(m_handle);
-        }
+        return box_value(value);
     }
+}
 
-    void set()
+template <typename T>
+static int conditional_unbox(T const& value)
+{
+    if constexpr (std::is_same_v<T, int>)
     {
-        WINRT_VERIFY(::SetEvent(m_handle));
+        return value;
     }
-
-    bool wait(DWORD timeoutMs = INFINITE)
+    else
     {
-        auto result = ::WaitForSingleObject(m_handle, timeoutMs);
-        REQUIRE(((result == WAIT_OBJECT_0) || (result == WAIT_TIMEOUT)));
-        return result == WAIT_OBJECT_0;
+        return unbox_value<int>(value);
     }
-};
+}
 
-static void test_single_reader_single_writer(IVector<int> const& v)
+template <typename T>
+static void test_single_reader_single_writer(IVector<T> const& v)
 {
     static constexpr int final_size = 10000;
     std::thread t([&]
     {
         for (int i = 0; i < final_size; ++i)
         {
-            v.Append(i);
+            v.Append(conditional_box<T>(i));
             std::this_thread::yield();
         }
     });
@@ -63,7 +60,7 @@ static void test_single_reader_single_writer(IVector<int> const& v)
                 break;
             }
 
-            REQUIRE(v.GetAt(i) == i);
+            REQUIRE(conditional_unbox(v.GetAt(i)) == i);
         }
 
         if (i == final_size)
@@ -79,18 +76,18 @@ static void test_single_reader_single_writer(IVector<int> const& v)
     {
         for (int i = 0; i < final_size; ++i)
         {
-            v.InsertAt(0, i);
+            v.InsertAt(0, conditional_box<T>(i));
             std::this_thread::yield();
         }
     });
 
-    int vals[100];
+    T vals[100];
     while (v.Size() < final_size)
     {
         auto len = v.GetMany(0, vals);
         for (uint32_t i = 1; i < len; ++i)
         {
-            REQUIRE(vals[i] == (vals[i - 1] - 1));
+            REQUIRE(conditional_unbox(vals[i]) == (conditional_unbox(vals[i - 1]) - 1));
         }
     }
     t.join();
@@ -109,20 +106,21 @@ static void test_single_reader_single_writer(IVector<int> const& v)
         auto len = v.GetMany(0, vals);
         for (uint32_t i = 1; i < len; ++i)
         {
-            REQUIRE(vals[i] == (vals[i - 1] - 1));
+            REQUIRE(conditional_unbox(vals[i]) == (conditional_unbox(vals[i - 1]) - 1));
         }
     }
     t.join();
 }
 
-static void test_iterator_invalidation(IVector<int> const& v)
+template <typename T>
+static void test_iterator_invalidation(IVector<T> const& v)
 {
     static constexpr uint32_t final_size = 100000;
     std::thread t([&]
     {
         for (int i = 0; i < final_size; ++i)
         {
-            v.Append(i);
+            v.Append(conditional_box<T>(i));
             std::this_thread::yield();
         }
     });
@@ -137,7 +135,7 @@ static void test_iterator_invalidation(IVector<int> const& v)
             int expect = 0;
             for (auto itr = v.First(); itr.HasCurrent(); itr.MoveNext())
             {
-                auto val = itr.Current();
+                auto val = conditional_unbox(itr.Current());
                 REQUIRE(val == expect++);
             }
 
@@ -160,13 +158,14 @@ static void test_iterator_invalidation(IVector<int> const& v)
     REQUIRE(exceptionCount > 50);
 }
 
-static void test_concurrent_iteration(IVector<int> const& v)
+template <typename T>
+static void test_concurrent_iteration(IVector<T> const& v)
 {
     // Large enough size that all threads should have enough time to spin up
     static constexpr uint32_t size = 10000;
     for (int i = 0; i < size; ++i)
     {
-        v.Append(i);
+        v.Append(conditional_box<T>(i));
     }
 
     auto itr = v.First();
@@ -184,7 +183,7 @@ static void test_concurrent_iteration(IVector<int> const& v)
                     // NOTE: Because there is no atomic "get and increment" function on IIterator, the best we can do is
                     // validate that we're getting valid increasing values, e.g. as opposed to validating that we read
                     // all unique values.
-                    auto val = itr.Current();
+                    auto val = conditional_unbox(itr.Current());
                     REQUIRE(val > last);
                     REQUIRE(val < size);
                     last = val;
@@ -222,12 +221,12 @@ static void test_concurrent_iteration(IVector<int> const& v)
     {
         threads[i] = std::thread([&itr, &totals, i]()
         {
-            int vals[10];
+            T vals[10];
             while (itr.HasCurrent())
             {
                 // Unlike 'Current', 'GetMany' _is_ atomic in regards to read+increment
                 auto len = itr.GetMany(vals);
-                totals[i] += std::accumulate(vals, vals + len, 0);
+                totals[i] += std::accumulate(vals, vals + len, 0, [](int curr, T const& next) { return curr + conditional_unbox(next); });
             }
         });
     }
@@ -242,7 +241,8 @@ static void test_concurrent_iteration(IVector<int> const& v)
     REQUIRE(total == (size * (size - 1) / 2));
 }
 
-static void test_multi_writer(IVector<int> const& v)
+template <typename T>
+static void test_multi_writer(IVector<T> const& v)
 {
     // Large enough that several threads should be executing concurrently
     static constexpr uint32_t size = 10000;
@@ -254,7 +254,7 @@ static void test_multi_writer(IVector<int> const& v)
         {
             for (int i = 0; i < size; ++i)
             {
-                v.Append(i);
+                v.Append(conditional_box<T>(i));
             }
         });
     }
@@ -267,7 +267,7 @@ static void test_multi_writer(IVector<int> const& v)
     REQUIRE(v.Size() == (size * threadCount));
 
     // sum(i = 1 -> N){i} = N * (N + 1) / 2
-    auto sum = std::accumulate(begin(v), end(v), 0);
+    auto sum = std::accumulate(begin(v), end(v), 0, [](int curr, T const& next) { return curr + conditional_unbox(next); });
     REQUIRE(sum == ((threadCount * (size - 1) * size) / 2));
 }
 
@@ -347,16 +347,35 @@ static void deadlock_test()
 TEST_CASE("multi_threaded_vector")
 {
     test_single_reader_single_writer(multi_threaded_vector<int>());
+    test_single_reader_single_writer(multi_threaded_vector<IInspectable>());
+
     test_iterator_invalidation(multi_threaded_vector<int>());
+    test_iterator_invalidation(multi_threaded_vector<IInspectable>());
+
     test_concurrent_iteration(multi_threaded_vector<int>());
+    test_concurrent_iteration(multi_threaded_vector<IInspectable>());
+
     test_multi_writer(multi_threaded_vector<int>());
+    test_multi_writer(multi_threaded_vector<IInspectable>());
+
     deadlock_test();
 }
 
 TEST_CASE("multi_threaded_observable_vector")
 {
-    test_single_reader_single_writer(multi_threaded_observable_vector<int>());
-    test_iterator_invalidation(multi_threaded_observable_vector<int>());
-    test_concurrent_iteration(multi_threaded_observable_vector<int>());
-    test_multi_writer(multi_threaded_observable_vector<int>());
+    test_single_reader_single_writer<int>(multi_threaded_observable_vector<int>());
+    test_single_reader_single_writer<IInspectable>(multi_threaded_observable_vector<IInspectable>());
+    test_single_reader_single_writer(multi_threaded_observable_vector<int>().as<IVector<IInspectable>>());
+
+    test_iterator_invalidation<int>(multi_threaded_observable_vector<int>());
+    test_iterator_invalidation<IInspectable>(multi_threaded_observable_vector<IInspectable>());
+    test_iterator_invalidation(multi_threaded_observable_vector<int>().as<IVector<IInspectable>>());
+
+    test_concurrent_iteration<int>(multi_threaded_observable_vector<int>());
+    test_concurrent_iteration<IInspectable>(multi_threaded_observable_vector<IInspectable>());
+    test_concurrent_iteration(multi_threaded_observable_vector<int>().as<IVector<IInspectable>>());
+
+    test_multi_writer<int>(multi_threaded_observable_vector<int>());
+    test_multi_writer<IInspectable>(multi_threaded_observable_vector<IInspectable>());
+    test_multi_writer(multi_threaded_observable_vector<int>().as<IVector<IInspectable>>());
 }

--- a/test/test/multi_threaded_vector.cpp
+++ b/test/test/multi_threaded_vector.cpp
@@ -1,0 +1,295 @@
+#include "pch.h"
+
+#include <numeric>
+#include <thread>
+
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+
+// Vector correctness tests exist elsewhere. These tests are strictly geared toward testing multi threaded functionality
+
+struct signal
+{
+    HANDLE m_handle;
+
+    signal() : m_handle(::CreateEventW(nullptr, true, false, nullptr))
+    {
+        REQUIRE(m_handle != nullptr);
+    }
+
+    ~signal()
+    {
+        if (m_handle)
+        {
+            ::CloseHandle(m_handle);
+        }
+    }
+
+    void set()
+    {
+        WINRT_VERIFY(::SetEvent(m_handle));
+    }
+
+    bool wait(DWORD timeoutMs = INFINITE)
+    {
+        auto result = ::WaitForSingleObject(m_handle, timeoutMs);
+        REQUIRE(((result == WAIT_OBJECT_0) || (result == WAIT_TIMEOUT)));
+        return result == WAIT_OBJECT_0;
+    }
+};
+
+static void test_single_reader_single_writer(IVector<int> const& v)
+{
+    static constexpr uint32_t final_size = 100000;
+
+    std::thread t([&]
+    {
+        for (int i = 0; i < final_size; ++i)
+        {
+            v.Append(i);
+        }
+    });
+
+    bool done = false;
+    bool caughtException = false;
+    auto iterable = v.as<IIterable<int>>(); // Don't use the 'fast_iterator'
+    while (!done)
+    {
+        try
+        {
+            bool forceExit = v.Size() == final_size;
+
+            int expected = 0;
+            for (auto val : iterable)
+            {
+                REQUIRE(val == expected++);
+            }
+            done = expected == final_size;
+
+            if (forceExit)
+            {
+                break;
+            }
+        }
+        catch (hresult_changed_state const&)
+        {
+            // Since we're concurrently modifying the vector, this is expected
+            caughtException = true;
+        }
+    }
+    REQUIRE(done);
+    // The size was chosen such that this should virtually always be true, however this cannot be guaranteed
+    // REQUIRE(caughtException);
+
+    t.join();
+
+    static constexpr uint32_t read_size = 100;
+    done = false;
+    signal s;
+    t = std::thread([&]
+    {
+        s.set();
+        while (!done)
+        {
+            for (int i = 0; i < read_size; ++i)
+            {
+                v.SetAt(i, v.GetAt(i) - 1);
+            }
+        }
+    });
+    s.wait();
+
+    int vals[read_size];
+    for (int i = 0; i < 20; ++i)
+    {
+        auto len = v.GetMany(0, vals);
+        REQUIRE(len == read_size);
+
+        int jumpCount = 0;
+        for (int j = 1; j < read_size; ++j)
+        {
+            auto diff = vals[j] - vals[j - 1];
+            REQUIRE(((diff > 0) && (diff <= 2)));
+            jumpCount += (diff == 2) ? 1 : 0;
+        }
+        REQUIRE(jumpCount <= 1);
+    }
+
+    done = true;
+    t.join();
+}
+
+static void test_concurrent_iteration(IVector<int> const& v)
+{
+    // Large enough size that all threads should have enough time to spin up
+    static constexpr uint32_t size = 10000;
+    for (int i = 0; i < size; ++i)
+    {
+        v.Append(i);
+    }
+
+    auto itr = v.First();
+    std::thread threads[2];
+    int increments[std::size(threads)] = {};
+    for (int i = 0; i < std::size(threads); ++i)
+    {
+        threads[i] = std::thread([&itr, &increments, i]
+        {
+            int last = -1;
+            while (true)
+            {
+                try
+                {
+                    // NOTE: Because there is no atomic "get and increment" function on IIterator, the best we can do is
+                    // validate that we're getting valid increasing values, e.g. as opposed to validating that we read
+                    // all unique values.
+                    auto val = itr.Current();
+                    REQUIRE(val > last);
+                    REQUIRE(val < size);
+                    last = val;
+                    if (!itr.MoveNext())
+                    {
+                        break;
+                    }
+
+                    // MoveNext is the only synchronized operation that has a predictable side effect we can validate
+                    ++increments[i];
+                }
+                catch (hresult_error const&)
+                {
+                    // There's no "get if" function, so concurrent increment past the end is always possible...
+                    REQUIRE(!itr.HasCurrent());
+                    break;
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    REQUIRE(!itr.HasCurrent());
+
+    auto totalIncrements = std::accumulate(std::begin(increments), std::end(increments), 0);
+    REQUIRE(totalIncrements == (size - 1));
+}
+
+static void test_multi_writer(IVector<int> const& v)
+{
+    // Large enough that several threads should be executing concurrently
+    static constexpr uint32_t size = 10000;
+    static constexpr size_t threadCount = 8;
+    std::thread threads[threadCount];
+    for (auto& t : threads)
+    {
+        t = std::thread([&v]
+        {
+            for (int i = 0; i < size; ++i)
+            {
+                v.Append(i);
+            }
+        });
+    }
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    REQUIRE(v.Size() == (size * threadCount));
+
+    // sum(i = 1 -> N){i} = N * (N + 1) / 2
+    auto sum = std::accumulate(begin(v), end(v), 0);
+    REQUIRE(sum == ((threadCount * (size - 1) * size) / 2));
+}
+
+struct exclusive_vector :
+    vector_base<exclusive_vector, int>,
+    implements<exclusive_vector, IVector<int>, IVectorView<int>, IIterable<int>>
+{
+    std::vector<int> container;
+    mutable slim_mutex mutex;
+
+    auto& get_container() noexcept
+    {
+        return container;
+    }
+
+    auto& get_container() const noexcept
+    {
+        return container;
+    }
+
+    // It is not safe to recursively acquire an SRWLOCK, even in shared mode, however this is unchecked by the SRWLOCK
+    // implementation. Using a vector that only performs exclusive operations is the simplest way to validate that
+    // the implementation does not attempt to recursively acquire the mutex.
+    template <typename Func>
+    auto exclusive_op(Func&& fn) const
+    {
+        slim_lock_guard guard(mutex);
+        return fn();
+    }
+};
+
+static void deadlock_test()
+{
+    auto v = make<exclusive_vector>();
+
+    v.Append(42);
+    v.InsertAt(0, 8);
+    REQUIRE(v.Size() == 2);
+    REQUIRE(v.GetAt(0) == 8);
+    uint32_t index;
+    REQUIRE(v.IndexOf(42, index));
+    REQUIRE(index == 1);
+    v.ReplaceAll({ 1, 2, 3 });
+    v.SetAt(1, 4);
+    int vals[5];
+    REQUIRE(v.GetMany(0, vals) == 3);
+    REQUIRE(vals[0] == 1);
+    REQUIRE(vals[1] == 4);
+    REQUIRE(vals[2] == 3);
+    v.RemoveAt(1);
+    REQUIRE(v.GetAt(1) == 3);
+    v.RemoveAtEnd();
+    REQUIRE(v.GetAt(0) == 1);
+    v.Clear();
+    REQUIRE(v.Size() == 0);
+
+    v.ReplaceAll({ 1, 2, 3 });
+    auto view = v.GetView();
+    REQUIRE(v.Size() == 3);
+    REQUIRE(v.GetAt(0) == 1);
+    REQUIRE(v.GetMany(0, vals) == 3);
+    REQUIRE(vals[0] == 1);
+    REQUIRE(vals[1] == 2);
+    REQUIRE(vals[2] == 3);
+    REQUIRE(v.IndexOf(2, index));
+    REQUIRE(index == 1);
+
+    auto itr = v.First();
+    REQUIRE(itr.HasCurrent());
+    REQUIRE(itr.Current() == 1);
+    REQUIRE(itr.MoveNext());
+    REQUIRE(itr.MoveNext());
+    REQUIRE(!itr.MoveNext());
+    REQUIRE(!itr.HasCurrent());
+}
+
+TEST_CASE("multi_threaded_vector")
+{
+    test_single_reader_single_writer(multi_threaded_vector<int>());
+    test_concurrent_iteration(multi_threaded_vector<int>());
+    test_multi_writer(multi_threaded_vector<int>());
+    deadlock_test();
+}
+
+TEST_CASE("multi_threaded_observable_vector")
+{
+    test_single_reader_single_writer(multi_threaded_observable_vector<int>());
+    test_concurrent_iteration(multi_threaded_observable_vector<int>());
+    test_multi_writer(multi_threaded_observable_vector<int>());
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -404,6 +404,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="multi_threaded_map.cpp" />
     <ClCompile Include="multi_threaded_vector.cpp" />
     <ClCompile Include="names.cpp" />
     <ClCompile Include="noexcept.cpp" />

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -404,6 +404,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="multi_threaded_vector.cpp" />
     <ClCompile Include="names.cpp" />
     <ClCompile Include="noexcept.cpp" />
     <ClCompile Include="notify_awaiter.cpp" />


### PR DESCRIPTION
This mainly re-uses the existing collections, but adds support for doing shared/exclusive operations. For the existing single threaded collections, nothing special is done and operations are performed without any synchronization. For the new multi-threaded collections, an SRWLOCK is acquired in either shared or exclusive mode.

The most noteworthy "flaw" is that mutating iterator operations lock the collection exclusively. This is mostly a limitation imposed by the base IIterable type which uses opaque iterators for the IIterator objects. In theory, the collection only needs to be locked in shared mode, however that would require the IIterator objects themselves to have a separate lock, which seemed like overkill and unlikely to be worth it. Compare this to the existing ABI collection types which know the underlying vector/map types and can perform interlocked operations - in the case of vector - or forgo sequential consistency while still guaranteeing safety - in the case of map.

The following were also discussed, but are not addressed here as they can be done separately as a later change:
* The vector/map types still implement IVectorView/IMapView and GetView returns a pointer to itself, meaning that you can still QI an IVectorView -> IVector
* The IObservable* types still allow modification during a change callout. This can pretty easily be addressed by an atomic_bool as locks aren't really helpful here anyway.