### PR TITLE
std::filesystem::canonical fails when running on a RAM drive

### DIFF
--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -414,11 +414,13 @@ namespace cppwinrt
             {
                 if (std::filesystem::is_directory(path))
                 {
-                    try
+                    std::error_code ec;
+                    auto canPath = std::filesystem::canonical(path, ec);
+                    if (!ec)
                     {
-                        add_directory(std::filesystem::canonical(path));
+                        add_directory(canPath);
                     }
-                    catch (std::filesystem::filesystem_error const&)
+                    else
                     {
                         // If canonical fails try using the provided path directly
                         add_directory(path);
@@ -428,11 +430,13 @@ namespace cppwinrt
 
                 if (std::filesystem::is_regular_file(path))
                 {
-                    try
+                    std::error_code ec;
+                    auto canPath = std::filesystem::canonical(path, ec);
+                    if (!ec)
                     {
-                        files.insert(std::filesystem::canonical(path).string());
+                        files.insert(canPath.string());
                     }
-                    catch (std::filesystem::filesystem_error const&)
+                    else
                     {
                         // If canonical fails try using the provided path directly
                         files.insert(path);

--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -414,13 +414,29 @@ namespace cppwinrt
             {
                 if (std::filesystem::is_directory(path))
                 {
-                    add_directory(std::filesystem::canonical(path));
+                    try
+                    {
+                        add_directory(std::filesystem::canonical(path));
+                    }
+                    catch (std::filesystem::filesystem_error const&)
+                    {
+                        // If canonical fails try using the provided path directly
+                        add_directory(path);
+                    }
                     continue;
                 }
 
                 if (std::filesystem::is_regular_file(path))
                 {
-                    files.insert(std::filesystem::canonical(path).string());
+                    try
+                    {
+                        files.insert(std::filesystem::canonical(path).string());
+                    }
+                    catch (std::filesystem::filesystem_error const&)
+                    {
+                        // If canonical fails try using the provided path directly
+                        files.insert(path);
+                    }
                     continue;
                 }
                 if (path == "local")

--- a/cppwinrt/main.cpp
+++ b/cppwinrt/main.cpp
@@ -92,7 +92,15 @@ Where <spec> is one or more of:
 
         path output_folder = args.value("output");
         create_directories(output_folder / "winrt/impl");
-        settings.output_folder = canonical(output_folder).string();
+        try
+        {
+            settings.output_folder = canonical(output_folder).string();
+        }
+        catch(std::filesystem::filesystem_error const&)
+        {
+            // If canonical fails try using the provided path directly
+            settings.output_folder = output_folder.string();
+        }
         settings.output_folder += '\\';
 
         for (auto && include : args.values("include"))
@@ -144,7 +152,15 @@ Where <spec> is one or more of:
             if (!component.empty())
             {
                 create_directories(component);
-                settings.component_folder = canonical(component).string();
+                try
+                {
+                    settings.component_folder = canonical(component).string();
+                }
+                catch (std::filesystem::filesystem_error const&)
+                {
+                    // If canonical fails try using the provided path directly
+                    settings.component_folder = component;
+                }
                 settings.component_folder += '\\';
             }
         }

--- a/cppwinrt/main.cpp
+++ b/cppwinrt/main.cpp
@@ -92,11 +92,10 @@ Where <spec> is one or more of:
 
         path output_folder = args.value("output");
         create_directories(output_folder / "winrt/impl");
-        try
-        {
-            settings.output_folder = canonical(output_folder).string();
-        }
-        catch(std::filesystem::filesystem_error const&)
+
+        std::error_code ec;
+        settings.output_folder = canonical(output_folder, ec).string();
+        if (ec)
         {
             // If canonical fails try using the provided path directly
             settings.output_folder = output_folder.string();


### PR DESCRIPTION
std::filesystem::canonical can fail due a driver not properly implementing support for __std_fs_get_final_path_name_by_handle.
If that were to happen, rather then bailing out, retry using the provided path directly.