### PR TITLE
Delete the rsp files on error and be smarter about detecting deleted files.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -385,10 +385,10 @@ namespace $(RootNamespace)
         </PropertyGroup>
         <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(XamlMetaDataProviderIdl)" Lines="$(XamlMetaDataProviderIdlLines)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
         <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(XamlMetaDataProviderIdl)" Lines="$(XamlMetaDataProviderIdlLines)"
-            ContinueOnError="true" Overwrite="true"
+            Overwrite="true"
             WriteOnlyWhenDifferent="true" />
     </Target>
 
@@ -407,10 +407,10 @@ $(XamlMetaDataProviderPch)
         </PropertyGroup>
         <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(XamlMetaDataProviderCpp)" Lines="$(XamlMetaDataProviderCppLines)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
         <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(XamlMetaDataProviderCpp)" Lines="$(XamlMetaDataProviderCppLines)"
-            ContinueOnError="true" Overwrite="true"
+            Overwrite="true"
             WriteOnlyWhenDifferent="true" />
     </Target>
 
@@ -438,7 +438,7 @@ $(XamlMetaDataProviderPch)
         <!-- Always write the midlrt.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
             File="$(CppWinRTMidlResponseFile)" Lines="$(_MidlrtParameters)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
         <Message Text="CppWinRTMidlReferences: @(_MidlReferences->'%(WinMDPath)')" Importance="$(CppWinRTVerbosity)"/>
     </Target>
 
@@ -470,10 +470,10 @@ $(XamlMetaDataProviderPch)
 
         <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" Lines="$(MdMergeDependencyHash)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
         <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
             File="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" Lines="$(MdMergeDependencyHash)"
-            ContinueOnError="true" Overwrite="true"
+            Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 
         <ItemGroup>
@@ -508,7 +508,7 @@ $(XamlMetaDataProviderPch)
         <!-- Always write the mdmerge.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
             File="$(CppWinRTMdMergeResponseFile)" Lines="$(_MdMergeParameters)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
 
         <MakeDir Directories="$(CppWinRTUnmergedDir);$(CppWinRTMergedDir)" />
         <Message Text="$(_MdMergeCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(CppWinRTMdMergeInputs)' != ''" />
@@ -559,7 +559,15 @@ $(XamlMetaDataProviderPch)
             <Output TaskParameter="HashResult" PropertyName="CppWinRTPlatformProjectionDependencyHash" />
         </Hash>
 
-        <WriteLinesToFile Lines="$(CppWinRTPlatformProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+        <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" 
+            Lines="$(CppWinRTPlatformProjectionDependencyHash)"
+            Overwrite="true" />
+        <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" 
+            Lines="$(CppWinRTPlatformProjectionDependencyHash)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
 
         <ItemGroup>
             <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" />
@@ -593,7 +601,7 @@ $(XamlMetaDataProviderPch)
         <!-- Always write the cppwinrt_plat.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
             File="$(CppWinRTPlatformProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
 
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtInputs)' != ''" />
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtInputs)' != ''" />
@@ -626,7 +634,15 @@ $(XamlMetaDataProviderPch)
             <Output TaskParameter="HashResult" PropertyName="CppWinRTReferenceProjectionDependencyHash" />
         </Hash>
 
-        <WriteLinesToFile Lines="$(CppWinRTReferenceProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+        <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache"
+            Lines="$(CppWinRTReferenceProjectionDependencyHash)"
+            Overwrite="true" />
+        <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache"
+            Lines="$(CppWinRTReferenceProjectionDependencyHash)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
 
         <ItemGroup>
             <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" />
@@ -664,7 +680,7 @@ $(XamlMetaDataProviderPch)
         <!-- Always write the cppwinrt_ref.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile 
             File="$(CppWinRTReferenceProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
 
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtRefInputs)' != ''" />
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtRefInputs)' != ''" />
@@ -699,8 +715,16 @@ $(XamlMetaDataProviderPch)
             <Output TaskParameter="HashResult" PropertyName="CppWinRTComponentProjectionDependencyHash" />
         </Hash>
 
-        <WriteLinesToFile Lines="$(CppWinRTComponentProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
-
+        <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache"
+            Lines="$(CppWinRTComponentProjectionDependencyHash)"
+            Overwrite="true" />
+        <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache"
+            Lines="$(CppWinRTComponentProjectionDependencyHash)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+        
         <ItemGroup>
             <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" />
         </ItemGroup>
