### PR TITLE
Add a hook to throw_hresult for integration with WIL

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -426,6 +426,11 @@ WINRT_EXPORT namespace winrt
 
     [[noreturn]] inline __declspec(noinline) void throw_hresult(hresult const result)
     {
+        if (winrt_throw_hresult_handler)
+        {
+            winrt_throw_hresult_handler(0, nullptr, nullptr, _ReturnAddress(), result);
+        }
+
         if (result == impl::error_bad_alloc)
         {
             throw std::bad_alloc();

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -1,5 +1,6 @@
 
 __declspec(selectany) int32_t(__stdcall* winrt_to_hresult_handler)(void* address) noexcept {};
+__declspec(selectany) void(__stdcall* winrt_throw_hresult_handler)(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept {};
 __declspec(selectany) void(__stdcall* winrt_suspend_handler)(void const* token) noexcept {};
 __declspec(selectany) void(__stdcall* winrt_resume_handler)(void const* token) noexcept {};
 __declspec(selectany) int32_t(__stdcall* winrt_activation_handler)(void* classId, winrt::guid const& iid, void** factory) noexcept {};

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -36,6 +36,17 @@ namespace
         REQUIRE(false);
         return 0;
     }
+
+    static bool s_loggerCalled = false;
+
+    void __stdcall logger(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept
+    {
+        lineNumber; fileName; functionName;
+        REQUIRE(returnAddress);
+        REQUIRE(result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
+        s_loggerCalled = true;
+    }
+
 }
 
 TEST_CASE("custom_error")
@@ -49,4 +60,20 @@ TEST_CASE("custom_error")
 
     // Remove global handler
     winrt_to_hresult_handler = nullptr;
+}
+
+TEST_CASE("custom_error_logger")
+{
+    // Set up global handler
+    REQUIRE(!s_loggerCalled);
+    REQUIRE(!winrt_throw_hresult_handler);
+    winrt_throw_hresult_handler = logger;
+
+    // Validate that handler translated exception
+    REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
+    REQUIRE(s_loggerCalled);
+
+    // Remove global handler
+    winrt_throw_hresult_handler = nullptr;
+    s_loggerCalled = false;
 }


### PR DESCRIPTION
#841

## Why is this change being made?
This change is being made to improve the interop between cppwinrt and WIL (particularly WIL's logging abilities for errors).  It introduces a hook to the `winrt::throw_hresult` method that <wil/cppwinrt.h> will be able to fill in with a valid function pointer.  That function pointer will allow WIL's logging abilities to gain knowledge of the exceptions that are originated within cppwinrt.

## Briefly summarize what changed
An extern function pointer was created which is empty by default.  If it is set then `winrt::throw_hresult` will call it before continuing with actually throwing the exception.

One interesting note is that several of the parameters to `winrt_throw_hresult_handler` are not actually filled in.  There is an expectation that [C++20 source_location](https://en.cppreference.com/w/cpp/utility/source_location) will allow correct file/function/line annotation to these calls for optimum debuggability.  That hopefully isn't too far off in the future so the contract is being established now to avoid the need to change it soon in a backwards-compatible way.  Once source_location does come online there will be no changes needed on the WIL side to log them properly.

## How was the change tested?
`build_test_all.cmd` was used for this.  A new test case was added to confirm that throw_hresult does call the handler if set.  I also copied my private build of cppwinrt.exe to a test project to confirm that the generated base.h matches expectations.