### PR TITLE
Define make_guid to parse string_view to guid

### DIFF
--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -197,41 +197,14 @@ namespace winrt::impl
         );
     }
 
-    template <typename T>
-    constexpr uint8_t hex_to_uint(T const c) noexcept
+    constexpr uint32_t to_guid(uint8_t a, uint8_t b, uint8_t c, uint8_t d) noexcept
     {
-        if (c >= static_cast<T>('0') && c <= static_cast<T>('9'))
-        {
-            return static_cast<uint8_t>(c - static_cast<T>('0'));
-        }
-        else if (c >= static_cast<T>('A') && c <= static_cast<T>('F'))
-        {
-            return static_cast<uint8_t>(10 + c - static_cast<T>('A'));
-        }
-        else if (c >= static_cast<T>('a') && c <= static_cast<T>('f'))
-        {
-            return static_cast<uint8_t>(10 + c - static_cast<T>('a'));
-        }
-        else 
-        {
-            std::terminate();
-        }
-    }
-
-    template <typename T>
-    constexpr uint8_t hex_to_uint8(T const a, T const b) noexcept
-    {
-        return (hex_to_uint(a) << 4) | hex_to_uint(b);
+        return (static_cast<uint32_t>(d) << 24) | (static_cast<uint32_t>(c) << 16) | (static_cast<uint32_t>(b) << 8) | static_cast<uint32_t>(a);
     }
 
     constexpr uint16_t to_guid(uint8_t a, uint8_t b) noexcept
     {
-        return (static_cast<uint16_t>(a) << 8) | static_cast<uint16_t>(b);
-    }
-
-    constexpr uint32_t to_guid(uint8_t a, uint8_t b, uint8_t c, uint8_t d) noexcept
-    {
-        return (static_cast<uint32_t>(to_guid(a, b)) << 16) | static_cast<uint32_t>(to_guid(c, d));
+        return (static_cast<uint32_t>(b) << 8) | static_cast<uint32_t>(a);
     }
 
     template <size_t Size>
@@ -246,44 +219,22 @@ namespace winrt::impl
         };
     }
 
-    template <typename TStringView>
-    constexpr guid to_guid(TStringView const value) noexcept
+    constexpr uint32_t endian_swap(uint32_t value) noexcept
     {
-        if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
-        {
-            std::terminate();
-        }
+        return (value & 0xFF000000) >> 24 | (value & 0x00FF0000) >> 8 | (value & 0x0000FF00) << 8 | (value & 0x000000FF) << 24;
+    }
 
-        return
-        {
-            to_guid
-            (
-                hex_to_uint8(value[0], value[1]),
-                hex_to_uint8(value[2], value[3]),
-                hex_to_uint8(value[4], value[5]),
-                hex_to_uint8(value[6], value[7])
-            ),
-            to_guid
-            (
-                hex_to_uint8(value[9], value[10]),
-                hex_to_uint8(value[11], value[12])
-            ),
-            to_guid
-            (
-                hex_to_uint8(value[14], value[15]),
-                hex_to_uint8(value[16], value[17])
-            ),
-            {
-                hex_to_uint8(value[19], value[20]),
-                hex_to_uint8(value[21], value[22]),
-                hex_to_uint8(value[24], value[25]),
-                hex_to_uint8(value[26], value[27]),
-                hex_to_uint8(value[28], value[29]),
-                hex_to_uint8(value[30], value[31]),
-                hex_to_uint8(value[32], value[33]),
-                hex_to_uint8(value[34], value[35]),
-            }
-        };
+    constexpr uint16_t endian_swap(uint16_t value) noexcept
+    {
+        return (value & 0xFF00) >> 8 | (value & 0x00FF) << 8;
+    }
+
+    constexpr guid endian_swap(guid value) noexcept
+    {
+        value.Data1 = endian_swap(value.Data1);
+        value.Data2 = endian_swap(value.Data2);
+        value.Data3 = endian_swap(value.Data3);
+        return value;
     }
 
     constexpr guid set_named_guid_fields(guid value) noexcept
@@ -482,8 +433,9 @@ namespace winrt::impl
 
         auto buffer = combine(to_array(namespace_guid), char_to_byte_array(value, std::make_index_sequence<Size>()));
         auto hash = calculate_sha1(buffer);
-        auto result = to_guid(hash);
-        return set_named_guid_fields(result);
+        auto big_endian_guid = to_guid(hash);
+        auto little_endian_guid = endian_swap(big_endian_guid);
+        return set_named_guid_fields(little_endian_guid);
     }
 
     template <typename TArg, typename... TRest>
