### PR TITLE
Fix some visualizer crashes and misbehavior

### DIFF
--- a/natvis/cppwinrtvisualizer.vcxproj
+++ b/natvis/cppwinrtvisualizer.vcxproj
@@ -205,10 +205,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.*\inc\VSDebugEng.h" />
-    <ClInclude Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.*\inc\vsdebugeng.templates.h" />
     <ClInclude Include="object_visualizer.h" />
     <ClInclude Include="cppwinrt_visualizer.h" />
+    <ClInclude Include="packages\Microsoft.VSSDK.Debugger.VSDebugEng.16.0.2012201-preview\inc\VSDebugEng.h" />
+    <ClInclude Include="packages\Microsoft.VSSDK.Debugger.VSDebugEng.16.0.2012201-preview\inc\vsdebugeng.templates.h" />
     <ClInclude Include="property_visualizer.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
@@ -238,9 +238,7 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.*\content\vsdconfig.xsd">
+    <None Include="packages\Microsoft.VSSDK.Debugger.VSDConfigTool.16.0.2012201-preview\content\vsdconfig.xsd">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/natvis/object_visualizer.cpp
+++ b/natvis/object_visualizer.cpp
@@ -583,22 +583,25 @@ HRESULT object_visualizer::GetChildren(
 )
 {
     // Ignore metadata errors to ensure that Raw Data is always available
-    try
+    if (m_propertyData.empty())
     {
-        GetPropertyData();
-    }
-    catch (std::invalid_argument const& e)
-    {
-        std::string_view message(e.what());
-        NatvisDiagnostic(m_pVisualizedExpression.get(),
-            std::wstring(L"Exception in object_visualizer::GetPropertyData: ") +
+        try
+        {
+            GetPropertyData();
+        }
+        catch (std::invalid_argument const& e)
+        {
+            std::string_view message(e.what());
+            NatvisDiagnostic(m_pVisualizedExpression.get(),
+                std::wstring(L"Exception in object_visualizer::GetPropertyData: ") +
                 std::wstring(message.begin(), message.end()),
-            NatvisDiagnosticLevel::Error, to_hresult());
-    }
-    catch (...)
-    {
-        NatvisDiagnostic(m_pVisualizedExpression.get(),
-            L"Exception in object_visualizer::GetPropertyData", NatvisDiagnosticLevel::Error, to_hresult());
+                NatvisDiagnosticLevel::Error, to_hresult());
+        }
+        catch (...)
+        {
+            NatvisDiagnostic(m_pVisualizedExpression.get(),
+                L"Exception in object_visualizer::GetPropertyData", NatvisDiagnosticLevel::Error, to_hresult());
+        }
     }
 
     com_ptr<DkmEvaluationResultEnumContext> pEnumContext;


### PR DESCRIPTION
Users trying to debug Xaml apps were having issues that rendered the debugging experience unusable. Namely:

- Generic types in the property list would throw an exception, closing down the visualizer pane.
- Properties of type "System.Object" (aka IInspectable) weren't handled properly, causing undefined behavior via uninitialized variables. This was causing crashes and other bizarre behavior in the visualizer.
- Types that had more than one page of properties would repeatedly recreate and append the properties to the list when the debugger requested more of the list, causing the list to grow endlessly.

In this change:
- Generics changed from throwing to omitting, with a diagnostic message.
- IInspectable properties changed from bad behavior to omitting, with a diagnostic message. (If anybody has pointers on how to enable them, I'm listening).
- We only create the property list once for a type/object.

I tested this by excercising scenarios that were previously blowing up the visualizer. Specifically, setting a breakpoint in a Xaml Button click handler, and trying to inspect the "sender" object. This sender is a Xaml Button, and so its property list satisfies all three conditions: it has generics, IInspectables, and a long list of properties that requires the debugger to make multiple requests.