### PR TITLE
add try_get_activation_factory overloads that take the runtimeclass name

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -401,9 +401,8 @@ namespace winrt::impl
     }
 
     template <typename Interface = Windows::Foundation::IActivationFactory>
-    com_ref<Interface> try_get_activation_factory(std::wstring_view className, hresult_error* exception = nullptr) noexcept
+    com_ref<Interface> try_get_activation_factory(param::hstring const& name, hresult_error* exception = nullptr) noexcept
     {
-        param::hstring const name{ className };
         void* result{};
         hresult const hr = get_runtime_activation_factory<Interface>(name, &result);
 
@@ -463,7 +462,7 @@ WINRT_EXPORT namespace winrt
     {
         // Normally, the callback avoids having to return a ref-counted object and the resulting AddRef/Release bump.
         // In this case we do want a unique reference, so we use the lambda to return one and thus produce an
-        // AddRef'd object that is returned to the caller. 
+        // AddRef'd object that is returned to the caller.
         return impl::call_factory<Class, Interface>([](auto&& factory)
         {
             return factory;
@@ -473,23 +472,23 @@ WINRT_EXPORT namespace winrt
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>
     auto try_get_activation_factory() noexcept
     {
-        return impl::try_get_activation_factory<Interface>(winrt::name_of<Class>());
+        return impl::try_get_activation_factory<Interface>(name_of<Class>());
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>
     auto try_get_activation_factory(hresult_error& exception) noexcept
     {
-        return impl::try_get_activation_factory<Interface>(winrt::name_of<Class>(), &exception);
+        return impl::try_get_activation_factory<Interface>(name_of<Class>(), &exception);
     }
 
     template <typename Interface = Windows::Foundation::IActivationFactory>
-    auto try_get_activation_factory(std::wstring_view name) noexcept
+    auto try_get_activation_factory(param::hstring const& name) noexcept
     {
         return impl::try_get_activation_factory<Interface>(name);
     }
 
     template <typename Interface = Windows::Foundation::IActivationFactory>
-    auto try_get_activation_factory(std::wstring_view name, hresult_error& exception) noexcept
+    auto try_get_activation_factory(param::hstring const& name, hresult_error& exception) noexcept
     {
         return impl::try_get_activation_factory<Interface>(name, &exception);
     }

--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -400,10 +400,10 @@ namespace winrt::impl
         return factory.call(static_cast<CastType>(callback));
     }
 
-    template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>
-    com_ref<Interface> try_get_activation_factory(hresult_error* exception = nullptr) noexcept
+    template <typename Interface = Windows::Foundation::IActivationFactory>
+    com_ref<Interface> try_get_activation_factory(std::wstring_view className, hresult_error* exception = nullptr) noexcept
     {
-        param::hstring const name{ name_of<Class>() };
+        param::hstring const name{ className };
         void* result{};
         hresult const hr = get_runtime_activation_factory<Interface>(name, &result);
 
@@ -473,13 +473,25 @@ WINRT_EXPORT namespace winrt
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>
     auto try_get_activation_factory() noexcept
     {
-        return impl::try_get_activation_factory<Class, Interface>();
+        return impl::try_get_activation_factory<Interface>(winrt::name_of<Class>());
     }
 
     template <typename Class, typename Interface = Windows::Foundation::IActivationFactory>
     auto try_get_activation_factory(hresult_error& exception) noexcept
     {
-        return impl::try_get_activation_factory<Class, Interface>(&exception);
+        return impl::try_get_activation_factory<Interface>(winrt::name_of<Class>(), &exception);
+    }
+
+    template <typename Interface = Windows::Foundation::IActivationFactory>
+    auto try_get_activation_factory(std::wstring_view name) noexcept
+    {
+        return impl::try_get_activation_factory<Interface>(name);
+    }
+
+    template <typename Interface = Windows::Foundation::IActivationFactory>
+    auto try_get_activation_factory(std::wstring_view name, hresult_error& exception) noexcept
+    {
+        return impl::try_get_activation_factory<Interface>(name, &exception);
     }
 
     inline void clear_factory_cache() noexcept

--- a/test/old_tests/UnitTests/get_activation_factory.cpp
+++ b/test/old_tests/UnitTests/get_activation_factory.cpp
@@ -26,16 +26,17 @@ TEST_CASE("get_activation_factory")
     REQUIRE_THROWS_AS(get_activation_factory(L"Composable.DoesNotExist"), hresult_class_not_registered);
 }
 
+// Used to test whether the IRestrictedErrorInfo was left on the thread
+auto get_error_info()
+{
+    com_ptr<IErrorInfo> info;
+    GetErrorInfo(0, info.put());
+    return info.as<impl::IRestrictedErrorInfo>();
+}
+
+
 TEST_CASE("try_get_activation_factory")
 {
-    // Used to test whether the IRestrictedErrorInfo was left on the thread
-    auto get_error_info = []
-    {
-        com_ptr<IErrorInfo> info;
-        GetErrorInfo(0, info.put());
-        return info.as<impl::IRestrictedErrorInfo>();
-    };
-
     // Try successfully
     {
         auto factory = try_get_activation_factory<Component::Errors>();
@@ -62,6 +63,40 @@ TEST_CASE("try_get_activation_factory")
     {
         hresult_error e;
         auto factory = try_get_activation_factory<Component::IErrors>(e);
+        REQUIRE(factory == nullptr);
+        REQUIRE(get_error_info() == nullptr);
+        REQUIRE(e.code() == REGDB_E_CLASSNOTREG);
+    }
+}
+
+TEST_CASE("try_get_activation_factory_with_names")
+{
+    // Try successfully
+    {
+        auto factory = try_get_activation_factory(winrt::name_of<Component::Errors>());
+        REQUIRE(factory != nullptr);
+        REQUIRE(get_error_info() == nullptr);
+    }
+
+    // Try unsuccessfully
+    {
+        auto factory = try_get_activation_factory(winrt::name_of<Component::IErrors>());
+        REQUIRE(factory == nullptr);
+        REQUIRE(get_error_info() == nullptr);
+    }
+
+    // Try successfully with error info
+    {
+        hresult_error e;
+        auto factory = try_get_activation_factory(winrt::name_of<Component::Errors>());
+        REQUIRE(factory != nullptr);
+        REQUIRE(get_error_info() == nullptr);
+    }
+
+    // Try unsuccessfully with error info
+    {
+        hresult_error e;
+        auto factory = try_get_activation_factory(winrt::name_of<Component::IErrors>(), e);
         REQUIRE(factory == nullptr);
         REQUIRE(get_error_info() == nullptr);
         REQUIRE(e.code() == REGDB_E_CLASSNOTREG);

--- a/test/old_tests/UnitTests/get_activation_factory.cpp
+++ b/test/old_tests/UnitTests/get_activation_factory.cpp
@@ -88,7 +88,7 @@ TEST_CASE("try_get_activation_factory_with_names")
     // Try successfully with error info
     {
         hresult_error e;
-        auto factory = try_get_activation_factory(winrt::name_of<Component::Errors>());
+        auto factory = try_get_activation_factory(winrt::name_of<Component::Errors>(), e);
         REQUIRE(factory != nullptr);
         REQUIRE(get_error_info() == nullptr);
     }


### PR DESCRIPTION
We have a design pattern "extension classes" that uses runtimeclasses as extensions. The class names are discovered at runtime, so we need to be able to specify them to the activation functions. this adds that support. 