### PR TITLE
Prevent inadvertent assignment to temporary object

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -2319,6 +2319,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         %(std::nullptr_t = nullptr) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IInspectable(ptr, take_ownership_from_abi) {}
+        %(% const&) noexcept = default;
+        %(%&&) noexcept = default;
+        %& operator=(% const&) & noexcept = default;
+        %& operator=(%&&) & noexcept = default;
 %%    };
 )";
 
@@ -2328,6 +2332,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 bind<write_interface_requires>(type),
                 type_name,
                 type_name,
+                type_name, // %(T const&)
+                type_name, // T(% const&)
+                type_name, // %(T&&)
+                type_name, // T(%&&)
+                type_name, // %& operator=(T const&)
+                type_name, // T& operator=(% const&)
+                type_name, // %& operator=(T&&)
+                type_name, // T& operator=(%&&)
                 bind<write_interface_usings>(type),
                 bind<write_interface_extensions>(type));
         }
@@ -2342,6 +2354,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {%
         %(std::nullptr_t = nullptr) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IInspectable(ptr, take_ownership_from_abi) {}
+        %(% const&) noexcept = default;
+        %(%&&) noexcept = default;
+        %& operator=(% const&) & noexcept = default;
+        %& operator=(%&&) & noexcept = default;
 %%    };
 )";
 
@@ -2353,6 +2369,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 bind<write_generic_asserts>(generics),
                 type_name,
                 type_name,
+                type_name, // %(T const&)
+                type_name, // T(% const&)
+                type_name, // %(T&&)
+                type_name, // T(%&&)
+                type_name, // %& operator=(T const&)
+                type_name, // T& operator=(% const&)
+                type_name, // %& operator=(T&&)
+                type_name, // T& operator=(%&&)
                 bind<write_interface_usings>(type),
                 bind<write_interface_extensions>(type));
         }
@@ -2378,6 +2402,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {%
         %(std::nullptr_t = nullptr) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IUnknown(ptr, take_ownership_from_abi) {}
+        %(% const&) noexcept = default;
+        %(%&&) noexcept = default;
+        %& operator=(% const&) & noexcept = default;
+        %& operator=(%&&) & noexcept = default;
         template <typename L> %(L lambda);
         template <typename F> %(F* function);
         template <typename O, typename M> %(O* object, M method);
@@ -2390,10 +2418,18 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         method_signature signature{ get_delegate_method(type) };
 
         w.write(format,
-            type_name,
+            type_name, // struct %
             bind<write_generic_asserts>(generics),
             type_name,
             type_name,
+            type_name, // %(T const&)
+            type_name, // T(% const&)
+            type_name, // %(T&&)
+            type_name, // T(%&&)
+            type_name, // %& operator=(T const&)
+            type_name, // T& operator=(% const&)
+            type_name, // %& operator=(T&&)
+            type_name, // T& operator=(%&&)
             type_name,
             type_name,
             type_name,
@@ -3067,7 +3103,11 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         %(std::nullptr_t) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : %(ptr, take_ownership_from_abi) {}
-%%%    };
+%        %(% const&) noexcept = default;
+        %(%&&) noexcept = default;
+        %& operator=(% const&) & noexcept = default;
+        %& operator=(%&&) & noexcept = default;
+%%    };
 )";
 
         w.write(format,
@@ -3079,6 +3119,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             type_name,
             base_type,
             bind<write_constructor_declarations>(type, factories),
+            type_name, // %(T const&)
+            type_name, // T(% const&)
+            type_name, // %(T%&)
+            type_name, // T(%&&)
+            type_name, // %& operator=(T const&)
+            type_name, // T& operator=(% const&)
+            type_name, // %& operator=(T&&)
+            type_name, // T& operator=(%&&)
             bind<write_class_usings>(type),
             bind_each<write_static_declaration>(factories, type));
     }
@@ -3092,7 +3140,11 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
     {
         %(std::nullptr_t) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : %(ptr, take_ownership_from_abi) {}
-%%%    };
+%        %(% const&) noexcept = default;
+        %(%&&) noexcept = default;
+        %& operator=(% const&) & noexcept = default;
+        %& operator=(%&&) & noexcept = default;
+%%    };
 )";
 
         w.write(format,
@@ -3103,6 +3155,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             type_name,
             base_type,
             bind<write_constructor_declarations>(type, factories),
+            type_name, // %(T const&)
+            type_name, // T(% const&)
+            type_name, // %(T%&)
+            type_name, // T(%&&)
+            type_name, // %& operator=(T const&)
+            type_name, // T& operator=(% const&)
+            type_name, // %& operator=(T&&)
+            type_name, // T& operator=(%&&)
             bind<write_fast_class_base_declarations>(type),
             bind_each<write_static_declaration>(factories, type));
     }

