### PR TITLE
to_message() function extracts exception text from catch(...)

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -546,6 +546,31 @@ WINRT_EXPORT namespace winrt
         }
     }
 
+    inline __declspec(noinline) hstring to_message() noexcept
+    {
+        if (winrt_to_message_handler)
+        {
+            return winrt_to_message_handler(WINRT_IMPL_RETURNADDRESS());
+        }
+
+        try
+        {
+            throw;
+        }
+        catch (hresult_error const& e)
+        {
+            return e.message();
+        }
+        catch (std::exception const& ex)
+        {
+            return winrt::to_hstring(ex.what());
+        }
+        catch (...)
+        {
+            std::terminate();
+        }
+    }
+
     [[noreturn]] inline void throw_last_error()
     {
         throw_hresult(impl::hresult_from_win32(WINRT_IMPL_GetLastError()));

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -563,7 +563,7 @@ WINRT_EXPORT namespace winrt
         }
         catch (std::exception const& ex)
         {
-            return winrt::to_hstring(ex.what());
+            return to_hstring(ex.what());
         }
         catch (...)
         {

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -546,7 +546,7 @@ WINRT_EXPORT namespace winrt
         }
     }
 
-    inline __declspec(noinline) hstring to_message() noexcept
+    inline __declspec(noinline) hstring to_message()
     {
         if (winrt_to_message_handler)
         {

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -1,5 +1,6 @@
 
 __declspec(selectany) int32_t(__stdcall* winrt_to_hresult_handler)(void* address) noexcept {};
+__declspec(selectany) winrt::hstring(__stdcall* winrt_to_message_handler)(void* address) {};
 __declspec(selectany) void(__stdcall* winrt_throw_hresult_handler)(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept {};
 __declspec(selectany) void(__stdcall* winrt_suspend_handler)(void const* token) noexcept {};
 __declspec(selectany) void(__stdcall* winrt_resume_handler)(void const* token) noexcept {};

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -556,3 +556,23 @@ TEST_CASE("hresult, std abi support")
     }
 }
 
+TEST_CASE("hresult, to_message")
+{
+    try
+    {
+        throw std::out_of_range("oh no, out of range");
+    }
+    catch (...)
+    {
+        REQUIRE(to_message() == L"oh no, out of range");
+    }
+
+    try
+    {
+        throw hresult_error(E_HANDLE, L"oh no, invalid handle");
+    }
+    catch (...)
+    {
+        REQUIRE(to_message() == L"oh no, invalid handle");
+    }
+}


### PR DESCRIPTION
Handy for logging. This complements to_hresult().