@@ -709,28 +661,5 @@ WINRT_EXPORT namespace winrt
     constexpr auto name_of() noexcept
     {
         return impl::to_wstring_view(impl::name_v<T>);
-    }
-
-    constexpr auto make_guid(std::string_view const value) noexcept
-    {
-        return impl::to_guid(value);
-    }
-
-    constexpr auto make_guid(std::wstring_view const value) noexcept
-    {
-        return impl::to_guid(value);
-    }
-
-    inline namespace literals
-    {
-        constexpr auto operator""_guid(const char* str, std::size_t length) noexcept
-        {
-            return make_guid(std::string_view{str, length});
-        }
-
-        constexpr auto operator""_guid(const wchar_t* str, std::size_t length) noexcept
-        {
-            return make_guid(std::wstring_view{str, length});
-        }
     }
 }

--- a/test/test/generic_types.h
+++ b/test/test/generic_types.h
@@ -6,7 +6,7 @@ using namespace Windows::Foundation::Collections;
 using namespace Windows::Foundation::Numerics;
 using namespace std::literals;
 
-#define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(make_guid(left), guid_of<__VA_ARGS__>()));
+#define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(guid(left), guid_of<__VA_ARGS__>()));
 #define REQUIRE_EQUAL_NAME(left, ...) STATIC_REQUIRE(left == name_of<__VA_ARGS__>());
 
 namespace
@@ -32,9 +32,6 @@ namespace
         using B = IKeyValuePair<hstring, IAsyncOperationWithProgress<A, float>>;
 
         REQUIRE_EQUAL_GUID("96369F54-8EB6-48F0-ABCE-C1B211E627C3"sv, IStringable);
-
-        // Guid string literals
-        STATIC_REQUIRE(equal(L"96369F54-8EB6-48F0-ABCE-C1B211E627C3"_guid, guid_of<IStringable>()));
 
         //
         // Generated Windows.Foundation GUIDs

