### PR TITLE
Use RAII to keep better track of code generation state

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -393,7 +393,7 @@ catch (...) { return winrt::to_hresult(); }
             return;
         }
 
-        write_type_namespace(w, type_namespace);
+        auto wrap_type = wrap_type_namespace(w, type_namespace);
 
         for (auto&&[factory_name, factory] : get_factories(w, type))
         {
@@ -538,8 +538,6 @@ catch (...) { return winrt::to_hresult(); }
                 }
             }
         }
-
-        write_close_namespace(w);
     }
 
     static void write_component_override_dispatch_base(writer& w, TypeDef const& type)

--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -7,41 +7,41 @@ namespace cppwinrt
         writer w;
         write_preamble(w);
         w.write(strings::base_version_odr, CPPWINRT_VERSION_STRING);
-        write_open_file_guard(w, "BASE");
+        {
+            auto wrap_file_guard = wrap_open_file_guard(w, "BASE");
 
-        w.write(strings::base_includes);
-        w.write(strings::base_macros);
-        w.write(strings::base_types);
-        w.write(strings::base_extern);
-        w.write(strings::base_meta);
-        w.write(strings::base_identity);
-        w.write(strings::base_handle);
-        w.write(strings::base_lock);
-        w.write(strings::base_abi);
-        w.write(strings::base_windows);
-        w.write(strings::base_com_ptr);
-        w.write(strings::base_string);
-        w.write(strings::base_string_input);
-        w.write(strings::base_string_operators);
-        w.write(strings::base_array);
-        w.write(strings::base_weak_ref);
-        w.write(strings::base_agile_ref);
-        w.write(strings::base_error);
-        w.write(strings::base_marshaler);
-        w.write(strings::base_delegate);
-        w.write(strings::base_events);
-        w.write(strings::base_activation);
-        w.write(strings::base_implements);
-        w.write(strings::base_composable);
-        w.write(strings::base_foundation);
-        w.write(strings::base_chrono);
-        w.write(strings::base_security);
-        w.write(strings::base_std_hash);
-        w.write(strings::base_coroutine_threadpool);
-        w.write(strings::base_natvis);
-        w.write(strings::base_version);
-
-        write_endif(w);
+            w.write(strings::base_includes);
+            w.write(strings::base_macros);
+            w.write(strings::base_types);
+            w.write(strings::base_extern);
+            w.write(strings::base_meta);
+            w.write(strings::base_identity);
+            w.write(strings::base_handle);
+            w.write(strings::base_lock);
+            w.write(strings::base_abi);
+            w.write(strings::base_windows);
+            w.write(strings::base_com_ptr);
+            w.write(strings::base_string);
+            w.write(strings::base_string_input);
+            w.write(strings::base_string_operators);
+            w.write(strings::base_array);
+            w.write(strings::base_weak_ref);
+            w.write(strings::base_agile_ref);
+            w.write(strings::base_error);
+            w.write(strings::base_marshaler);
+            w.write(strings::base_delegate);
+            w.write(strings::base_events);
+            w.write(strings::base_activation);
+            w.write(strings::base_implements);
+            w.write(strings::base_composable);
+            w.write(strings::base_foundation);
+            w.write(strings::base_chrono);
+            w.write(strings::base_security);
+            w.write(strings::base_std_hash);
+            w.write(strings::base_coroutine_threadpool);
+            w.write(strings::base_natvis);
+            w.write(strings::base_version);
+        }
         w.flush_to_file(settings.output_folder + "winrt/base.h");
     }
 
@@ -49,17 +49,18 @@ namespace cppwinrt
     {
         writer w;
         write_preamble(w);
-        write_open_file_guard(w, "FAST_FORWARD");
+        {
+            auto wrap_file_guard = wrap_open_file_guard(w, "FAST_FORWARD");
 
-        auto const fast_abi_size = get_fastabi_size(w, classes);
+            auto const fast_abi_size = get_fastabi_size(w, classes);
 
-        w.write(strings::base_fast_forward,
-            fast_abi_size,
-            fast_abi_size,
-            bind<write_component_fast_abi_thunk>(),
-            bind<write_component_fast_abi_vtable>());
+            w.write(strings::base_fast_forward,
+                fast_abi_size,
+                fast_abi_size,
+                bind<write_component_fast_abi_thunk>(),
+                bind<write_component_fast_abi_vtable>());
 
-        write_endif(w);
+        }
         w.flush_to_file(settings.output_folder + "winrt/fast_forward.h");
     }
 