--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -516,6 +516,10 @@ WINRT_EXPORT namespace winrt
         {
             IActivationFactory(std::nullptr_t = nullptr) noexcept {}
             IActivationFactory(void* ptr, take_ownership_from_abi_t) noexcept : IInspectable(ptr, take_ownership_from_abi) {}
+            IActivationFactory(IActivationFactory const&) noexcept = default;
+            IActivationFactory(IActivationFactory&&) noexcept = default;
+            IActivationFactory& operator=(IActivationFactory const&) & noexcept = default;
+            IActivationFactory& operator=(IActivationFactory&&) & noexcept = default;
 
             template <typename T>
             T ActivateInstance() const

--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -295,7 +295,7 @@ WINRT_EXPORT namespace winrt
             other.m_size = 0;
         }
 
-        com_array& operator=(com_array&& other) noexcept
+        com_array& operator=(com_array&& other) & noexcept
         {
             clear();
             this->m_data = other.m_data;

--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -33,13 +33,13 @@ WINRT_EXPORT namespace winrt
             release_ref();
         }
 
-        com_ptr& operator=(com_ptr const& other) noexcept
+        com_ptr& operator=(com_ptr const& other) & noexcept
         {
             copy_ref(other.m_ptr);
             return*this;
         }
 
-        com_ptr& operator=(com_ptr&& other) noexcept
+        com_ptr& operator=(com_ptr&& other) & noexcept
         {
             if (this != &other)
             {
@@ -51,14 +51,14 @@ WINRT_EXPORT namespace winrt
         }
 
         template <typename U>
-        com_ptr& operator=(com_ptr<U> const& other) noexcept
+        com_ptr& operator=(com_ptr<U> const& other) & noexcept
         {
             copy_ref(other.m_ptr);
             return*this;
         }
 
         template <typename U>
-        com_ptr& operator=(com_ptr<U>&& other) noexcept
+        com_ptr& operator=(com_ptr<U>&& other) & noexcept
         {
             release_ref();
             m_ptr = std::exchange(other.m_ptr, {});

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -29,7 +29,7 @@ WINRT_EXPORT namespace winrt
         event_revoker& operator=(event_revoker const&) = delete;
         event_revoker(event_revoker&&) noexcept = default;
 
-        event_revoker& operator=(event_revoker&& other) noexcept
+        event_revoker& operator=(event_revoker&& other) & noexcept
         {
             if (this != &other)
             {
@@ -84,7 +84,7 @@ WINRT_EXPORT namespace winrt
         factory_event_revoker& operator=(factory_event_revoker const&) = delete;
         factory_event_revoker(factory_event_revoker&&) noexcept = default;
 
-        factory_event_revoker& operator=(factory_event_revoker&& other) noexcept
+        factory_event_revoker& operator=(factory_event_revoker&& other) & noexcept
         {
             if (this != &other)
             {
@@ -140,7 +140,7 @@ namespace winrt::impl
         event_revoker& operator=(event_revoker const&) = delete;
 
         event_revoker(event_revoker&&) noexcept = default;
-        event_revoker& operator=(event_revoker&& other) noexcept
+        event_revoker& operator=(event_revoker&& other) & noexcept
         {
             event_revoker(std::move(other)).swap(*this);
             return *this;

--- a/strings/base_handle.h
+++ b/strings/base_handle.h
@@ -16,7 +16,7 @@ WINRT_EXPORT namespace winrt
         {
         }
 
-        handle_type& operator=(handle_type&& other) noexcept
+        handle_type& operator=(handle_type&& other) & noexcept
         {
             if (this != &other)
             {

--- a/strings/base_security.h
+++ b/strings/base_security.h
@@ -55,7 +55,7 @@ WINRT_EXPORT namespace winrt
 
         access_token() = default;
         access_token(access_token&& other) = default;
-        access_token& operator=(access_token&& other) = default;
+        access_token& operator=(access_token&& other) & = default;
 
         access_token impersonate() const
         {

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -179,16 +179,16 @@ WINRT_EXPORT namespace winrt
             m_handle(impl::duplicate_hstring(value.m_handle.get()))
         {}
 
-        hstring& operator=(hstring const& value)
+        hstring& operator=(hstring const& value) &
         {
             m_handle.attach(impl::duplicate_hstring(value.m_handle.get()));
             return*this;
         }
 
         hstring(hstring&&) noexcept = default;
-        hstring& operator=(hstring&&) = default;
+        hstring& operator=(hstring&&) & = default;
         hstring(std::nullptr_t) = delete;
-        hstring& operator=(std::nullptr_t) = delete;
+        hstring& operator=(std::nullptr_t) & = delete;
 
         hstring(std::initializer_list<wchar_t> value) :
             hstring(value.begin(), static_cast<uint32_t>(value.size()))
@@ -206,17 +206,17 @@ WINRT_EXPORT namespace winrt
             hstring(value.data(), static_cast<size_type>(value.size()))
         {}
 
-        hstring& operator=(std::wstring_view const& value)
+        hstring& operator=(std::wstring_view const& value) &
         {
             return *this = hstring{ value };
         }
 
-        hstring& operator=(wchar_t const* const value)
+        hstring& operator=(wchar_t const* const value) &
         {
             return *this = hstring{ value };
         }
 
-        hstring& operator=(std::initializer_list<wchar_t> value)
+        hstring& operator=(std::initializer_list<wchar_t> value) &
         {
             return *this = hstring{ value };
         }

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -161,7 +161,7 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
             release_ref();
         }
 
-        IUnknown& operator=(IUnknown const& other) noexcept
+        IUnknown& operator=(IUnknown const& other) & noexcept
         {
             if (this != &other)
             {
@@ -173,7 +173,7 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
             return*this;
         }
 
-        IUnknown& operator=(IUnknown&& other) noexcept
+        IUnknown& operator=(IUnknown&& other) & noexcept
         {
             if (this != &other)
             {
@@ -189,7 +189,7 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
             return nullptr != m_ptr;
         }
 
-        IUnknown& operator=(std::nullptr_t) noexcept
+        IUnknown& operator=(std::nullptr_t) & noexcept
         {
             release_ref();
             return*this;
@@ -425,5 +425,9 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
     {
         IInspectable(std::nullptr_t = nullptr) noexcept {}
         IInspectable(void* ptr, take_ownership_from_abi_t) noexcept : IUnknown(ptr, take_ownership_from_abi) {}
+        IInspectable(IInspectable const&) noexcept = default;
+        IInspectable(IInspectable&&) noexcept = default;
+        IInspectable& operator=(IInspectable const&) & noexcept = default;
+        IInspectable& operator=(IInspectable&&) & noexcept = default;
     };
 }

--- a/test/old_tests/UnitTests/properties.cpp
+++ b/test/old_tests/UnitTests/properties.cpp
@@ -44,4 +44,50 @@ TEST_CASE("properties")
 
     REQUIRE_THROWS_AS(e.Name(L"throw"), hresult_invalid_argument);
     REQUIRE_THROWS_AS(e.Name(), hresult_invalid_argument);
+
+}
+
+namespace
+{
+    // Make sure that statements like
+    //
+    //    e.Name() = L"Fred";       // intended e.Name(L"Fred");
+    //    e.Uri() = newUri;         // intended e.Uri(newUri);
+    //
+    // are not valid. These are common beginner errors when
+    // trying to set Windows Runtime properties.
+
+    template<typename T, bool default_constructible, typename... ConstructorArgs>
+    struct validate_rvalue_operations
+    {
+        // Make sure we didn't damage default constructor.
+        static_assert(std::is_default_constructible_v<T> == default_constructible);
+
+        // Make sure we didn't damage other constructors.
+        static_assert((std::is_constructible_v<T, ConstructorArgs> && ...));
+
+        // Make sure we didn't damage copy and move constructors.
+        static_assert(std::is_copy_constructible_v<T>);
+        static_assert(std::is_move_constructible_v<T>);
+
+        // Make sure rvalue assignment is disallowed, but lvalue is still okay.
+        static_assert(!std::is_assignable_v<T&&, T>);
+        static_assert((!std::is_assignable_v<T&&, ConstructorArgs> && ...));
+        static_assert(std::is_assignable_v<T&, T>);
+        static_assert((std::is_assignable_v<T&, ConstructorArgs> && ...));
+
+        constexpr static bool validate()
+        {
+            // Dummy method. Exists only to force instantiation of type so the static_assert's will fire.
+            return true;
+        }
+    };
+
+    static_assert(validate_rvalue_operations<hstring, true, const wchar_t*>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::IInspectable, true, std::nullptr_t>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::IActivationFactory, true, std::nullptr_t>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::IAsyncOperation<int32_t>, true, std::nullptr_t>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::EventHandler<Windows::Foundation::IInspectable>, true, std::nullptr_t>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::IUriRuntimeClass, true, std::nullptr_t>::validate());
+    static_assert(validate_rvalue_operations<Windows::Foundation::Uri, false /* not default constructible */, std::nullptr_t>::validate());
 }


### PR DESCRIPTION
Common porting error coming from languages that have properties as native concepts is trying to set a C++/WinRT property by doing

```cpp
o.Property() = value;
```

due to overzealous application of the rule "In C++/WinRT, you access a property by doing `o.Property()`."

Fix this by making all assignment operators require the assigned-to variable to be an lvalue, rendering the above mistake a compile-time error.

Assigning to an rvalue is not interesting because the rvalue has no name, so you have no way of using the assigned-to object. There are some wacky fringe cases where you might be doing this on purpose:

```cpp
get_abi(hstring() = L"Hello")
```

gives you an ABI string handle for a temporary. But this is decidedly non-idiomatic and I'm fairly confident nobody does this on purpose. The idiomatic way of writing this is simply

```cpp
get_abi(hstring(L"Hello"))
```

This fixes issue #359 

## Implementation notes

Assignment operators default to non-ref-qualified, which makes them applicable to both lvalue and rvalue references. We must explicitly redeclare them as lvalue ref-qualified in order to remove the rvalue ref-qualified version.

Once you have an explicit assignment operator, the implicit copy and move constructors disappear, so we have to bring them back explicitly.

Once you add explicit copy and move constructors, then the implicit default constructor disappears. Fortunately, we never relied upon the implicit default constructor, so we don't have to to make explicit versions.