### PR TITLE
Add value type support to as() and try_as()

### DIFF
--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -133,8 +133,17 @@ WINRT_EXPORT namespace winrt
         template <typename To>
         bool try_as(To& to) const noexcept
         {
-            to = try_as<impl::wrapped_type_t<To>>();
-            return static_cast<bool>(to);
+            if constexpr (impl::is_com_interface_v<To> || !std::is_same_v<To, impl::wrapped_type_t<To>>)
+            {
+                to = try_as<impl::wrapped_type_t<To>>();
+                return static_cast<bool>(to);
+            }
+            else
+            {
+                auto result = try_as<To>();
+                to = result.has_value() ? result.value() : impl::empty_value<To>();
+                return result.has_value();
+            }
         }
 
         hresult as(guid const& id, void** result) const noexcept

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -226,15 +226,6 @@ namespace winrt::impl
     template <typename T>
     using wrapped_type_t = typename wrapped_type<T>::type;
 
-    template <template <typename...> typename Trait, typename Enabler, typename... Args>
-    struct is_detected : std::false_type {};
-
-    template <template <typename...> typename Trait, typename... Args>
-    struct is_detected<Trait, std::void_t<Trait<Args...>>, Args...> : std::true_type {};
-
-    template <template <typename...> typename Trait, typename... Args>
-    inline constexpr bool is_detected_v = std::is_same_v<typename is_detected<Trait, void, Args...>::type, std::true_type>;
-
     template <typename ... Types>
     struct typelist {};
 


### PR DESCRIPTION
This permits fluent usage, which lets you read the code left-to-right instead of prefix usage which forces the eyes to dart back and forth.

Example of using `as` instead of `unbox_value`:

```cpp
// old and busted with unbox_value()
auto h = unbox_value<Size>(SelectedItem().Tag()).Height;
auto h = unbox_value<Size>(propertySet.Lookup(L"key")).Height;

// new hotness with as()
auto h = SelectedItem().Tag().as<Size>().Height;
auto h = propertySet.Lookup(L"key").as<Size>().Height;
```

Example of using `try_as` instead of `unbox_value_or`:
```cpp
// old and busted with unbox_value_or()
auto h = unbox_value_or<Size>(SelectedItem().Tag(), default_size).Height;
auto h = unbox_value_or<Size>(propertySet.TryLookup(L"key"), default_size).Height;

// new hotness with try_as() + std::optional
auto h = SelectedItem().Tag().try_as<Size>().value_or(default_size).Height;
auto h = propertySet.TryLookup(L"key").try_as<Size>().value_or(default_size).Height;
```

Including `winrt/Windows.Foundation.h` lights up these overloads. If you don't include it, then you get a compile-time error that points you to a line with the comment

```cpp
// You must include <winrt/Windows.Foundation.h> to use this overload.
```

The new functionality is overloaded onto the existing names `as` and `try_as` to avoid introducing new names into `com_ptr` and `IUnknown`.

Factored unit tests to make it easier to add tests for the new overload. Also added a new unit test for `com_ptr` duck typing, which is an interesting corner case: You can use `com_ptr` for things that aren't actually COM objects, as long as they quack like a COM object. Care must be taken not to cast such objects to IUnknown, because the decoys won't have the same vtable layout (or possibly no vtable at all). Note such care in the new `impl::try_as` method, where we cast the raw pointer to `com_ptr` if it isn't a COM interface, thereby allowing the duck typing to proceed.

The trickiest parts are finding the right definition for the `is_com_interface` detector class and deploying it correctly via `enable_if_t` and `if constexpr`. The `try_as` overload which sets an output parameter in particular needs to detect `is_com_interface` + `com_ptr`. I reused the `wrapped_type` detector class for detecting `com_ptr`.

Also deleted apparently-unused `is_detected` detector class.