@@ -68,48 +69,49 @@ namespace cppwinrt
         writer w;
         w.type_namespace = ns;
 
-        write_type_namespace(w, ns);
-        w.write_each<write_enum>(members.enums);
-        w.write_each<write_forward>(members.interfaces);
-        w.write_each<write_forward>(members.classes);
-        w.write_each<write_forward>(members.structs);
-        w.write_each<write_forward>(members.delegates);
-        write_close_namespace(w);
-        write_impl_namespace(w);
-        w.write_each<write_category>(members.interfaces, "interface_category");
-        w.write_each<write_category>(members.classes, "class_category");
-        w.write_each<write_category>(members.enums, "enum_category");
-        w.write_each<write_struct_category>(members.structs);
-        w.write_each<write_category>(members.delegates, "delegate_category");
+        {
+            auto wrap_type = wrap_type_namespace(w, ns);
+            w.write_each<write_enum>(members.enums);
+            w.write_each<write_forward>(members.interfaces);
+            w.write_each<write_forward>(members.classes);
+            w.write_each<write_forward>(members.structs);
+            w.write_each<write_forward>(members.delegates);
+        }
+        {
+            auto wrap_impl = wrap_impl_namespace(w);
+            w.write_each<write_category>(members.interfaces, "interface_category");
+            w.write_each<write_category>(members.classes, "class_category");
+            w.write_each<write_category>(members.enums, "enum_category");
+            w.write_each<write_struct_category>(members.structs);
+            w.write_each<write_category>(members.delegates, "delegate_category");
 
-        // Class names are always required for activation.
-        // Class, enum, and struct names are required for producing GUIDs for generic types.
-        // Interface and delegates names are required for Xaml compatibility.
-        w.write_each<write_name>(members.classes);
-        w.write_each<write_name>(members.enums);
-        w.write_each<write_name>(members.structs);
-        w.write_each<write_name>(members.interfaces);
-        w.write_each<write_name>(members.delegates);
+            // Class names are always required for activation.
+            // Class, enum, and struct names are required for producing GUIDs for generic types.
+            // Interface and delegates names are required for Xaml compatibility.
+            w.write_each<write_name>(members.classes);
+            w.write_each<write_name>(members.enums);
+            w.write_each<write_name>(members.structs);
+            w.write_each<write_name>(members.interfaces);
+            w.write_each<write_name>(members.delegates);
 
-        w.write_each<write_guid>(members.interfaces);
-        w.write_each<write_guid>(members.delegates);
-        w.write_each<write_default_interface>(members.classes);
-        w.write_each<write_interface_abi>(members.interfaces);
-        w.write_each<write_delegate_abi>(members.delegates);
-        w.write_each<write_consume>(members.interfaces);
-        w.write_each<write_struct_abi>(members.structs);
-        write_close_namespace(w);
+            w.write_each<write_guid>(members.interfaces);
+            w.write_each<write_guid>(members.delegates);
+            w.write_each<write_default_interface>(members.classes);
+            w.write_each<write_interface_abi>(members.interfaces);
+            w.write_each<write_delegate_abi>(members.delegates);
+            w.write_each<write_consume>(members.interfaces);
+            w.write_each<write_struct_abi>(members.structs);
+        }
 
-        write_endif(w);
+        write_close_file_guard(w);
         w.swap();
         write_preamble(w);
         write_open_file_guard(w, ns, '0');
 
         for (auto&& depends : w.depends)
         {
-            write_type_namespace(w, depends.first);
+            auto wrap_type = wrap_type_namespace(w, depends.first);
             w.write_each<write_forward>(depends.second);
-            write_close_namespace(w);
         }
 
         w.save_header('0');
@@ -120,11 +122,12 @@ namespace cppwinrt
         writer w;
         w.type_namespace = ns;
 
-        write_type_namespace(w, ns);
-        w.write_each<write_interface>(members.interfaces);
-        write_close_namespace(w);
+        {
+            auto wrap_type = wrap_type_namespace(w, ns);
+            w.write_each<write_interface>(members.interfaces);
+        }
 
-        write_endif(w);
+        write_close_file_guard(w);
         w.swap();
         write_preamble(w);
         write_open_file_guard(w, ns, '1');
@@ -143,14 +146,16 @@ namespace cppwinrt
         writer w;
         w.type_namespace = ns;
 
