### PR TITLE
Targets that add compiler options must run before FixupCLCompileOptions

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -82,9 +82,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <BeforeClCompileTargets>
             $(BeforeClCompileTargets);CppWinRTAddXamlMetaDataProviderCpp;CppWinRTMakeProjections;
         </BeforeClCompileTargets>
+
+        <!-- Ensure ComputeCompileInputsTargets runs at the end so that FixupCLCompileOptions is the last to run -->
         <ComputeCompileInputsTargets>
-            $(ComputeCompileInputsTargets);CppWinRTComputeXamlGeneratedCompileInputs;CppWinRTHeapEnforcementOptOut;
+            CppWinRTComputeXamlGeneratedCompileInputs;CppWinRTHeapEnforcementOptOut;$(ComputeCompileInputsTargets);
         </ComputeCompileInputsTargets>
+
         <MarkupCompilePass1DependsOn>
             $(MarkupCompilePass1DependsOn);CppWinRTAddXamlReferences
         </MarkupCompilePass1DependsOn>
@@ -94,7 +97,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CleanDependsOn>
             $(CleanDependsOn);CppWinRTClean
         </CleanDependsOn>
-        
+
     </PropertyGroup>
 
     <!-- For a static library we don't want the winmd/lib/pdb to be packaged -->

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -85,7 +85,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         <!-- Ensure ComputeCompileInputsTargets runs at the end so that FixupCLCompileOptions is the last to run -->
         <ComputeCompileInputsTargets>
-            CppWinRTComputeXamlGeneratedCompileInputs;CppWinRTHeapEnforcementOptOut;$(ComputeCompileInputsTargets);
+            CppWinRTComputeXamlGeneratedCompileInputs;$(ComputeCompileInputsTargets);CppWinRTHeapEnforcementOptOut;
         </ComputeCompileInputsTargets>
 
         <MarkupCompilePass1DependsOn>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -127,7 +127,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Delete Files="@(_FilesToDelete)"/>
     </Target>
 
-    <Target Name="CppWinRTHeapEnforcementOptOut" Condition="'@(ClCompile)' != ''" BeforeTargets="FixupCLCompileOptions">
+    <Target Name="CppWinRTHeapEnforcementOptOut" Condition="'@(ClCompile)' != ''">
         <ItemGroup Condition="'$(CppWinRTHeapEnforcement)'=='' and ('@(Page)' != '' Or '@(ApplicationDefinition)' != '')">
             <ClCompile>
                 <AdditionalOptions>%(ClCompile.AdditionalOptions) /DWINRT_NO_MAKE_DETECTION</AdditionalOptions>
@@ -359,8 +359,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTComputeXamlGeneratedCompileInputs"
             DependsOnTargets="$(CppWinRTComputeXamlGeneratedCompileInputsDependsOn)"
-            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT' and '$(CppWinRTAddXamlMetaDataProviderIdl)' == 'true'"
-            BeforeTargets="FixupCLCompileOptions">
+            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT' and '$(CppWinRTAddXamlMetaDataProviderIdl)' == 'true'">
         <ItemGroup>
             <ClCompile Remove="$(XamlMetaDataProviderCpp)" />
             <ClCompile Include="$(XamlMetaDataProviderCpp)" Condition="'$(CppWinRTOptimized)'=='true'">

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -94,7 +94,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CleanDependsOn>
             $(CleanDependsOn);CppWinRTClean
         </CleanDependsOn>
-
+        
     </PropertyGroup>
 
     <!-- For a static library we don't want the winmd/lib/pdb to be packaged -->
@@ -124,7 +124,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <Delete Files="@(_FilesToDelete)"/>
     </Target>
 
-    <Target Name="CppWinRTHeapEnforcementOptOut" Condition="'@(ClCompile)' != ''">
+    <Target Name="CppWinRTHeapEnforcementOptOut" Condition="'@(ClCompile)' != ''" BeforeTargets="FixupCLCompileOptions">
         <ItemGroup Condition="'$(CppWinRTHeapEnforcement)'=='' and ('@(Page)' != '' Or '@(ApplicationDefinition)' != '')">
             <ClCompile>
                 <AdditionalOptions>%(ClCompile.AdditionalOptions) /DWINRT_NO_MAKE_DETECTION</AdditionalOptions>
@@ -356,7 +356,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Note that Condition is evaluated before DependsOnTargets are run -->
     <Target Name="CppWinRTComputeXamlGeneratedCompileInputs"
             DependsOnTargets="$(CppWinRTComputeXamlGeneratedCompileInputsDependsOn)"
-            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT' and '$(CppWinRTAddXamlMetaDataProviderIdl)' == 'true'">
+            Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT' and '$(CppWinRTAddXamlMetaDataProviderIdl)' == 'true'"
+            BeforeTargets="FixupCLCompileOptions">
         <ItemGroup>
             <ClCompile Remove="$(XamlMetaDataProviderCpp)" />
             <ClCompile Include="$(XamlMetaDataProviderCpp)" Condition="'$(CppWinRTOptimized)'=='true'">


### PR DESCRIPTION
Fixes #741 
This is hit when forcing proc count in msbuild since /MP should also imply /FS (force synchronous writes) but that enforcement is done by `FixupCLCompileOptions` after all other `ComputeCompileInputsTargets` runs. If something runs after the fix up has already happened, we break the build (`Error C1041: cannot open program database`)