### PR TITLE
Multithreading tests: Add dummy definition to keep compiler happy

### DIFF
--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -237,6 +237,17 @@ namespace concurrent_collections
     {
         return it += offset;
     }
+
+    // Dummy definition to keep compiler happy. Instantiated by the
+    // constructor whose purpose is to offer an implicit conversion from
+    // non-const iterator to const iterator. When applied to a const
+    // iterator, it offers implicit construction from this garbage type
+    // to const iterator (triggering its instantiation), but then the constructor
+    // is deleted by SFINAE, so the type is never actually created at runtime.
+    template<typename Container>
+    struct concurrency_checked_random_access_iterator<Container, void, void>
+    {
+    };
 #pragma endregion
 
     struct concurrency_guard

--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -238,12 +238,12 @@ namespace concurrent_collections
         return it += offset;
     }
 
-    // Dummy definition to keep compiler happy. Instantiated by the
-    // constructor whose purpose is to offer an implicit conversion from
+    // We have a constructor whose purpose is to offer an implicit conversion from
     // non-const iterator to const iterator. When applied to a const
     // iterator, it offers implicit construction from this garbage type
     // to const iterator (triggering its instantiation), but then the constructor
     // is deleted by SFINAE, so the type is never actually created at runtime.
+    // This specialization is necessary so that the garbage instantiation succeeds.
     template<typename Container>
     struct concurrency_checked_random_access_iterator<Container, void, void>
     {


### PR DESCRIPTION
This type is instantiated by the deleted constructor whose original purpose is to allow an implicit conversion from non-const iterator to const iterator. When applied to the const iterator itself, it enables an implicit conversion from garbage to const iterator. The conversion is deleted, but the compiler still instantiates it, so we define the type to keep everybody happy.