--- a/test/test/generic_types.h
+++ b/test/test/generic_types.h
@@ -11,60 +11,6 @@ using namespace std::literals;
 
 namespace
 {
-    constexpr uint32_t to_uint(char const value) noexcept
-    {
-        if (value >= '0' && value <= '9')
-        {
-            return value - '0';
-        }
-
-        if (value >= 'A' && value <= 'F')
-        {
-            return 10 + value - 'A';
-        }
-
-        if (value >= 'a' && value <= 'f')
-        {
-            return 10 + value - 'a';
-        }
-
-        std::terminate();
-    }
-
-    constexpr guid make_guid(std::string_view const& value) noexcept
-    {
-        if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
-        {
-            std::terminate();
-        }
-
-        return
-        {
-            ((to_uint(value[0]) * 16 + to_uint(value[1])) << 24) +
-            ((to_uint(value[2]) * 16 + to_uint(value[3])) << 16) +
-            ((to_uint(value[4]) * 16 + to_uint(value[5])) << 8) +
-             (to_uint(value[6]) * 16 + to_uint(value[7])),
-
-            static_cast<uint16_t>(((to_uint(value[9]) * 16 + to_uint(value[10])) << 8) +
-                (to_uint(value[11]) * 16 + to_uint(value[12]))),
-
-            static_cast<uint16_t>(((to_uint(value[14]) * 16 + to_uint(value[15])) << 8) +
-                (to_uint(value[16]) * 16 + to_uint(value[17]))),
-
-            {
-                static_cast<uint8_t>(to_uint(value[19]) * 16 + to_uint(value[20])),
-                static_cast<uint8_t>(to_uint(value[21]) * 16 + to_uint(value[22])),
-
-                static_cast<uint8_t>(to_uint(value[24]) * 16 + to_uint(value[25])),
-                static_cast<uint8_t>(to_uint(value[26]) * 16 + to_uint(value[27])),
-                static_cast<uint8_t>(to_uint(value[28]) * 16 + to_uint(value[29])),
-                static_cast<uint8_t>(to_uint(value[30]) * 16 + to_uint(value[31])),
-                static_cast<uint8_t>(to_uint(value[32]) * 16 + to_uint(value[33])),
-                static_cast<uint8_t>(to_uint(value[34]) * 16 + to_uint(value[35])),
-            }
-        };
-    }
-
     constexpr bool equal(guid const& left, guid const& right) noexcept
     {
         return left.Data1 == right.Data1 &&
@@ -86,6 +32,9 @@ namespace
         using B = IKeyValuePair<hstring, IAsyncOperationWithProgress<A, float>>;
 
         REQUIRE_EQUAL_GUID("96369F54-8EB6-48F0-ABCE-C1B211E627C3"sv, IStringable);
+
+        // Guid string literals
+        STATIC_REQUIRE(equal(L"96369F54-8EB6-48F0-ABCE-C1B211E627C3"_guid, guid_of<IStringable>()));
 
         //
         // Generated Windows.Foundation GUIDs

--- a/test/test_win7/generic_types.h
+++ b/test/test_win7/generic_types.h
@@ -6,7 +6,7 @@ using namespace Windows::Foundation::Collections;
 using namespace Windows::Foundation::Numerics;
 using namespace std::literals;
 
-#define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(make_guid(left), guid_of<__VA_ARGS__>()));
+#define REQUIRE_EQUAL_GUID(left, ...) STATIC_REQUIRE(equal(guid(left), guid_of<__VA_ARGS__>()));
 #define REQUIRE_EQUAL_NAME(left, ...) STATIC_REQUIRE(left == name_of<__VA_ARGS__>());
 
 namespace
@@ -32,9 +32,6 @@ namespace
         using B = IKeyValuePair<hstring, IAsyncOperationWithProgress<A, float>>;
 
         REQUIRE_EQUAL_GUID("96369F54-8EB6-48F0-ABCE-C1B211E627C3"sv, IStringable);
-
-        // Guid string literals
-        STATIC_REQUIRE(equal(L"96369F54-8EB6-48F0-ABCE-C1B211E627C3"_guid, guid_of<IStringable>()));
 
         //
         // Generated Windows.Foundation GUIDs

--- a/test/test_win7/generic_types.h
+++ b/test/test_win7/generic_types.h
@@ -11,60 +11,6 @@ using namespace std::literals;
 
 namespace
 {
-    constexpr uint32_t to_uint(char const value) noexcept
-    {
-        if (value >= '0' && value <= '9')
-        {
-            return value - '0';
-        }
-
-        if (value >= 'A' && value <= 'F')
-        {
-            return 10 + value - 'A';
-        }
-
-        if (value >= 'a' && value <= 'f')
-        {
-            return 10 + value - 'a';
-        }
-
-        std::terminate();
-    }
-
-    constexpr guid make_guid(std::string_view const& value) noexcept
-    {
-        if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
-        {
-            std::terminate();
-        }
-
-        return
-        {
-            ((to_uint(value[0]) * 16 + to_uint(value[1])) << 24) +
-            ((to_uint(value[2]) * 16 + to_uint(value[3])) << 16) +
-            ((to_uint(value[4]) * 16 + to_uint(value[5])) << 8) +
-             (to_uint(value[6]) * 16 + to_uint(value[7])),
-
-            static_cast<uint16_t>(((to_uint(value[9]) * 16 + to_uint(value[10])) << 8) +
-                (to_uint(value[11]) * 16 + to_uint(value[12]))),
-
-            static_cast<uint16_t>(((to_uint(value[14]) * 16 + to_uint(value[15])) << 8) +
-                (to_uint(value[16]) * 16 + to_uint(value[17]))),
-
-            {
-                static_cast<uint8_t>(to_uint(value[19]) * 16 + to_uint(value[20])),
-                static_cast<uint8_t>(to_uint(value[21]) * 16 + to_uint(value[22])),
-
-                static_cast<uint8_t>(to_uint(value[24]) * 16 + to_uint(value[25])),
-                static_cast<uint8_t>(to_uint(value[26]) * 16 + to_uint(value[27])),
-                static_cast<uint8_t>(to_uint(value[28]) * 16 + to_uint(value[29])),
-                static_cast<uint8_t>(to_uint(value[30]) * 16 + to_uint(value[31])),
-                static_cast<uint8_t>(to_uint(value[32]) * 16 + to_uint(value[33])),
-                static_cast<uint8_t>(to_uint(value[34]) * 16 + to_uint(value[35])),
-            }
-        };
-    }
-
     constexpr bool equal(guid const& left, guid const& right) noexcept
     {
         return left.Data1 == right.Data1 &&
@@ -86,6 +32,9 @@ namespace
         using B = IKeyValuePair<hstring, IAsyncOperationWithProgress<A, float>>;
 
         REQUIRE_EQUAL_GUID("96369F54-8EB6-48F0-ABCE-C1B211E627C3"sv, IStringable);
+
+        // Guid string literals
+        STATIC_REQUIRE(equal(L"96369F54-8EB6-48F0-ABCE-C1B211E627C3"_guid, guid_of<IStringable>()));
 
         //
         // Generated Windows.Foundation GUIDs


### PR DESCRIPTION
- Migrate logic from `generic_types.h` (test projects) to `winrt/base.h`.
- Add `_guid` string literal wrappers.
- Support for `std::wstring_view`.
- Address `std::string_view` ->`winrt::guid` parsing in #797. A version of formatting is available in `winrt::impl::to_array`.