### PR TITLE
To support local servers, use .exe files from dependent projects as Implementation in Microsoft.Windows.CppWinRT.targets

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -253,7 +253,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <WinMDFullPath Include="@(_CppWinRTProjectWinMDItems->FullPath()->Distinct()->ClearMetadata())" Condition="'$(CppWinRTGenerateWindowsMetadata)' == 'true'">
                 <TargetPath>$([System.IO.Path]::GetFileName('$(CppWinRTProjectWinMD)'))</TargetPath>
                 <Primary>true</Primary>
-                <Implementation Condition="'$(TargetExt)' == '.dll'">$(WinMDImplementationPath)$(TargetName)$(TargetExt)</Implementation>
+                <Implementation Condition="'$(TargetExt)' == '.dll' or '$(TargetExt)' == '.exe'">$(WinMDImplementationPath)$(TargetName)$(TargetExt)</Implementation>
                 <FileType>winmd</FileType>
                 <WinMDFile>true</WinMDFile>
                 <ProjectName>$(MSBuildProjectName)</ProjectName>


### PR DESCRIPTION
I found that if I create a WinRT local server project, a dependent app project won't build due to a missing file referenced in the .appxmanifest (the WinRT local server registration information that I added). The error lead me to this line in the build system that supports `.dll` dependents, but not `.exe`s. Adding the `.exe` test fixes this problem and seems appropriate (experts please advise).

With this change a warning is still produced, it seems to to missing support in the .appxmanifest generation support.
```
warning APPX1708: The executable 'WinRtLocalServer.exe' is specified as the implementation for the .winmd file 'C:\Users\chris\source\repos\ChrisGuzakWork\WinRtLocalServerClient\Debug\WinRtLocalServer.winmd'. 
Only in-process servers are supported for generating registration information in the app manifest. You must specify the out-of-process server registration information in the app manifest.
```
This can be ignored.