@@ -761,7 +785,7 @@ $(XamlMetaDataProviderPch)
         <!-- Always write the cppwinrt_comp.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
             File="$(CppWinRTComponentProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
-            ContinueOnError="true" Overwrite="true" />
+            Overwrite="true" />
         
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtCompInputs)' != ''"/>
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtCompInputs)' != ''"/>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -31,6 +31,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <XamlMetaDataProviderIdl Condition="'$(XamlMetaDataProviderIdl)'== ''">$(GeneratedFilesDir)XamlMetaDataProvider.idl</XamlMetaDataProviderIdl>
         <XamlMetaDataProviderCpp Condition="'$(XamlMetaDataProviderCpp)'== ''">$(GeneratedFilesDir)XamlMetaDataProvider.cpp</XamlMetaDataProviderCpp>
 
+        <CppWinRTMdMergeResponseFile Condition="'$(CppWinRTMdMergeResponseFile)'==''">$(IntDir)$(MSBuildProjectFile).mdmerge.rsp</CppWinRTMdMergeResponseFile>
+        <CppWinRTMidlResponseFile Condition="'$(CppWinRTMidlResponseFile)'==''">$(IntDir)$(MSBuildProjectFile).midlrt.rsp</CppWinRTMidlResponseFile>
+        <CppWinRTPlatformProjectionResponseFile Condition="'$(CppWinRTPlatformProjectionResponseFile)'==''">$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.rsp</CppWinRTPlatformProjectionResponseFile>
+        <CppWinRTReferenceProjectionResponseFile Condition="'$(CppWinRTReferenceProjectionResponseFile)'==''">$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.rsp</CppWinRTReferenceProjectionResponseFile>
+        <CppWinRTComponentProjectionResponseFile Condition="'$(CppWinRTComponentProjectionResponseFile)'==''">$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.rsp</CppWinRTComponentProjectionResponseFile>
+        
         <!-- For CX projects, CppWinRT will never output a winmd-->
         <!-- NOTE: We don't set a default here as the default requires evaluation of project references
              and this is done by the CppWinRTComputeGenerateWindowsMetadata target. -->
@@ -413,7 +419,7 @@ $(XamlMetaDataProviderPch)
             Condition="'$(CppWinRTModernIDL)' != 'false'"
             DependsOnTargets="GetCppWinRTPlatformWinMDReferences;GetCppWinRTDirectWinMDReferences;GetCppWinRTProjectWinMDReferences;$(CppWinRTSetMidlReferencesDependsOn)"
             Inputs="$(MSBuildAllProjects);@(CppWinRTDirectWinMDReferences);@(CppWinRTStaticProjectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
-            Outputs="$(IntDir)midlrt.rsp">
+            Outputs="$(CppWinRTMidlResponseFile)">
         <ItemGroup>
             <_MidlReferences Remove="@(_MidlReferences)"/>
             <_MidlReferences Include="@(CppWinRTDirectWinMDReferences)"/>
@@ -423,7 +429,7 @@ $(XamlMetaDataProviderPch)
             <_MidlReferencesDistinct Remove="@(_MidlReferencesDistinct)" />
             <_MidlReferencesDistinct Include="@(_MidlReferences->'%(WinMDPath)'->Distinct())" />
             <Midl Condition="'%(Midl.DisableReferences)'==''">
-                <AdditionalOptions>%(Midl.AdditionalOptions) %40"$(IntDir)midlrt.rsp"</AdditionalOptions>
+                <AdditionalOptions>%(Midl.AdditionalOptions) %40"$(CppWinRTMidlResponseFile)"</AdditionalOptions>
             </Midl>
         </ItemGroup>
         <PropertyGroup>
@@ -431,7 +437,7 @@ $(XamlMetaDataProviderPch)
         </PropertyGroup>
         <!-- Always write the midlrt.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
-            File="$(IntDir)midlrt.rsp" Lines="$(_MidlrtParameters)"
+            File="$(CppWinRTMidlResponseFile)" Lines="$(_MidlrtParameters)"
             ContinueOnError="true" Overwrite="true" />
         <Message Text="CppWinRTMidlReferences: @(_MidlReferences->'%(WinMDPath)')" Importance="$(CppWinRTVerbosity)"/>
     </Target>
