### PR TITLE
C++20 coroutine support

### DIFF
--- a/scratch/scratch.vcxproj
+++ b/scratch/scratch.vcxproj
@@ -129,7 +129,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -151,7 +151,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -171,7 +171,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -191,7 +191,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -211,7 +211,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -233,7 +233,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -257,7 +257,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -281,7 +281,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\..\..\library</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -100,7 +100,7 @@ namespace winrt::impl
 
     struct disconnect_aware_handler
     {
-        disconnect_aware_handler(std::experimental::coroutine_handle<> handle) noexcept
+        disconnect_aware_handler(coroutine_handle<> handle) noexcept
             : m_handle(handle) { }
 
         disconnect_aware_handler(disconnect_aware_handler&& other) noexcept
@@ -119,7 +119,7 @@ namespace winrt::impl
 
     private:
         resume_apartment_context m_context;
-        std::experimental::coroutine_handle<> m_handle;
+        coroutine_handle<> m_handle;
 
         void Complete()
         {
@@ -148,7 +148,7 @@ namespace winrt::impl
             return false;
         }
 
-        void await_suspend(std::experimental::coroutine_handle<> handle)
+        void await_suspend(coroutine_handle<> handle)
         {
             auto extend_lifetime = async;
             async.Completed([this, handler = disconnect_aware_handler{ handle }](auto&&, auto operation_status) mutable
@@ -282,7 +282,7 @@ namespace winrt::impl
             return true;
         }
 
-        void await_suspend(std::experimental::coroutine_handle<>) const noexcept
+        void await_suspend(coroutine_handle<>) const noexcept
         {
         }
 
@@ -324,7 +324,7 @@ namespace winrt::impl
             return true;
         }
 
-        void await_suspend(std::experimental::coroutine_handle<>) const noexcept
+        void await_suspend(coroutine_handle<>) const noexcept
         {
         }
 
@@ -355,7 +355,7 @@ namespace winrt::impl
             if (remaining == 0)
             {
                 std::atomic_thread_fence(std::memory_order_acquire);
-                std::experimental::coroutine_handle<Derived>::from_promise(*static_cast<Derived*>(this)).destroy();
+                coroutine_handle<Derived>::from_promise(*static_cast<Derived*>(this)).destroy();
             }
 
             return remaining;
@@ -496,7 +496,7 @@ namespace winrt::impl
             }
         }
 
-        std::experimental::suspend_never initial_suspend() const noexcept
+        suspend_never initial_suspend() const noexcept
         {
             return{};
         }
@@ -514,7 +514,7 @@ namespace winrt::impl
             {
             }
 
-            bool await_suspend(std::experimental::coroutine_handle<>) const noexcept
+            bool await_suspend(coroutine_handle<>) const noexcept
             {
                 promise->set_completed();
                 uint32_t const remaining = promise->subtract_reference();
@@ -629,7 +629,11 @@ namespace winrt::impl
     };
 }
 
-WINRT_EXPORT namespace std::experimental
+#ifdef __cpp_lib_coroutine
+namespace std
+#else
+namespace std::experimental
+#endif
 {
     template <typename... Args>
     struct coroutine_traits<winrt::Windows::Foundation::IAsyncAction, Args...>

--- a/strings/base_coroutine_system.h
+++ b/strings/base_coroutine_system.h
@@ -23,7 +23,7 @@ WINRT_EXPORT namespace winrt
                 return m_queued;
             }
 
-            bool await_suspend(std::experimental::coroutine_handle<> handle)
+            bool await_suspend(impl::coroutine_handle<> handle)
             {
                 return m_dispatcher.TryEnqueue(m_priority, [handle, this]
                     {

--- a/strings/base_coroutine_system_winui.h
+++ b/strings/base_coroutine_system_winui.h
@@ -23,7 +23,7 @@ WINRT_EXPORT namespace winrt
                 return m_queued;
             }
 
-            bool await_suspend(std::experimental::coroutine_handle<> handle)
+            bool await_suspend(impl::coroutine_handle<> handle)
             {
                 return m_dispatcher.TryEnqueue(m_priority, [handle, this]
                     {

--- a/strings/base_coroutine_ui_core.h
+++ b/strings/base_coroutine_ui_core.h
@@ -22,7 +22,7 @@ WINRT_EXPORT namespace winrt
             {
             }
 
-            void await_suspend(std::experimental::coroutine_handle<> handle) const
+            void await_suspend(impl::coroutine_handle<> handle) const
             {
                 m_dispatcher.RunAsync(m_priority, [handle]
                     {

--- a/strings/base_deferral.h
+++ b/strings/base_deferral.h
@@ -22,7 +22,7 @@ WINRT_EXPORT namespace winrt
 
         [[nodiscard]] Windows::Foundation::IAsyncAction wait_for_deferrals()
         {
-            struct awaitable : std::experimental::suspend_always
+            struct awaitable : impl::suspend_always
             {
                 bool await_suspend(coroutine_handle handle)
                 {
@@ -37,7 +37,7 @@ WINRT_EXPORT namespace winrt
 
     private:
 
-        using coroutine_handle = std::experimental::coroutine_handle<>;
+        using coroutine_handle = impl::coroutine_handle<>;
 
         void one_deferral_completed()
         {


### PR DESCRIPTION
Fixes #676

With this update, C++/WinRT supports both C++17 with `/await` as well as C++20 coroutine support. 