### PR TITLE
Allow empty apartment_contexts

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -62,7 +62,7 @@ namespace winrt::impl
             m_context_type = std::exchange(other.m_context_type, -1);
             return *this;
         }
-        bool valid() const
+        bool valid() const noexcept
         {
             return m_context_type >= 0;
         }
@@ -359,8 +359,8 @@ WINRT_EXPORT namespace winrt
         apartment_context() = default;
         apartment_context(std::nullptr_t) : context(nullptr) { }
 
-        operator bool() const { return context.valid(); }
-        bool operator!() const { return !context.valid(); }
+        operator bool() const noexcept { return context.valid(); }
+        bool operator!() const noexcept { return !context.valid(); }
 
         bool await_ready() const noexcept
         {

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -50,6 +50,23 @@ namespace winrt::impl
 
     struct resume_apartment_context
     {
+        resume_apartment_context() = default;
+        resume_apartment_context(std::nullptr_t) : m_context(nullptr), m_context_type(-1) {}
+        resume_apartment_context(resume_apartment_context const&) = default;
+        resume_apartment_context(resume_apartment_context&& other) noexcept :
+            m_context(std::move(other.m_context)), m_context_type(std::exchange(other.m_context_type, -1)) {}
+        resume_apartment_context& operator=(resume_apartment_context const&) = default;
+        resume_apartment_context& operator=(resume_apartment_context&& other) noexcept
+        {
+            m_context = std::move(other.m_context);
+            m_context_type = std::exchange(other.m_context_type, -1);
+            return *this;
+        }
+        bool valid() const
+        {
+            return m_context_type >= 0;
+        }
+
         com_ptr<IContextCallback> m_context = try_capture<IContextCallback>(WINRT_IMPL_CoGetObjectContext);
         int32_t m_context_type = get_apartment_type().first;
     };
@@ -88,6 +105,7 @@ namespace winrt::impl
 
     inline auto resume_apartment(resume_apartment_context const& context, coroutine_handle<> handle)
     {
+        WINRT_ASSERT(context.valid());
         if ((context.m_context == nullptr) || (context.m_context == try_capture<IContextCallback>(WINRT_IMPL_CoGetObjectContext)))
         {
             handle();
@@ -338,6 +356,12 @@ WINRT_EXPORT namespace winrt
 
     struct apartment_context
     {
+        apartment_context() = default;
+        apartment_context(std::nullptr_t) : context(nullptr) { }
+
+        operator bool() const { return context.valid(); }
+        bool operator!() const { return !context.valid(); }
+
         bool await_ready() const noexcept
         {
             return false;


### PR DESCRIPTION
Constructing an apartment_context with nullptr creates an empty apartment context that cannot be used for anything, but you can later assign another apartment context to it.

This is handy if you don't want to capture the apartment context right now, but you have to declare the variable right now. For example, member variables are constructed when the containing class is constructed, even though you may not want to capture the apartment context until later.

Prior to this fix, you had to use std::optional to defer the construction of the apartment_context.

It's unfortunate that adding std::move support is so wordy.

We take advantage of this in the unit test itself: The code to generate an apartment_context from a IContextCallback, for example, needs to predeclare an empty apartment_context so that it can be filled in from inside the IContextCallback callback function.

An empty apartment_context is represented by an apartment type of -1, which is not a legal value: It corresponds to APTTYPE_CURRENT, which is never returned by CoGetApartmentType.