### PR TITLE
Visualizer should try to find winmd for interface and property types,…

### DIFF
--- a/natvis/cppwinrt_visualizer.cpp
+++ b/natvis/cppwinrt_visualizer.cpp
@@ -100,8 +100,14 @@ void LoadMetadata(DkmProcess* process, WCHAR const* processPath, std::string_vie
         if (FindMetadata(process, winmd_path))
         {
             MetadataDiagnostic(process, L"Loaded ", winmd_path);
-            db_files.push_back(winmd_path.string());
-            db->add_database(winmd_path.string());
+
+            auto const path_string = winmd_path.string();
+
+            if (std::find(db_files.begin(), db_files.end(), path_string) == db_files.end())
+            {
+                db->add_database(path_string);
+                db_files.push_back(path_string);
+            }
         }
         auto pos = probe_file.rfind('.');
         if (pos == std::string::npos)
@@ -125,6 +131,19 @@ TypeDef FindType(DkmProcess* process, std::string_view const& typeName)
             NatvisDiagnostic(process,
                 std::wstring(L"Could not find metadata for ") + std::wstring(typeName.begin(), typeName.end()), NatvisDiagnosticLevel::Error);
         }
+    }
+    return type;
+}
+
+TypeDef FindType(DkmProcess* process, std::string_view const& typeNamespace, std::string_view const& typeName)
+{
+    auto type = db->find(typeNamespace, typeName);
+    if (!type)
+    {
+        std::string fullName(typeNamespace);
+        fullName.append(".");
+        fullName.append(typeName);
+        FindType(process, fullName);
     }
     return type;
 }

--- a/natvis/object_visualizer.cpp
+++ b/natvis/object_visualizer.cpp
@@ -361,7 +361,11 @@ void GetInterfaceData(
     _Inout_ std::vector<PropertyData>& propertyData,
     _Out_ bool& isStringable
 ){
-    auto [type, propIid] = ResolveTypeInterface(index);
+    auto [type, propIid] = ResolveTypeInterface(process, index);
+    if (!type)
+    {
+        return;
+    }
 
     if (propIid == IID_IStringable)
     {
@@ -402,7 +406,12 @@ void GetInterfaceData(
             },
             [&](coded_index<TypeDefOrRef> const& index)
             {
-                auto type = ResolveType(index);
+                auto type = ResolveType(process, index);
+                if (!type)
+                {
+                    return;
+                }
+
                 auto typeName = type.TypeName();
                 if (typeName == "GUID"sv)
                 {

--- a/natvis/pch.h
+++ b/natvis/pch.h
@@ -89,21 +89,22 @@ inline bool starts_with(std::string_view const& value, std::string_view const& m
 }
 
 winmd::reader::TypeDef FindType(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string_view const& typeName);
+winmd::reader::TypeDef FindType(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string_view const& typeNamespace, std::string_view const& typeName);
 
-inline winmd::reader::TypeDef ResolveType(winmd::reader::coded_index<winmd::reader::TypeDefOrRef> index) noexcept
+inline winmd::reader::TypeDef ResolveType(Microsoft::VisualStudio::Debugger::DkmProcess* process, winmd::reader::coded_index<winmd::reader::TypeDefOrRef> index) noexcept
 {
     switch (index.type())
     {
     case winmd::reader::TypeDefOrRef::TypeDef:
         return index.TypeDef();
     case winmd::reader::TypeDefOrRef::TypeRef:
-        return winmd::reader::find_required(index.TypeRef());
+        return FindType(process, index.TypeRef().TypeNamespace(), index.TypeRef().TypeName());
     default: //case TypeDefOrRef::TypeSpec:
         return winmd::reader::find_required(index.TypeSpec().Signature().
             GenericTypeInst().GenericType().TypeRef());
     }
 }
 
-std::pair<winmd::reader::TypeDef, std::wstring> ResolveTypeInterface(winmd::reader::coded_index<winmd::reader::TypeDefOrRef> index);
+std::pair<winmd::reader::TypeDef, std::wstring> ResolveTypeInterface(Microsoft::VisualStudio::Debugger::DkmProcess* process, winmd::reader::coded_index<winmd::reader::TypeDefOrRef> index);
 
 void ClearTypeResolver();

--- a/natvis/type_resolver.cpp
+++ b/natvis/type_resolver.cpp
@@ -3,6 +3,7 @@
 using namespace winrt;
 using namespace winmd::reader;
 using namespace std::literals;
+using namespace Microsoft::VisualStudio::Debugger;
 
 static std::map<coded_index<TypeDefOrRef>, std::pair<TypeDef, std::wstring>> _cache;
 
@@ -277,14 +278,19 @@ static guid generate_guid(coded_index<TypeDefOrRef> const& type)
     return set_named_guid_fields(endian_swap(to_guid(calculate_sha1(buffer))));
 }
 
-std::pair<TypeDef, std::wstring> ResolveTypeInterface(coded_index<TypeDefOrRef> index)
+std::pair<TypeDef, std::wstring> ResolveTypeInterface(DkmProcess* process, coded_index<TypeDefOrRef> index)
 {
     if (auto found = _cache.find(index); found != _cache.end())
     {
         return found->second;
     }
 
-    TypeDef type = ResolveType(index);
+    TypeDef type = ResolveType(process, index);
+    if (!type)
+    {
+        return {};
+    }
+
     auto guid = index.type() == TypeDefOrRef::TypeSpec ?
         format_guid(generate_guid(index)) : format_guid(get_guid(type));
 


### PR DESCRIPTION
… and should fail more gracefully when not found.

Currently, if the visualizer only tries to load up new winmds for missing runtimeclasses in the case of top-level types and their bases. It then assumes the type graph should be fully resolvable, even for interfaces and properties, and throws an exception if they aren't found at this point.

There are two problems with this approach:
1. Just because a runtimeclass has its winmd loaded, this doesn't guarantee that its interfaces and property types have had their winmds loaded. Like `runtimeclass MyApp.Foo { Component.Widget MyProperty; }` - we may have loaded MyApp.winmd, but that doesn't mean Component.winmd has been loaded, so we should extend the metadata loading courtesy to interface and property lookups.
2.  Following from 1. if we then try to load a missing winmd, and still can't find the type, we shouldn't throw an exception and take down the debugger process. We should fail gracefully and skip those interfaces and/or properties that we couldn't resolve.