### PR TITLE
user versioned paths for .winmd refs, selecting winmd's from multiple installed SDKs

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -154,7 +154,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
        Condition="'$(CppWinRTImplicitlyExpandTargetPlatform)' == 'true'">
 
         <ItemGroup>
-            <_TargetPlatformWinMDs Condition="'$(TargetPlatformWinMDLocation)' != ''" Include="$(TargetPlatformWinMDLocation)\**\*.winmd">
+            <_TargetPlatformWinMDs Condition="'$(TargetPlatformWinMDLocation)' != ''" Include="$(TargetPlatformWinMDLocation)\$(TargetPlatformVersion)\**\*.winmd">
                 <WinMDFile>true</WinMDFile>
                 <CopyLocal>false</CopyLocal>
                 <ReferenceGrouping>$(TargetPlatformMoniker)</ReferenceGrouping>
@@ -894,7 +894,7 @@ $(XamlMetaDataProviderPch)
         </ClCompile>
         <Midl Condition="'$(CppWinRTModernIDL)' != 'false'">
             <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' != ''">$(WindowsSDK_MetadataFoundationPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
-            <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' == ''">$(WindowsSDK_MetadataPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
+            <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' == ''">$(WindowsSDK_MetadataPathVersioned);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
             <AdditionalOptions>%(AdditionalOptions) /nomidl</AdditionalOptions>
         </Midl>
         <Link>


### PR DESCRIPTION
fixes #790
@jlaanstra, I have a naïve understanding of this design so please check carefully. I learned about these variables by browsing them in the VS macros UI. I hope that is reliable and version resilient. 