### PR TITLE
Make vector<bool> work again

### DIFF
--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -60,7 +60,8 @@ namespace winrt::impl
     struct removed_value
     {
         // Trivially destructible; okay to run destructor under lock
-        void assign(T&) {}
+        template <typename U>
+        void assign(U&&) {}
     };
 
     template <typename T>
@@ -68,7 +69,8 @@ namespace winrt::impl
     {
         std::optional<T> m_value;
 
-        void assign(T& value)
+        template <typename U>
+        void assign(U&& value)
         {
             m_value.emplace(std::move(value));
         }
@@ -313,7 +315,7 @@ WINRT_EXPORT namespace winrt
             }
 
             this->increment_version();
-            auto& pos = static_cast<D&>(*this).get_container()[index];
+            auto&& pos = static_cast<D&>(*this).get_container()[index];
             oldValue.assign(pos);
             pos = static_cast<D const&>(*this).wrap_value(value);
         }

--- a/test/old_tests/UnitTests/single_threaded_vector.cpp
+++ b/test/old_tests/UnitTests/single_threaded_vector.cpp
@@ -110,3 +110,33 @@ TEST_CASE("test_single_threaded_vector")
     test_vector(single_threaded_vector<int>());
     test_vector(single_threaded_observable_vector<int>());
 }
+
+TEST_CASE("single_threaded_vector of bool")
+{
+    auto values = single_threaded_vector<bool>();
+    values.Append(true);
+    values.ReplaceAll({ false, true, false, true });
+    values.InsertAt(1, false);
+    values.SetAt(2, false);
+    REQUIRE(values.Size() == 5);
+    REQUIRE(!values.GetAt(0));
+    uint32_t index;
+    REQUIRE((values.IndexOf(true, index) && (index == 4)));
+
+    auto itr = values.First();
+    REQUIRE(itr.HasCurrent());
+    REQUIRE(!itr.Current());
+    REQUIRE(itr.MoveNext());
+    REQUIRE(itr.MoveNext());
+    bool temp[5];
+    REQUIRE(itr.GetMany(temp) == 3);
+    REQUIRE((!temp[0] && !temp[1] && temp[2]));
+
+    values.RemoveAt(0);
+    values.RemoveAtEnd();
+    REQUIRE(values.Size() == 3);
+    REQUIRE(values.GetMany(0, temp) == 3);
+    REQUIRE((!temp[0] && !temp[1] && !temp[2]));
+    values.Clear();
+    REQUIRE(values.Size() == 0);
+}


### PR DESCRIPTION
`std::vector<bool>` returns proxy objects for iteration/indexing, so switching to forwarding references where necessary. Still using `std:move` (over `std::forward`) since the intent is taking ownership.