### PR TITLE
VS 2017 compatibility for enable_await_cancellation

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -174,7 +174,7 @@ WINRT_EXPORT namespace winrt
     struct enable_await_cancellation
     {
         enable_await_cancellation() noexcept = default;
-        enable_await_cancellation(enable_await_cancellation const&) = delete;
+        enable_await_cancellation(enable_await_cancellation const&) = default;
 
         ~enable_await_cancellation()
         {
@@ -223,7 +223,7 @@ namespace winrt::impl
     {
         decltype(get_awaiter(std::declval<T&&>())) awaitable;
 
-        notify_awaiter(T&& awaitable_arg, cancellable_promise* promise = nullptr) : awaitable(get_awaiter(static_cast<T&&>(awaitable_arg)))
+        notify_awaiter(T&& awaitable_arg, [[maybe_unused]] cancellable_promise* promise = nullptr) : awaitable(get_awaiter(static_cast<T&&>(awaitable_arg)))
         {
             if constexpr (std::is_convertible_v<std::remove_reference_t<decltype(awaitable)>&, enable_await_cancellation&>)
             {


### PR DESCRIPTION
VS 2017 requires an accessible copy constructor even though it is never used. Turns out we're okay with `enable_await_cancellation` being copied, as long as it's not copied while awaiting (which we don't do). So go ahead and let it be copyable.

VS 2017 also reports an unused variable error when the use of the `promise` is removed via `if constexpr`. Mark it as `[[maybe_unused]]` to help the compiler.