### PR TITLE
Support _USE_32BIT_TIME_T

### DIFF
--- a/strings/base_chrono.h
+++ b/strings/base_chrono.h
@@ -42,7 +42,7 @@ WINRT_EXPORT namespace winrt
 
         static time_t to_time_t(time_point const& time) noexcept
         {
-            return std::chrono::system_clock::to_time_t(to_sys(time));
+            return static_cast<time_t>(std::chrono::system_clock::to_time_t(to_sys(time)));
         }
 
         static time_point from_time_t(time_t time) noexcept


### PR DESCRIPTION
When `_USE_32BIT_TIME_T` is defined, `time_t` is 32-bit rather than 64-bit. This is not recommended and seldom used, but does come up from time to time. This change simply avoids a build error if this occurs by forcing the conversion. 