### PR TITLE
Support boxing delegates

### DIFF
--- a/strings/base_reference_produce.h
+++ b/strings/base_reference_produce.h
@@ -266,8 +266,6 @@ namespace winrt::impl
     template <typename T, typename From>
     T unbox_value_type(From&& value)
     {
-        static_assert(!is_com_interface_v<T>);
-
         if (!value)
         {
             throw hresult_no_interface();

--- a/test/test/box_delegate.cpp
+++ b/test/test/box_delegate.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+
+TEST_CASE("box_delegate")
+{
+    using Handler = winrt::Windows::Foundation::TypedEventHandler<int, bool>;
+
+    Handler d = [](auto&&...) {};
+    REQUIRE(d);
+
+    auto box = winrt::box_value(d);
+
+    Handler unbox = winrt::unbox_value<Handler>(box);
+    REQUIRE(winrt::get_abi(unbox) == winrt::get_abi(d));
+
+    unbox = winrt::unbox_value_or<Handler>(box, Handler {});
+    REQUIRE(winrt::get_abi(unbox) == winrt::get_abi(d));
+
+    unbox = winrt::unbox_value_or<Handler>(winrt::Windows::Foundation::IInspectable{}, Handler{});
+    REQUIRE(!unbox);
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -296,6 +296,7 @@
     <ClCompile Include="async_completed.cpp" />
     <ClCompile Include="async_propagate_cancel.cpp" />
     <ClCompile Include="async_ref_result.cpp" />
+    <ClCompile Include="box_delegate.cpp" />
     <ClCompile Include="box_guid.cpp" />
     <ClCompile Include="capture.cpp" />
     <ClCompile Include="coro_foundation.cpp">


### PR DESCRIPTION
This used to work but was blocked when this assert was added. There's probably a less restrictive assert that would be beneficial but I couldn't get a simple example working quickly and I need this to unblock the Windows build.