@@ -439,18 +445,58 @@ $(XamlMetaDataProviderPch)
     <!--Ctrl+F7 (selected file) midl compilation support-->
     <Target Name="CppWinRTSetSelectMidlReferences" BeforeTargets="SelectMidl" DependsOnTargets="CppWinRTSetMidlReferences" />
 
+    <!--
+    ============================================================
+    Generate a file used to track MdMerge dependencies between incremental build
+    executions. This handles cases where items are added or removed and can't 
+    otherwise be detected with timestamp comparisons. The file contains a hash of 
+    MdMerge inputs that are known to contribute to incremental build inconsistencies.
+    ============================================================
+    -->
+    <Target Name="_CppWinRTGenerateMergeProjectWinMDDependencyCache" DependsOnTargets="Midl;GetCppWinRTMdMergeInputs">
+        <ItemGroup>
+            <CustomAdditionalMdMergeInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" />
+            <MdMergeCache Include="@(CppWinRTMdMergeInputs)" />
+            <MdMergeCache Include="@(Page)" />
+            <MdMergeCache Include="@(ApplicationDefinition)" />
+            <!-- No need to include properties here as those should be caught by having $(MSBuildAllProjects) as input to the target-->
+        </ItemGroup>
+
+        <Hash
+          ItemsToHash="@(MdMergeCache)"
+          IgnoreCase="$([MSBuild]::ValueOrDefault(`$(MdMergeCacheIgnoreCase)`, `true`))">
+            <Output TaskParameter="HashResult" PropertyName="MdMergeDependencyHash" />
+        </Hash>
+
+        <WriteLinesToFile Condition="!$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" Lines="$(MdMergeDependencyHash)"
+            ContinueOnError="true" Overwrite="true" />
+        <WriteLinesToFile Condition="$(CppWinRTWriteOnlyWhenDifferent)"
+            File="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" Lines="$(MdMergeDependencyHash)"
+            ContinueOnError="true" Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+
+        <ItemGroup>
+            <FileWrites Include="$(IntDir)$(MSBuildProjectFile).MdMergeInputs.cache" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_CppWinRTCleanMdMergeOutputs">
+        <Delete Files="$(CppWinRTMdMergeResponseFile)" />
+    </Target>
+
     <!--Merge project-generated WinMDs and project-referenced static library WinMDs into project WinMD-->
     <Target Name="CppWinRTMergeProjectWinMDInputs"
-            DependsOnTargets="Midl;GetCppWinRTMdMergeInputs;$(CppWinRTMergeProjectWinMDInputsDependsOn)"
-            Inputs="$(MSBuildAllProjects);@(CppWinRTMdMergeInputs)"
-            Outputs="@(_MdMergedOutput);$(IntDir)mdmerge.rsp">
+            DependsOnTargets="Midl;GetCppWinRTMdMergeInputs;_CppWinRTGenerateMergeProjectWinMDDependencyCache;$(CppWinRTMergeProjectWinMDInputsDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(CppWinRTMdMergeInputs);@(CustomAdditionalMdMergeInputs)"
+            Outputs="@(_MdMergedOutput);$(CppWinRTMdMergeResponseFile)">
         <PropertyGroup>
             <!--Note: CppWinRTNamespaceMergeDepth supersedes CppWinRTMergeDepth-->
             <_MdMergeDepth Condition="'$(CppWinRTNamespaceMergeDepth)' != ''">-n:$(CppWinRTNamespaceMergeDepth)</_MdMergeDepth>
             <_MdMergeDepth Condition="'$(_MdMergeDepth)' == ''">$(CppWinRTMergeDepth)</_MdMergeDepth>
             <_MdMergeDepth Condition="'$(_MdMergeDepth)' == '' And '$(CppWinRTRootNamespaceAutoMerge)' == 'true'">-n:$(RootNamespace.Split('.').length)</_MdMergeDepth>
             <_MdMergeDepth Condition="'$(_MdMergeDepth)' == '' And ('@(Page)' != '' Or '@(ApplicationDefinition)' != '')">-n:1</_MdMergeDepth>