-        write_type_namespace(w, ns);
-        w.write_each<write_delegate>(members.delegates);
-        bool const promote = write_structs(w, members.structs);
-        w.write_each<write_class>(members.classes);
-        w.write_each<write_interface_override>(members.classes);
-        write_close_namespace(w);
+        bool promote;
+        {
+            auto wrap_type = wrap_type_namespace(w, ns);
+            w.write_each<write_delegate>(members.delegates);
+            promote = write_structs(w, members.structs);
+            w.write_each<write_class>(members.classes);
+            w.write_each<write_interface_override>(members.classes);
+        }
 
-        write_endif(w);
+        write_close_file_guard(w);
         w.swap();
         write_preamble(w);
         write_open_file_guard(w, ns, '2');
@@ -171,32 +176,33 @@ namespace cppwinrt
         writer w;
         w.type_namespace = ns;
 
-        write_impl_namespace(w);
-        w.write_each<write_consume_definitions>(members.interfaces);
-        w.write_each<write_delegate_implementation>(members.delegates);
-        w.write_each<write_produce>(members.interfaces, c);
-        w.write_each<write_dispatch_overridable>(members.classes);
-        write_close_namespace(w);
-
-        write_type_namespace(w, ns);
-        w.write_each<write_enum_operators>(members.enums);
-        w.write_each<write_class_definitions>(members.classes);
-        w.write_each<write_fast_class_base_definitions>(members.classes);
-        w.write_each<write_delegate_definition>(members.delegates);
-        w.write_each<write_interface_override_methods>(members.classes);
-        w.write_each<write_class_override>(members.classes);
-        write_close_namespace(w);
-
-        write_std_namespace(w);
-        write_lean_and_mean(w);
-        w.write_each<write_std_hash>(members.interfaces);
-        w.write_each<write_std_hash>(members.classes);
-        write_endif(w);
-        write_close_namespace(w);
+        {
+            auto wrap_impl = wrap_impl_namespace(w);
+            w.write_each<write_consume_definitions>(members.interfaces);
+            w.param_names = true;
+            w.write_each<write_delegate_implementation>(members.delegates);
+            w.write_each<write_produce>(members.interfaces, c);
+            w.write_each<write_dispatch_overridable>(members.classes);
+        }
+        {
+            auto wrap_type = wrap_type_namespace(w, ns);
+            w.write_each<write_enum_operators>(members.enums);
+            w.write_each<write_class_definitions>(members.classes);
+            w.write_each<write_fast_class_base_definitions>(members.classes);
+            w.write_each<write_delegate_definition>(members.delegates);
+            w.write_each<write_interface_override_methods>(members.classes);
+            w.write_each<write_class_override>(members.classes);
+        }
+        {
+            auto wrap_std = wrap_std_namespace(w);
+            auto wrap_lean = wrap_lean_and_mean(w);
+            w.write_each<write_std_hash>(members.interfaces);
+            w.write_each<write_std_hash>(members.classes);
+        }
 
         write_namespace_special(w, ns, c);
 
-        write_endif(w);
+        write_close_file_guard(w);
         w.swap();
         write_preamble(w);
         write_open_file_guard(w, ns);

--- a/cppwinrt/helpers.h
+++ b/cppwinrt/helpers.h
@@ -200,7 +200,7 @@ namespace cppwinrt
 
     static bool has_fastabi(TypeDef const& type)
     {
-        return settings.fastabi && has_attribute(type, "Windows.Foundation.Metadata", "FastAbiAttribute");
+        return settings.fastabi&& has_attribute(type, "Windows.Foundation.Metadata", "FastAbiAttribute");
     }
 
     static bool is_always_disabled(TypeDef const& type)


### PR DESCRIPTION
Instead of having everybody just whack state variables (which results in a rats nest of "I don't know what state I'm in any more"), use RAII types to scope the state changes.

The changes for `abi_types` exactly match the previous behavior, except that `abi_types` is now `false` during the generation of `write_forward` for forward declarations of types from other namespaces, when it used to be `true`. Fortunately, it doesn't seem to matter, since those forward types don't appear to be affected by the setting of `abi_types`.

Cannot use RAII types for the file guards because we generate the bottom half of the header file before the top half.

The state of `param_names` in `component_writers.h` is still somewhat unclear, so I left that part alone.

Verified that all generated header files (both by `build_projection.cmd` and `Generated Files\*.h`) are identical both before and after this change, even with a private hacked pair of builds that assumed all types supported FastABI (which lights up new code paths).

Aside from the `param_names` issue, this fixes #516 