### PR TITLE
abort

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -567,7 +567,7 @@ WINRT_EXPORT namespace winrt
         }
         catch (...)
         {
-            std::terminate();
+            abort();
         }
     }
 

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -29,7 +29,7 @@ namespace winrt::impl
             }
             else if (remaining < 0)
             {
-                std::terminate();
+                abort();
             }
 
             return remaining;
@@ -116,7 +116,7 @@ namespace winrt::impl
 
         if (value[length] != 0)
         {
-            std::terminate();
+            abort();
         }
 
         header.flags = hstring_reference_flag;

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -36,7 +36,7 @@ namespace winrt::impl
         }
         else 
         {
-            std::terminate();
+            abort();
         }
     }
 
@@ -89,7 +89,7 @@ WINRT_EXPORT namespace winrt
         {
             if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
             {
-                std::terminate();
+                abort();
             }
 
             return


### PR DESCRIPTION
Switched remaining `std::terminate` calls to `abort` - more exhaustive testing with Clang still runs into issues in some dev environments. 