-            <_MdMergeCommand>$(MdMergePath)mdmerge %40"$(IntDir)mdmerge.rsp"</_MdMergeCommand>
+            <_MdMergeCommand>$(MdMergePath)mdmerge %40"$(CppWinRTMdMergeResponseFile)"</_MdMergeCommand>
         </PropertyGroup>
         <PropertyGroup>
             <!-- mdmerge.exe wants the folders to not have a trailing \ -->
@@ -458,10 +504,12 @@ $(XamlMetaDataProviderPch)
             <_MdMergeParameters>$(_MdMergeParameters) @(CppWinRTMdMergeInputs->'-i &quot;%(Identity)&quot;', '&#x0d;&#x0a;')</_MdMergeParameters>
             <_MdMergeParameters>$(_MdMergeParameters) -o &quot;$(CppWinRTMergedDir.TrimEnd('\'))&quot; -partial $(_MdMergeDepth)</_MdMergeParameters>
         </PropertyGroup>
+
         <!-- Always write the mdmerge.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
-            File="$(IntDir)mdmerge.rsp" Lines="$(_MdMergeParameters)"
+            File="$(CppWinRTMdMergeResponseFile)" Lines="$(_MdMergeParameters)"
             ContinueOnError="true" Overwrite="true" />
+
         <MakeDir Directories="$(CppWinRTUnmergedDir);$(CppWinRTMergedDir)" />
         <Message Text="$(_MdMergeCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(CppWinRTMdMergeInputs)' != ''" />
         <!-- Only run mdmerge.exe when we actually have inputs -->
@@ -471,6 +519,10 @@ $(XamlMetaDataProviderPch)
             <_MdMergedOutput Include="$(CppWinRTMergedDir)*.winmd"/>
         </ItemGroup>
         <Message Text="CppWinRTMdMerge output: @(MdMergeOutput)" Importance="$(CppWinRTVerbosity)"/>
+
+        <!-- Clean the output file if the target failed to indicate it needs to be rebuild -->
+        <OnError ExecuteTargets="_CppWinRTCleanMdMergeOutputs" />
+        
     </Target>
 
     <!-- Only copy winmd to output folder if CppWinRTGenerateWindowsMetadata is true -->
@@ -486,15 +538,47 @@ $(XamlMetaDataProviderPch)
             DestinationFiles="@(_MdMergedOutput->'$(OutDir)%(Filename)%(Extension)')" />
     </Target>
 
-    <!-- Build the platform projection from the winmds that sip with the platform in the Windows SDK -->
+    <!--
+    ============================================================
+    Generate a file used to track C++/WinRT platform WinMD input dependencies between incremental build
+    executions. This handles cases where items are added or removed and can't 
+    otherwise be detected with timestamp comparisons. The file contains a hash of 
+    the platform winmd inputs that are known to contribute to incremental build inconsistencies.
+    ============================================================
+    -->
+    <Target Name="_CppWinRTMakePlatformProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences;GetCppWinRTPlatformWinMDInputs">
+        <ItemGroup>
+            <CustomAdditionalPlatformWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" />
+            <CppWinRTPlatformProjectionCache Include="@(CppWinRTPlatformWinMDInputs)" />
+            <!-- No need to include properties here as those should be caught by having $(MSBuildAllProjects) as input to the target-->
+        </ItemGroup>
+
+        <Hash
+          ItemsToHash="@(CppWinRTPlatformProjectionCache)"
+          IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CppWinRTPlatformProjectionCacheIgnoreCase)`, `true`))">
+            <Output TaskParameter="HashResult" PropertyName="CppWinRTPlatformProjectionDependencyHash" />
+        </Hash>
+
+        <WriteLinesToFile Lines="$(CppWinRTPlatformProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_CppWinRTCleanMakePlatformProjectionOutputs">
+        <Delete Files="$(CppWinRTPlatformProjectionResponseFile)" />
+    </Target>
+    
+    <!-- Build the platform projection from the winmds that ship with the platform in the Windows SDK -->
     <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTMakePlatformProjection"
             Condition="'$(CppWinRTEnablePlatformProjection)' == 'true' AND '$(CppWinRTOverrideSDKReferences)' != 'true'"
-            DependsOnTargets="GetCppWinRTPlatformWinMDInputs;$(CppWinRTMakePlatformProjectionDependsOn)"
-            Inputs="$(MSBuildAllProjects);@(CppWinRTPlatformWinMDInputs)"
-            Outputs="$(IntDir)cppwinrt_plat.rsp">
+            DependsOnTargets="CppWinRTResolveReferences;GetCppWinRTPlatformWinMDInputs;_CppWinRTMakePlatformProjectionDependencyCache;$(CppWinRTMakePlatformProjectionDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(CppWinRTPlatformWinMDInputs);@(CustomAdditionalPlatformWinMDInputs)"
+            Outputs="$(CppWinRTPlatformProjectionResponseFile)">
         <PropertyGroup>
-            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(IntDir)cppwinrt_plat.rsp"</CppWinRTCommand>
+            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(CppWinRTPlatformProjectionResponseFile)"</CppWinRTCommand>
         </PropertyGroup>
         <ItemGroup>
             <_CppwinrtInputs Remove="@(_CppwinrtInputs)"/>
@@ -505,23 +589,63 @@ $(XamlMetaDataProviderPch)
             <_CppwinrtParameters>$(_CppwinrtParameters) @(_CppwinrtInputs->'-in &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_CppwinrtParameters>
             <_CppwinrtParameters>$(_CppwinrtParameters) -out &quot;$(GeneratedFilesDir).&quot;</_CppwinrtParameters>
         </PropertyGroup>
+
         <!-- Always write the cppwinrt_plat.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
-            File="$(IntDir)cppwinrt_plat.rsp" Lines="$(_CppwinrtParameters)"
+            File="$(CppWinRTPlatformProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
             ContinueOnError="true" Overwrite="true" />
+
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtInputs)' != ''" />
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtInputs)' != ''" />
+
+        <!-- Clean the output file if the target failed to indicate it needs to be rebuild -->
+        <OnError ExecuteTargets="_CppWinRTCleanMakePlatformProjectionOutputs" />
+
     </Target>
 
+    <!--
+    ============================================================
+    Generate a file used to track C++/WinRT reference WinMD input dependencies between incremental build
+    executions. This handles cases where items are added or removed and can't 
+    otherwise be detected with timestamp comparisons. The file contains a hash of 
+    the reference winmd inputs that are known to contribute to incremental build inconsistencies.
+    ============================================================
+    -->
+    <Target Name="_CppWinRTMakeReferenceProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences">
+        <ItemGroup>
+            <CustomAdditionalReferenceWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" />
+            <CppWinRTReferenceProjectionCache Include="@(CppWinRTDirectWinMDReferences)" />
+            <CppWinRTReferenceProjectionCache Include="@(CppWinRTDynamicProjectWinMDReferences)" />
+            <CppWinRTReferenceProjectionCache Include="@(CppWinRTPlatformWinMDReferences)" />
+            <!-- No need to include properties here as those should be caught by having $(MSBuildAllProjects) as input to the target-->
+        </ItemGroup>
+
+        <Hash
+          ItemsToHash="@(CppWinRTReferenceProjectionCache)"
+          IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CppWinRTReferenceProjectionCacheIgnoreCase)`, `true`))">
+            <Output TaskParameter="HashResult" PropertyName="CppWinRTReferenceProjectionDependencyHash" />
+        </Hash>
+
+        <WriteLinesToFile Lines="$(CppWinRTReferenceProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_CppWinRTCleanMakeReferenceProjectionOutputs">
+        <Delete Files="$(CppWinRTReferenceProjectionResponseFile)" />
+    </Target>
+    
     <!--Build reference projection from WinMD project references and dynamic library project references-->
     <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTMakeReferenceProjection"
             Condition="'@(CppWinRTDirectWinMDReferences)@(CppWinRTDynamicProjectWinMDReferences)' != '' AND '$(CppWinRTEnableReferenceProjection)' == 'true'"
