### PR TITLE
Add ODR detection to WINRT_NO_MAKE_DETECTION

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1,3 +1,10 @@
+#if defined(_MSC_VER)
+#if defined(_DEBUG) && !defined(WINRT_NO_MAKE_DETECTION)
+#pragma detect_mismatch("C++/WinRT WINRT_NO_MAKE_DETECTION", "make detection enabled (DEBUG and !WINRT_NO_MAKE_DETECTION)")
+#else
+#pragma detect_mismatch("C++/WinRT WINRT_NO_MAKE_DETECTION", "make detection disabled (!DEBUG or WINRT_NO_MAKE_DETECTION)")
+#endif
+#endif
 
 namespace winrt::impl
 {

--- a/test/test/no_make_detection.cpp
+++ b/test/test/no_make_detection.cpp
@@ -1,48 +1,10 @@
-// This test validates that defining WINRT_NO_MAKE_DETECTION actually
-// allows an implementation to be final and have a private destructor.
-// This is *not* recommended as there are no safeguards for direct and
-// invalid allocations, but is provided for compatibility.
-
-#define WINRT_NO_MAKE_DETECTION
-#include "catch.hpp"
-#include "winrt/Windows.Foundation.h"
+#include "pch.h"
+#include "winrt/test_component.h"
 
 using namespace winrt;
-using namespace Windows::Foundation;
-
-namespace
-{
-    struct Stringable final : implements<Stringable, IStringable>
-    {
-        hstring ToString()
-        {
-            return L"Stringable";
-        }
-
-        inline static bool Destroyed{};
-
-    private:
-
-        ~Stringable()
-        {
-            Destroyed = true;
-        }
-    };
-}
+using namespace test_component;
 
 TEST_CASE("no_make_detection")
 {
-    {
-        IStringable stringable{ (new Stringable())->get_abi<IStringable>(), take_ownership_from_abi };
-        REQUIRE(!Stringable::Destroyed);
-        stringable = nullptr;
-        REQUIRE(Stringable::Destroyed);
-    }
-    {
-        Stringable::Destroyed = false;
-        IStringable stringable = make<Stringable>();
-        REQUIRE(!Stringable::Destroyed);
-        stringable = nullptr;
-        REQUIRE(Stringable::Destroyed);
-    }
+    REQUIRE(test_component::Class::TestNoMakeDetection());
 }

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -410,16 +410,7 @@
     <ClCompile Include="names.cpp" />
     <ClCompile Include="noexcept.cpp" />
     <ClCompile Include="notify_awaiter.cpp" />
-    <ClCompile Include="no_make_detection.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="no_make_detection.cpp" />
     <ClCompile Include="numerics.cpp" />
     <ClCompile Include="out_params.cpp" />
     <ClCompile Include="out_params_abi.cpp" />

--- a/test/test_component/Class.cpp
+++ b/test/test_component/Class.cpp
@@ -471,4 +471,48 @@ namespace winrt::test_component::implementation
         co_await args->wait_for_deferrals();
         co_return args->m_counter;
     }
+
+    // This test validates that defining WINRT_NO_MAKE_DETECTION actually
+    // allows an implementation to be final and have a private destructor.
+    // This is *not* recommended as there are no safeguards for direct and
+    // invalid allocations, but is provided for compatibility.
+
+    bool Class::TestNoMakeDetection()
+    {
+        static bool Destroyed{};
+
+        struct Stringable final : implements<Stringable, IStringable>
+        {
+            hstring ToString()
+            {
+                return L"Stringable";
+            }
+
+        private:
+
+            ~Stringable()
+            {
+                Destroyed = true;
+            }
+        };
+
+        bool pass = true;
+
+        {
+            Destroyed = false;
+            IStringable stringable{ (new Stringable())->get_abi<IStringable>(), take_ownership_from_abi };
+            pass = pass && !Destroyed;
+
+            stringable = nullptr;
+            pass = pass && Destroyed;
+        }
+        {
+            Destroyed = false;
+            IStringable stringable = make<Stringable>();
+            pass = pass && !Destroyed;
+            stringable = nullptr;
+            pass = pass && Destroyed;
+        }
+        return pass;
+    }
 }

