### PR TITLE
Produce IntelliSense comments from winmd custom attributes

### DIFF
--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -137,7 +137,9 @@ namespace cppwinrt
             HKEY_LOCAL_MACHINE,
             L"SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots",
             0,
-            KEY_READ,
+            // https://task.ms/29349404 - The SDK sometimes stores the 64 bit location into KitsRoot10 which is wrong,
+            // this breaks 64-bit cppwinrt.exe, so work around this by forcing to use the WoW64 hive.
+            KEY_READ | KEY_WOW64_32KEY, 
             &key))
         {
             throw std::invalid_argument("Could not find the Windows SDK in the registry");

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -208,7 +208,7 @@ namespace cppwinrt
     {
       std::string ret{};
       if (!doc_string.empty()) {
-        ret = "/// <summary>" + std::string(doc_string) + "</summary>\r\n";
+        ret = "    /// <summary>" + std::string(doc_string) + "</summary>\r\n";
       }
       return ret;
     }
@@ -1032,7 +1032,10 @@ namespace cppwinrt
         auto method_name = get_name(method);
         auto type = method.Parent();
 
-        w.write("        %WINRT_IMPL_AUTO(%) %(%) const%;\n",
+        auto implFormat = "        %WINRT_IMPL_AUTO(%) %(%) const%;\n";
+        auto implFormatWithDoc = getDocXml(method) + implFormat;
+
+        w.write(implFormatWithDoc,
             is_get_overload(method) ? "[[nodiscard]] " : "",
             signature.return_signature(),
             method_name,

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -204,31 +204,35 @@ namespace cppwinrt
     }
 
 
-    static std::string getDocXml(std::string_view doc_string)
+    static std::string get_doc_xml(std::string_view doc_string)
     {
       std::string ret{};
-      if (!doc_string.empty()) {
+      if (!doc_string.empty())
+      {
         ret = "    /// <summary>" + std::string(doc_string) + "</summary>\r\n";
       }
       return ret;
     }
 
     template<typename T>
-    static std::string getDocXml(T const& type)
+    static std::string get_doc_xml(T const& type)
     {
       if (auto const& attr = get_attribute(type, "HelpStringAttribute"))
       {
         auto sig = attr.Value();
         auto fixed = sig.FixedArgs();
-        if (fixed.size() == 1) {
-          return getDocXml(std::get<std::string_view>(std::get<ElemSig>(fixed[0].value).value));
+        if (fixed.size() == 1)
+        {
+          return get_doc_xml(std::get<std::string_view>(std::get<ElemSig>(fixed[0].value).value));
         }
-        else {
+        else
+        {
           auto named = sig.NamedArgs();
           auto content = std::find_if(named.begin(), named.end(), [](NamedArgSig const& namedsig) { return namedsig.name == "Content"; });
-          if (content != named.end()) {
+          if (content != named.end())
+          {
             auto value = content->value;
-            return getDocXml(std::get<std::string_view>(std::get<ElemSig>(value.value).value));
+            return get_doc_xml(std::get<std::string_view>(std::get<ElemSig>(value.value).value));
           }
         }
       }
@@ -242,7 +246,7 @@ namespace cppwinrt
 
         if (auto constant = field.Constant())
         {
-            auto formatWithDoc = getDocXml(field) + format;
+            auto formatWithDoc = get_doc_xml(field) + format;
             w.write(formatWithDoc, field.Name(), *constant);
         }
     }
@@ -253,7 +257,7 @@ namespace cppwinrt
     {
 %    };
 )";
-        auto formatWithDoc = getDocXml(type) + format;
+        auto formatWithDoc = get_doc_xml(type) + format;
 
         auto fields = type.FieldList();
         w.write(formatWithDoc, type.TypeName(), fields.first.Signature().Type(), bind_each<write_enum_field>(fields));
@@ -1033,7 +1037,7 @@ namespace cppwinrt
         auto type = method.Parent();
 
         auto implFormat = "        %WINRT_IMPL_AUTO(%) %(%) const%;\n";
-        auto implFormatWithDoc = getDocXml(method) + implFormat;
+        auto implFormatWithDoc = get_doc_xml(method) + implFormat;
 
         w.write(implFormatWithDoc,
             is_get_overload(method) ? "[[nodiscard]] " : "",
@@ -1188,7 +1192,7 @@ namespace cppwinrt
 )";
         }
 
-        auto formatWithDoc = getDocXml(method) + format;
+        auto formatWithDoc = get_doc_xml(method) + format;
 
 
         w.write(formatWithDoc,
@@ -1852,7 +1856,7 @@ namespace cppwinrt
         std::string upcall = "this->shim().";
         upcall += get_name(method);
 
-        auto formatWithDoc = getDocXml(method) + format;
+        auto formatWithDoc = get_doc_xml(method) + format;
         w.write(formatWithDoc,
             get_abi_name(method),
             bind<write_produce_params>(signature),
@@ -2381,7 +2385,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IInspectable(ptr, take_ownership_from_abi) {}
 %%    };
 )";
-            auto formatWithDoc = getDocXml(type) + format;
+            auto formatWithDoc = get_doc_xml(type) + format;
 
             w.write(formatWithDoc,
                 type_name,
@@ -2671,7 +2675,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             {
                 for (auto&& field : type.FieldList())
                 {
-                    fields.emplace_back(field.Name(), w.write_temp("%", field.Signature().Type()), getDocXml(field));
+                    fields.emplace_back(field.Name(), w.write_temp("%", field.Signature().Type()), get_doc_xml(field));
                 }
             }
 
@@ -2732,7 +2736,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             auto name = type.type.TypeName();
             std::string_view is_noexcept = type.is_noexcept ? " noexcept" : "";
 
-            auto formatWithDoc = getDocXml(type.type) + format;
+            auto formatWithDoc = get_doc_xml(type.type) + format;
 
             w.write(formatWithDoc,
                 name,
@@ -3135,7 +3139,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 %%%    };
 )";
 
-        auto formatWithDoc = getDocXml(type) + format;
+        auto formatWithDoc = get_doc_xml(type) + format;
 
         w.write(formatWithDoc,
             type_name,
@@ -3162,7 +3166,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 %%%    };
 )";
 
-        auto formatWithDoc = getDocXml(type) + format;
+        auto formatWithDoc = get_doc_xml(type) + format;
 
         w.write(formatWithDoc,
             type_name,

--- a/test/test_component/Simple.cpp
+++ b/test/test_component/Simple.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "Simple.h"
 #include "Simple.g.cpp"
-
+#include "winrt/test_component.h"
 namespace winrt::test_component::implementation
 {
     void Simple::Method()
@@ -23,5 +23,19 @@ namespace winrt::test_component::implementation
     Windows::Foundation::IInspectable Simple::Object(Windows::Foundation::DateTime const&)
     {
         throw hresult_not_implemented();
+    }
+
+    void DocStringTest() {
+      winrt::test_component::InterfaceWithDoc id;
+      id.f();
+      auto ip = id.InterfacePropertyWithDoc();
+
+      auto cat = winrt::test_component::EnumWithDoc::Cat;
+
+      winrt::test_component::StructWithDoc sd{};
+      auto x = sd.val;
+      
+      winrt::test_component::ClassWithDoc cd{nullptr};
+      cd.g();
     }
 }

--- a/test/test_component/Simple.cpp
+++ b/test/test_component/Simple.cpp
@@ -30,7 +30,7 @@ namespace winrt::test_component::implementation
       id.f();
       auto ip = id.InterfacePropertyWithDoc();
 
-      auto cat = winrt::test_component::EnumWithDoc::Cat;
+      auto cat = winrt::test_component::EnumWithDoc::Gecko;
 
       winrt::test_component::StructWithDoc sd{};
       auto x = sd.val;

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -7,10 +7,57 @@ namespace Windows.Foundation.Metadata
     attribute NoExceptionAttribute
     {
     }
+
+    [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
+    [attributename("help_string")]
+    attribute HelpStringAttribute {
+      String Content;
+    }
+
+  //[attributeusage(target_property, target_method)]
+  //[attributename("doc_default")] attribute DocDefaultAttribute {
+  //  String Content;
+  //}
 }
 
 namespace test_component
 {
+    [help_string("this is an interface")]
+    interface InterfaceWithDoc
+    {
+      [help_string("this is a function with docs")]
+      void f();
+
+      [help_string("this is a property")]
+      Int32 InterfacePropertyWithDoc;
+    };
+
+    [help_string("this is an enum")]
+    enum EnumWithDoc
+    {
+      Dog,
+      Cat,
+      [help_string("this is a gecko")] // xmldoc in enum values aren't properly displayed by VS yet
+      Gecko
+    };
+
+    [help_string("this is a struct")]
+    struct StructWithDoc
+    {
+      [help_string("this is the value")]
+      Int32 val;
+    };
+
+    [help_string("this is a class")]
+    runtimeclass ClassWithDoc
+    {
+      [help_string("this is a property")]
+      Int32 SomeValue;
+
+      [help_string("this is a method")]
+      void g();
+    }
+
     struct Struct
     {
         String First;

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -9,52 +9,47 @@ namespace Windows.Foundation.Metadata
     }
 
     [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
-    [attributename("help_string")]
+    [attributename("helpstring")]
     attribute HelpStringAttribute {
       String Content;
     }
-
-  //[attributeusage(target_property, target_method)]
-  //[attributename("doc_default")] attribute DocDefaultAttribute {
-  //  String Content;
-  //}
 }
 
 namespace test_component
 {
-    [help_string("this is an interface")]
+    [helpstring("this is an interface")]
     interface InterfaceWithDoc
     {
-      [help_string("this is a function with docs")]
+      [helpstring("this is a function with docs")]
       void f();
 
-      [help_string("this is a property")]
+      [helpstring("this is a property")]
       Int32 InterfacePropertyWithDoc;
     };
 
-    [help_string("this is an enum")]
+    [helpstring("this is an enum")]
     enum EnumWithDoc
     {
       Dog,
       Cat,
-      [help_string("this is a gecko")] // xmldoc in enum values aren't properly displayed by VS yet
+      [helpstring("this is a gecko")] // xmldoc in enum values aren't properly displayed by VS yet
       Gecko
     };
 
-    [help_string("this is a struct")]
+    [helpstring("this is a struct")]
     struct StructWithDoc
     {
-      [help_string("this is the value")]
+      [helpstring("this is the value")]
       Int32 val;
     };
 
-    [help_string("this is a class")]
+    [helpstring("this is a class")]
     runtimeclass ClassWithDoc
     {
-      [help_string("this is a property")]
+      [helpstring("this is a property")]
       Int32 SomeValue;
 
-      [help_string("this is a method")]
+      [helpstring("this is a method")]
       void g();
     }
 


### PR DESCRIPTION
Fixes #804 
# Description

Implements proposal to leverage any attribute named `HelpStringAttribute` (in any namespace).
This PR will produce comments in the projected code of the form `/// <summary>comment</summary>`, where `comment` is a string stored in a custom attribute named `HelpStringAttribute`.

# NYI
- cppwinrt has some text-replacement logic (`^`, `%`, `@`) which the doc strings need to be exempted from.
- XML comments seem to work in VS but they're not officially supported ([feature request filed](https://developercommunity.visualstudio.com/idea/1271536/c-intellisense-doc-comments-should-support-templat.html))
- test which should check that when building with /doc, the intellisense XML produced has the right entries.

# Demo
Assume this IDL:
```idl
namespace Windows.Foundation.Metadata
{
    [attributeusage(target_runtimeclass, target_interface, target_struct, target_enum, target_delegate, target_field, target_property, target_method, target_event)]
    [attributename("helpstring")]
    attribute HelpStringAttribute {
      String Content;
    }
}

namespace test_component
{
    [helpstring("this is an interface")]
    interface InterfaceWithDoc
    {
      [helpstring("this is a function with docs")]
      void f();

      [helpstring("this is a property")]
      Int32 InterfacePropertyWithDoc;
    };

    [helpstring("this is an enum")]
    enum EnumWithDoc
    {
      Dog,
      Cat,
      [helpstring("this is a gecko")] // xmldoc in enum values aren't properly displayed by VS yet
      Gecko
    };

    [helpstring("this is a struct")]
    struct StructWithDoc
    {
      [helpstring("this is the value")]
      Int32 val;
    };

    [helpstring("this is a class")]
    runtimeclass ClassWithDoc
    {
      [helpstring("this is a property")]
      Int32 SomeValue;

      [helpstring("this is a method")]
      void g();
    }
```
With this you get these kind of suggestions:

## on an interface
![image](https://user-images.githubusercontent.com/22989529/100529708-24174d00-319f-11eb-9361-9507d3cbbad9.png)

## on a method in an interface
![image](https://user-images.githubusercontent.com/22989529/100529707-1f529900-319f-11eb-81a9-39eb31918d00.png)

## on a property in an interface
![image](https://user-images.githubusercontent.com/22989529/100529700-0ea22300-319f-11eb-8603-1026203a9d2d.png)

## on enums
![image](https://user-images.githubusercontent.com/22989529/100529694-01853400-319f-11eb-9f69-d0072b19f59e.png)

## on enum values
![image](https://user-images.githubusercontent.com/22989529/100529747-6e003300-319f-11eb-8722-1ddf6945182b.png)

## on structs
![image](https://user-images.githubusercontent.com/22989529/100529689-f3cfae80-319e-11eb-91a8-13ecd4d8dc88.png)

## on struct fields
![image](https://user-images.githubusercontent.com/22989529/100529781-9c7e0e00-319f-11eb-8542-9329859a640c.png)

## on classes
![image](https://user-images.githubusercontent.com/22989529/100529692-fa5e2600-319e-11eb-96ee-0ad463a85444.png)

## on a method in a class
![image](https://user-images.githubusercontent.com/22989529/100529803-cfc09d00-319f-11eb-996c-0ccd76d4b8b1.png)

## on a property in a class
![image](https://user-images.githubusercontent.com/22989529/100529810-e2d36d00-319f-11eb-94a5-ad4b05fd0f7f.png)

