### PR TITLE
Make return address extraction build (and even work) on non-MSVC compilers

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -1,4 +1,13 @@
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#define WINRT_IMPL_RETURNADDRESS() _ReturnAddress()
+#elif defined(__GNUC__)
+#define WINRT_IMPL_RETURNADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))
+#else
+#define WINRT_IMPL_RETURNADDRESS() nullptr
+#endif
+
 namespace winrt::impl
 {
     struct heap_traits
@@ -428,7 +437,7 @@ WINRT_EXPORT namespace winrt
     {
         if (winrt_throw_hresult_handler)
         {
-            winrt_throw_hresult_handler(0, nullptr, nullptr, _ReturnAddress(), result);
+            winrt_throw_hresult_handler(0, nullptr, nullptr, WINRT_IMPL_RETURNADDRESS(), result);
         }
 
         if (result == impl::error_bad_alloc)
@@ -508,7 +517,7 @@ WINRT_EXPORT namespace winrt
     {
         if (winrt_to_hresult_handler)
         {
-            return winrt_to_hresult_handler(_ReturnAddress());
+            return winrt_to_hresult_handler(WINRT_IMPL_RETURNADDRESS());
         }
 
         try
@@ -608,3 +617,5 @@ namespace winrt::impl
         return result;
     }
 }
+
+#undef WINRT_IMPL_RETURNADDRESS


### PR DESCRIPTION
At a minimum, avoid build breaks on non-MSVC compilers.

Turns out that gcc, clang, icc, djgpp, ellcc, and zapcc all define the symbol `__GNUC__` and support the gcc return address extraction extensions. So we need only test two symbols: `_MSC_VER` for MSVC, and `__GNUC__` for everyone else.

clang and icc implement the gcc extensions for compatibility. djgpp is built on top of gcc, so it inherits the gcc extensions. ellcc and zapcc are built on top of clang, so they inherit the gcc extensions via clang.

For MSVC, you must include `intrin.h` before using `_ReturnAddress()`, so we do that explicitly. rather than relying on the kindness of strangers (in this case, relying on apps having the `WindowsNumerics.impl.h` header file installed and leaving `_XM_NO_INTRINSICS_ ` undefined, so that `directxmath.h` will include `intrin.h` for us).

I opted against making this a caller-overridable thing, to avoid odr problems. If somebody tries to onboard a new compiler toolchain, the `custom_error_logger` test will fail (null return address), and they can make a PR to this repo to add return address support for it.