--- a/test/test_component/Class.h
+++ b/test/test_component/Class.h
@@ -111,6 +111,8 @@ namespace winrt::test_component::implementation
         event_token DeferrableEvent(Windows::Foundation::TypedEventHandler<test_component::Class, test_component::DeferrableEventArgs> const& handler);
         void DeferrableEvent(event_token const& token);
         Windows::Foundation::IAsyncOperation<int> RaiseDeferrableEventAsync();
+
+        static bool TestNoMakeDetection();
     private:
 
         bool m_fail{};

--- a/test/test_component/pch.h
+++ b/test/test_component/pch.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #define WINRT_LEAN_AND_MEAN
+#define WINRT_NO_MAKE_DETECTION // for test in Class.cpp
 #include <numeric>
 #include <winrt/Windows.Foundation.h>

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -148,6 +148,8 @@ namespace test_component
 
         event Windows.Foundation.TypedEventHandler<Class, DeferrableEventArgs> DeferrableEvent;
         Windows.Foundation.IAsyncOperation<Int32> RaiseDeferrableEventAsync();
+
+        static Boolean TestNoMakeDetection();
     }
 
     namespace Structs

--- a/test/test_win7/no_make_detection.cpp
+++ b/test/test_win7/no_make_detection.cpp
@@ -1,48 +1,10 @@
-// This test validates that defining WINRT_NO_MAKE_DETECTION actually
-// allows an implementation to be final and have a private destructor.
-// This is *not* recommended as there are no safeguards for direct and
-// invalid allocations, but is provided for compatibility.
-
-#define WINRT_NO_MAKE_DETECTION
-#include "catch.hpp"
-#include "winrt/Windows.Foundation.h"
+#include "pch.h"
+#include "winrt/test_component.h"
 
 using namespace winrt;
-using namespace Windows::Foundation;
-
-namespace
-{
-    struct Stringable final : implements<Stringable, IStringable>
-    {
-        hstring ToString()
-        {
-            return L"Stringable";
-        }
-
-        inline static bool Destroyed{};
-
-    private:
-
-        ~Stringable()
-        {
-            Destroyed = true;
-        }
-    };
-}
+using namespace test_component;
 
 TEST_CASE("no_make_detection")
 {
-    {
-        IStringable stringable{ (new Stringable())->get_abi<IStringable>(), take_ownership_from_abi };
-        REQUIRE(!Stringable::Destroyed);
-        stringable = nullptr;
-        REQUIRE(Stringable::Destroyed);
-    }
-    {
-        Stringable::Destroyed = false;
-        IStringable stringable = make<Stringable>();
-        REQUIRE(!Stringable::Destroyed);
-        stringable = nullptr;
-        REQUIRE(Stringable::Destroyed);
-    }
+    REQUIRE(test_component::Class::TestNoMakeDetection());
 }

--- a/test/test_win7/test_win7.vcxproj
+++ b/test/test_win7/test_win7.vcxproj
@@ -358,9 +358,7 @@
     </ClCompile>
     <ClCompile Include="names.cpp" />
     <ClCompile Include="noexcept.cpp" />
-    <ClCompile Include="no_make_detection.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="no_make_detection.cpp" />
     <ClCompile Include="numerics.cpp" />
     <ClCompile Include="out_params.cpp" />
     <ClCompile Include="parent_includes.cpp" />


### PR DESCRIPTION
Mismatching `WINRT_NO_MAKE_DETECTION` results in inconsistent vtables and very confusing runtime crashes. Detect the problem at link time.

`pragma detect_mismatch` must occur at global scope, so we float it to the top of `base_implements.h` even though it would more logically be placed at the point of declaration of the bonus virtual member.

This change uncovered the fact that `test` and `test_win7` had portions built with and without `WINRT_NO_MAKE_DETECTION`, so it was already violating ODR. Moved the `WINRT_NO_MAKE_DETECTION` to the test component and make the entire test component enable `WINRT_NO_MAKE_DETECTION`.

The symbol `WINRT_LEAN_AND_MEAN` does not require ODR protection because it excludes entire functions and classes, rather than rewriting pieces of existing functions and classes.

Technically, `WINRT_IMPL_IUNKNOWN_DEFINED` and `__IInspectable_INTERFACE_DEFINED__ ` are also subject to ODR due to how it changes the definition of some type traits classes some types in the `winrt::impl` namespace, and activates some member functions and specializations. In practice, this isn't a problem because the type traits classes are constexpr (and therefore follow the settings of the current translation unit), and the other issues, if conflicting, trigger linkage errors.