### PR TITLE
Status() doesn't need a lock

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -375,6 +375,9 @@ namespace winrt::impl
 
         AsyncStatus Status() noexcept
         {
+            // It's okay to race against another thread that is changing the
+            // status. In the case where the promise was published from another
+            // thread, we need acquire in order to preserve causality.
             return m_status.load(std::memory_order_acquire);
         }
 

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -375,7 +375,7 @@ namespace winrt::impl
 
         AsyncStatus Status() noexcept
         {
-            return m_status.load(std::memory_order_relaxed);
+            return m_status.load(std::memory_order_acquire);
         }
 
         hresult ErrorCode() noexcept

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -347,13 +347,13 @@ namespace winrt::impl
 
                 m_completed_assigned = true;
 
-                if (m_status == AsyncStatus::Started)
+                if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Started)
                 {
                     m_completed = make_agile_delegate(handler);
                     return;
                 }
 
-                status = m_status;
+                status = m_status.load(std::memory_order_relaxed);
             }
 
             if (handler)
@@ -375,8 +375,7 @@ namespace winrt::impl
 
         AsyncStatus Status() noexcept
         {
-            slim_lock_guard const guard(m_lock);
-            return m_status;
+            return m_status.load(std::memory_order_relaxed);
         }
 
         hresult ErrorCode() noexcept
@@ -400,9 +399,9 @@ namespace winrt::impl
             {
                 slim_lock_guard const guard(m_lock);
 
-                if (m_status == AsyncStatus::Started)
+                if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Started)
                 {
-                    m_status = AsyncStatus::Canceled;
+                    m_status.store(AsyncStatus::Canceled, std::memory_order_relaxed);
                     m_exception = std::make_exception_ptr(hresult_canceled());
                     cancel = std::move(m_cancel);
                 }
@@ -422,13 +421,13 @@ namespace winrt::impl
         {
             slim_lock_guard const guard(m_lock);
 
-            if (m_status == AsyncStatus::Completed)
+            if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Completed)
             {
                 return static_cast<Derived*>(this)->get_return_value();
             }
 
             rethrow_if_failed();
-            WINRT_ASSERT(m_status == AsyncStatus::Started);
+            WINRT_ASSERT(m_status.load(std::memory_order_relaxed) == AsyncStatus::Started);
             throw hresult_illegal_method_call();
         }
 
@@ -449,13 +448,13 @@ namespace winrt::impl
             {
                 slim_lock_guard const guard(m_lock);
 
-                if (m_status == AsyncStatus::Started)
+                if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Started)
                 {
-                    m_status = AsyncStatus::Completed;
+                    m_status.store(AsyncStatus::Completed, std::memory_order_relaxed);
                 }
 
                 handler = std::move(this->m_completed);
-                status = this->m_status;
+                status = this->m_status.load(std::memory_order_relaxed);
             }
 
             if (handler)
@@ -509,7 +508,7 @@ namespace winrt::impl
         void unhandled_exception() noexcept
         {
             slim_lock_guard const guard(m_lock);
-            WINRT_ASSERT(m_status == AsyncStatus::Started || m_status == AsyncStatus::Canceled);
+            WINRT_ASSERT(m_status.load(std::memory_order_relaxed) == AsyncStatus::Started || m_status.load(std::memory_order_relaxed) == AsyncStatus::Canceled);
             m_exception = std::current_exception();
 
             try
@@ -518,11 +517,11 @@ namespace winrt::impl
             }
             catch (hresult_canceled const&)
             {
-                m_status = AsyncStatus::Canceled;
+                m_status.store(AsyncStatus::Canceled, std::memory_order_relaxed);
             }
             catch (...)
             {
-                m_status = AsyncStatus::Error;
+                m_status.store(AsyncStatus::Error, std::memory_order_relaxed);
             }
         }
 
@@ -552,7 +551,7 @@ namespace winrt::impl
             {
                 slim_lock_guard const guard(m_lock);
 
-                if (m_status != AsyncStatus::Canceled)
+                if (m_status.load(std::memory_order_relaxed) != AsyncStatus::Canceled)
                 {
                     m_cancel = std::move(cancel);
                     return;
@@ -575,7 +574,7 @@ namespace winrt::impl
 
         void rethrow_if_failed() const
         {
-            if (m_status == AsyncStatus::Error || m_status == AsyncStatus::Canceled)
+            if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Error || m_status.load(std::memory_order_relaxed) == AsyncStatus::Canceled)
             {
                 std::rethrow_exception(m_exception);
             }
@@ -585,7 +584,7 @@ namespace winrt::impl
         slim_mutex m_lock;
         async_completed_handler_t<AsyncInterface> m_completed;
         winrt::delegate<> m_cancel;
-        AsyncStatus m_status{ AsyncStatus::Started };
+        std::atomic<AsyncStatus> m_status;
         bool m_completed_assigned{ false };
     };
 }


### PR DESCRIPTION
Reading the status of an IAsyncXxx does not require a lock because the operation is already inherently racy. Change the `m_status` to a `std::atomic` so we can access it from multiple threads without a lock. Everybody who accesses it under a lock can use `std::memory_order_relaxed` because the lock is providing the memory ordering protection. The `Status()` method uses acquire order to handle the case where one thread publishes the IAsyncXxx with release semantics, and another thread picks it up and interrogates the status. Causality requires us to report the status that was published by the first thread, so we need acquire.

Reading the value while another thread is changing it is okay, as long as we get either the entire old value or the entire new value, which is what `std::atomic` guarantees. If we read a stale value, that's okay, because multithreading means that we could have executed a few cycles sooner, in which case the stale value was current at the time.

If anybody makes a decision based on the status, they will have to return to the IAsyncXxx to get the Result or the ErrorCode, and those will take the lock and ensure consistency of the other protected members.

This change remove a lock from the `await_transform` method, which would otherwise need to be entered (and exited) at every `co_await` operation. The code sequence

```
    lea      rcx, this->m_mutex
    call     AcquireSRWLockExclusive
    mov      rdi, this->m_status
    lea      rcx, this->m_mutex
    call     ReleaseSRWLockExclusive
    cmp      rdi, 2
    jz       throw_cancelled
```

becomes

```
    cmp      this->m_status, 2
    jz       throw_cancelled
```

which avoids two calls, frees up a nonvolatile register, and avoid a spill of volatile registers.

Relaxed order access to atomics is implemented as a simple load or store on all supported platforms, so the change from a simple variable to a `std::atomic` has no code generation effect for all of the other uses.