-            DependsOnTargets="$(CppWinRTMakeReferenceProjectionDependsOn)"
-            Inputs="$(MSBuildAllProjects);@(CppWinRTDirectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
-            Outputs="$(IntDir)cppwinrt_ref.rsp">
+            DependsOnTargets="CppWinRTResolveReferences;_CppWinRTMakeReferenceProjectionDependencyCache;$(CppWinRTMakeReferenceProjectionDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(CppWinRTDirectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences);@(CustomAdditionalReferenceWinMDInputs)"
+            Outputs="$(CppWinRTReferenceProjectionResponseFile)">
         <PropertyGroup>
-            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(IntDir)cppwinrt_ref.rsp"</CppWinRTCommand>
+            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(CppWinRTReferenceProjectionResponseFile)"</CppWinRTCommand>
         </PropertyGroup>
         <ItemGroup>
             <_CppwinrtRefInputs Remove="@(_CppwinrtRefInputs)"/>
@@ -536,21 +660,63 @@ $(XamlMetaDataProviderPch)
             <_CppwinrtParameters>$(_CppwinrtParameters) @(_CppwinrtRefRefs->'-ref &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_CppwinrtParameters>
             <_CppwinrtParameters>$(_CppwinrtParameters) -out &quot;$(GeneratedFilesDir).&quot;</_CppwinrtParameters>
         </PropertyGroup>
+
         <!-- Always write the cppwinrt_ref.rsp file when the target runs, because the file is used as the output of this target. -->
-        <WriteLinesToFile
-            File="$(IntDir)cppwinrt_ref.rsp" Lines="$(_CppwinrtParameters)"
+        <WriteLinesToFile 
+            File="$(CppWinRTReferenceProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
             ContinueOnError="true" Overwrite="true" />
+
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtRefInputs)' != ''" />
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtRefInputs)' != ''" />
+
+        <!-- Clean the output file if the target failed to indicate it needs to be rebuild -->
+        <OnError ExecuteTargets="_CppWinRTCleanMakeReferenceProjectionOutputs" />
+
+    </Target>
+
+    <!--
+    ============================================================
+    Generate a file used to track C++/WinRT reference WinMD input dependencies between incremental build
+    executions. This handles cases where items are added or removed and can't 
+    otherwise be detected with timestamp comparisons. The file contains a hash of 
+    the reference winmd inputs that are known to contribute to incremental build inconsistencies.
+    ============================================================
+    -->
+    <Target Name="_CppWinRTMakeComponentProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences">
+        <ItemGroup>
+            <CustomAdditionalComponentWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" />
+            <CppWinRTComponentProjectionCache Include="@(CppWinRTMdMergeInputs)" />
+            <CppWinRTComponentProjectionCache Include="@(CppWinRTStaticProjectWinMDReferences)" />
+            <CppWinRTComponentProjectionCache Include="@(CppWinRTDirectWinMDReferences)"/>
+            <CppWinRTComponentProjectionCache Include="@(CppWinRTDynamicProjectWinMDReferences)"/>
+            <CppWinRTComponentProjectionCache Include="@(CppWinRTPlatformWinMDReferences)"/>
+            <!-- No need to include properties here as those should be caught by having $(MSBuildAllProjects) as input to the target-->
+        </ItemGroup>
+
+        <Hash
+          ItemsToHash="@(CppWinRTComponentProjectionCache)"
+          IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CppWinRTComponentProjectionCacheIgnoreCase)`, `true`))">
+            <Output TaskParameter="HashResult" PropertyName="CppWinRTComponentProjectionDependencyHash" />
+        </Hash>
+
+        <WriteLinesToFile Lines="$(CppWinRTComponentProjectionDependencyHash)" File="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+
+        <ItemGroup>
+            <FileWrites Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_CppWinRTCleanMakeComponentProjectionOutputs">
+        <Delete Files="$(CppWinRTComponentProjectionResponseFile)" />
     </Target>
 
     <!--Build component projection from project WinMD file and static library project references-->
     <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTMakeComponentProjection"
             Condition="'$(CppWinRTEnableComponentProjection)' == 'true'"
-            DependsOnTargets="GetCppWinRTMdMergeInputs;$(CppWinRTMakeComponentProjectionDependsOn)"
-            Inputs="$(MSBuildAllProjects);@(CppWinRTMdMergeInputs);@(CppWinRTStaticProjectWinMDReferences)"
-            Outputs="$(IntDir)cppwinrt_comp.rsp">
+            DependsOnTargets="CppWinRTResolveReferences;GetCppWinRTMdMergeInputs;_CppWinRTMakeComponentProjectionDependencyCache;$(CppWinRTMakeComponentProjectionDependsOn)"
+            Inputs="$(MSBuildAllProjects);@(CppWinRTMdMergeInputs);@(CppWinRTStaticProjectWinMDReferences);@(CustomAdditionalComponentWinMDInputs)"
+            Outputs="$(CppWinRTComponentProjectionResponseFile)">
         <PropertyGroup>
             <_PCH>@(ClCompile->Metadata('PrecompiledHeaderFile')->Distinct())</_PCH>
         </PropertyGroup>
@@ -563,7 +729,7 @@ $(XamlMetaDataProviderPch)
         <PropertyGroup>
             <CppWinRTCommandUsePrefixes Condition="'$(CppWinRTUsePrefixes)' == 'true'">-prefix</CppWinRTCommandUsePrefixes>
             <CppWinRTCommandPrecompiledHeader Condition="'$(CppWinRTPrecompiledHeader)' != ''">-pch $(CppWinRTPrecompiledHeader)</CppWinRTCommandPrecompiledHeader>
-            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(IntDir)cppwinrt_comp.rsp"</CppWinRTCommand>
+            <CppWinRTCommand>$(CppWinRTPath)cppwinrt %40"$(CppWinRTComponentProjectionResponseFile)"</CppWinRTCommand>
         </PropertyGroup>
         <ItemGroup>
             <!-- use the output from MdMerge directly to generate the component projection. -->
@@ -591,12 +757,17 @@ $(XamlMetaDataProviderPch)
             <_CppwinrtParameters>$(_CppwinrtParameters) @(_CppwinrtCompRefs->'-ref &quot;%(WinMDPath)&quot;', '&#x0d;&#x0a;')</_CppwinrtParameters>
             <_CppwinrtParameters>$(_CppwinrtParameters) -out &quot;$(GeneratedFilesDir).&quot;</_CppwinrtParameters>
         </PropertyGroup>
+
         <!-- Always write the cppwinrt_comp.rsp file when the target runs, because the file is used as the output of this target. -->
         <WriteLinesToFile
-            File="$(IntDir)cppwinrt_comp.rsp" Lines="$(_CppwinrtParameters)"
+            File="$(CppWinRTComponentProjectionResponseFile)" Lines="$(_CppwinrtParameters)"
             ContinueOnError="true" Overwrite="true" />
+        
         <Message Text="$(CppWinRTCommand)" Importance="$(CppWinRTVerbosity)" Condition="'@(_CppwinrtCompInputs)' != ''"/>
         <Exec Command="$(CppWinRTCommand)" Condition="'@(_CppwinrtCompInputs)' != ''"/>
+
+        <!-- Clean the output file if the target failed to indicate it needs to be rebuild -->
+        <OnError ExecuteTargets="_CppWinRTCleanMakeComponentProjectionOutputs" />
     </Target>
 
     <Target Name="CppWinRTMakeProjections" DependsOnTargets="CppWinRTResolveReferences;CppWinRTMakePlatformProjection;CppWinRTMakeReferenceProjection;CppWinRTMakeComponentProjection;$(CppWinRTMakeProjectionsDependsOn)" />

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -21,6 +21,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CppWinRTUseHardlinksIfPossible Condition="'$(CppWinRTUseHardlinksIfPossible)' == ''">false</CppWinRTUseHardlinksIfPossible>
         <CppWinRTWriteOnlyWhenDifferent Condition="('$(CppWinRTWriteOnlyWhenDifferent)' == '') And (('$(MSBuildToolsVersion)' == 'Current') Or ('$(MSBuildToolsVersion)' &gt;= '15'))">true</CppWinRTWriteOnlyWhenDifferent>
         <CppWinRTWriteOnlyWhenDifferent Condition="'$(CppWinRTWriteOnlyWhenDifferent)' != 'true'">false</CppWinRTWriteOnlyWhenDifferent>
+        <CppWinRTHasHashTask Condition="('$(CppWinRTHasHashTask)' == '') And (('$(MSBuildToolsVersion)' == 'Current') Or ('$(MSBuildToolsVersion)' &gt;= '15'))">true</CppWinRTHasHashTask>
+        <CppWinRTHasHashTask Condition="'$(CppWinRTHasHashTask)' != 'true'">false</CppWinRTHasHashTask>
         <CppWinRTPackageDir Condition="'$(CppWinRTPackage)' == 'true' and '$(CppWinRTPackageDir)'==''">$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)))..\..\</CppWinRTPackageDir>
         <CppWinRTPackageDir Condition="'$(CppWinRTPackage)' != 'true' and '$(CppWinRTPackageDir)'==''">$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)))</CppWinRTPackageDir>
         <CppWinRTParameters Condition="'$(CppWinRTFastAbi)'=='true'">$(CppWinRTParameters) -fastabi</CppWinRTParameters>
@@ -451,9 +453,10 @@ $(XamlMetaDataProviderPch)
     executions. This handles cases where items are added or removed and can't 
     otherwise be detected with timestamp comparisons. The file contains a hash of 
     MdMerge inputs that are known to contribute to incremental build inconsistencies.
+    NOTE: this is not used when building with older MSBuild versions.
     ============================================================
     -->
-    <Target Name="_CppWinRTGenerateMergeProjectWinMDDependencyCache" DependsOnTargets="Midl;GetCppWinRTMdMergeInputs">
+    <Target Name="_CppWinRTGenerateMergeProjectWinMDDependencyCache" Condition="'$(CppWinRTHasHashTask)' == 'true'" DependsOnTargets="Midl;GetCppWinRTMdMergeInputs">
         <ItemGroup>
             <CustomAdditionalMdMergeInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).MdMergeInputs.cache" />
             <MdMergeCache Include="@(CppWinRTMdMergeInputs)" />
@@ -544,9 +547,10 @@ $(XamlMetaDataProviderPch)
     executions. This handles cases where items are added or removed and can't 
     otherwise be detected with timestamp comparisons. The file contains a hash of 
     the platform winmd inputs that are known to contribute to incremental build inconsistencies.
+    NOTE: this is not used when building with older MSBuild versions.
     ============================================================
     -->
-    <Target Name="_CppWinRTMakePlatformProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences;GetCppWinRTPlatformWinMDInputs">
+    <Target Name="_CppWinRTMakePlatformProjectionDependencyCache"  Condition="'$(CppWinRTHasHashTask)' == 'true'" DependsOnTargets="CppWinRTResolveReferences;GetCppWinRTPlatformWinMDInputs">
         <ItemGroup>
             <CustomAdditionalPlatformWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_plat.cache" />
             <CppWinRTPlatformProjectionCache Include="@(CppWinRTPlatformWinMDInputs)" />
@@ -617,9 +621,10 @@ $(XamlMetaDataProviderPch)
     executions. This handles cases where items are added or removed and can't 
     otherwise be detected with timestamp comparisons. The file contains a hash of 
     the reference winmd inputs that are known to contribute to incremental build inconsistencies.
+    NOTE: this is not used when building with older MSBuild versions.
     ============================================================
     -->
-    <Target Name="_CppWinRTMakeReferenceProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences">
+    <Target Name="_CppWinRTMakeReferenceProjectionDependencyCache"  Condition="'$(CppWinRTHasHashTask)' == 'true'" DependsOnTargets="CppWinRTResolveReferences">
         <ItemGroup>
             <CustomAdditionalReferenceWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_ref.cache" />
             <CppWinRTReferenceProjectionCache Include="@(CppWinRTDirectWinMDReferences)" />
@@ -696,9 +701,10 @@ $(XamlMetaDataProviderPch)
     executions. This handles cases where items are added or removed and can't 
     otherwise be detected with timestamp comparisons. The file contains a hash of 
     the reference winmd inputs that are known to contribute to incremental build inconsistencies.
+    NOTE: this is not used when building with older MSBuild versions.
     ============================================================
     -->
-    <Target Name="_CppWinRTMakeComponentProjectionDependencyCache" DependsOnTargets="CppWinRTResolveReferences">
+    <Target Name="_CppWinRTMakeComponentProjectionDependencyCache" Condition="'$(CppWinRTHasHashTask)' == 'true'" DependsOnTargets="CppWinRTResolveReferences">
         <ItemGroup>
             <CustomAdditionalComponentWinMDInputs Include="$(IntDir)$(MSBuildProjectFile).cppwinrt_comp.cache" />
             <CppWinRTComponentProjectionCache Include="@(CppWinRTMdMergeInputs)" />


### PR DESCRIPTION
Delete the rsp files on error and be smarter about detecting deleted input files, by using a technique similar to what the C# compiler is using here: https://github.com/dotnet/msbuild/blob/0e7b70f663ab86af7ab41d5d7b409f72f7143899/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3397-L3427

Fixes #706 

TODO:
- [x] Run a razzle build.