### PR TITLE
Set Private to false for specific projects instead of everything.

### DIFF
--- a/nuget/CppWinrtRules.Project.xml
+++ b/nuget/CppWinrtRules.Project.xml
@@ -76,4 +76,9 @@
                 Description="Enables or disables the generation of Windows Metadata"
                 Category="General" />
 
+  <BoolProperty Name="CppWinRTEnableDefaultPrivateFalse"
+                DisplayName="Enable Copy Local Defaults"
+                Description="Enables or disables the default for copying bineries to the output folder"
+                Category="General" />
+
 </Rule>

--- a/nuget/CppWinrtRules.Project.xml
+++ b/nuget/CppWinrtRules.Project.xml
@@ -78,7 +78,7 @@
 
   <BoolProperty Name="CppWinRTEnableDefaultPrivateFalse"
                 DisplayName="Enable Copy Local Defaults"
-                Description="Enables or disables the default for copying bineries to the output folder"
+                Description="Enables or disables the default for copying binaries to the output folder"
                 Category="General" />
 
 </Rule>

--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -23,6 +23,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <WinMDAssembly>true</WinMDAssembly>
         <!--Set a value to prevent SDK's uap.props from setting it and pointing to the wrong headers-->
         <CppWinRT_IncludePath>PreventSdkUapPropsAssignment</CppWinRT_IncludePath>
+        <CppWinRTEnableDefaultPrivateFalse Condition="'$(CppWinRTEnableDefaultPrivateFalse)' == ''"></CppWinRTEnableDefaultPrivateFalse>
     </PropertyGroup>
 
     <ItemDefinitionGroup>
@@ -43,19 +44,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <ProxyFileName Condition="'%(Midl.ProxyFileName)'==''">nul</ProxyFileName>
             <TypeLibraryName Condition="'%(Midl.TypeLibraryName)'==''"></TypeLibraryName>
         </Midl>
-        <ProjectReference Condition="'$(XamlLanguage)' != 'C++'">
+        <ProjectReference Condition="'$(XamlLanguage)' != 'C++' and '$(CppWinRTEnableDefaultPrivateFalse)' == 'true'">
             <!-- By default, for a C++/WinRT project,
                  don't copy project reference output to the output directory
-                 of the current project unless this is an exe. -->
-            <Private>false</Private>
-            <Private Condition="'$(ConfigurationType)' == 'Application' or '$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">true</Private>
+                 of the current project for projects that are not an exe. -->
+            <Private Condition=" and '$(ConfigurationType)' != 'Application' and '$(OutputType)'!='winexe' and '$(OutputType)'!='exe' and '$(OutputType)'!='appcontainerexe'">false</Private>
         </ProjectReference>
-        <Reference Condition="'$(XamlLanguage)' != 'C++'">
+        <Reference Condition="'$(XamlLanguage)' != 'C++' and '$(CppWinRTEnableDefaultPrivateFalse)' == 'true'">
             <!-- By default, for a C++/WinRT project,
                  don't copy reference output to the output directory
-                 of the current project unless this is an exe. -->
-            <Private>false</Private>
-            <Private Condition="'$(ConfigurationType)' == 'Application' or '$(OutputType)'=='winexe' or '$(OutputType)'=='exe' or '$(OutputType)'=='appcontainerexe'">true</Private>
+                 of the current project for projects that are not an exe. -->
+            <Private Condition=" and '$(ConfigurationType)' != 'Application' and '$(OutputType)'!='winexe' and '$(OutputType)'!='exe' and '$(OutputType)'!='appcontainerexe'">false</Private>
         </Reference>
     </ItemDefinitionGroup>
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -68,6 +68,7 @@ C++/WinRT behavior can be customized with these project properties:
 | CppWinRTProjectLanguage | C++/CX \| *C++/WinRT | Selects the C++ dialect for the project.  C++/WinRT provides full projection support, C++/CX permits consuming projection headers. |
 | CppWinRTOptimized | true \| *false | Enables component projection [optimization features](https://kennykerr.ca/2019/06/07/cppwinrt-optimizing-components/) |
 | CppWinRTGenerateWindowsMetadata | true \| *false | Indicates whether this project produces Windows Metadata |
+| CppWinRTEnableDefaultPrivateFalse | true \| *false | Indicates whether this project uses C++/WinRT optimized default for copying binaries to the output directory |
 \*Default value
 
 To customize common C++/WinRT project properties: 


### PR DESCRIPTION
Set Private explicitly to false for certain projects instead of setting it to false for everything and then setting it true for certain projects and allow projects to opt-out.

TODO:

- [x] Add docs for the new property.