### PR TITLE
Allow IAsync...WithProgress to report intermediate results

### DIFF
--- a/test/old_tests/UnitTests/async.cpp
+++ b/test/old_tests/UnitTests/async.cpp
@@ -832,7 +832,8 @@ TEST_CASE("async, Cancel_IAsyncActionWithProgress")
     handle event { CreateEvent(nullptr, false, false, nullptr)};
     IAsyncActionWithProgress<double> async = Cancel_IAsyncActionWithProgress(event.get());
     REQUIRE(async.Status() == AsyncStatus::Started);
-    REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+    // It is legal to read results of an incomplete WithProgress.
+    REQUIRE_NOTHROW(async.GetResults());
 
     async.Cancel();
     SetEvent(event.get()); // signal async to run
@@ -862,7 +863,8 @@ TEST_CASE("async, Cancel_IAsyncActionWithProgress, 2")
     handle event { CreateEvent(nullptr, false, false, nullptr)};
     IAsyncActionWithProgress<double> async = Cancel_IAsyncActionWithProgress(event.get());
     REQUIRE(async.Status() == AsyncStatus::Started);
-    REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+    // It is legal to read results of an incomplete WithProgress.
+    REQUIRE_NOTHROW(async.GetResults());
 
     bool completed = false;
     bool objectMatches = false;
@@ -952,7 +954,8 @@ TEST_CASE("async, Cancel_IAsyncOperationWithProgress")
     handle event { CreateEvent(nullptr, false, false, nullptr)};
     IAsyncOperationWithProgress<uint64_t, uint64_t> async = Cancel_IAsyncOperationWithProgress(event.get());
     REQUIRE(async.Status() == AsyncStatus::Started);
-    REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+    // It is legal to read results of an incomplete WithProgress.
+    REQUIRE_NOTHROW(async.GetResults());
 
     async.Cancel();
     SetEvent(event.get()); // signal async to run
@@ -982,7 +985,8 @@ TEST_CASE("async, Cancel_IAsyncOperationWithProgress, 2")
     handle event { CreateEvent(nullptr, false, false, nullptr)};
     IAsyncOperationWithProgress<uint64_t, uint64_t> async = Cancel_IAsyncOperationWithProgress(event.get());
     REQUIRE(async.Status() == AsyncStatus::Started);
-    REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+    // It is legal to read results of an incomplete WithProgress.
+    REQUIRE_NOTHROW(async.GetResults());
 
     bool completed = false;
     bool objectMatches = false;

--- a/test/test/async_result.cpp
+++ b/test/test/async_result.cpp
@@ -40,7 +40,15 @@ namespace
         handle completed{ CreateEvent(nullptr, true, false, nullptr) };
         auto async = make(start.get());
         REQUIRE(async.Status() == AsyncStatus::Started);
-        REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        if constexpr (has_async_progress<decltype(async)>)
+        {
+            // You're allowed to peek at partial results of IAsyncXxxWithProgress.
+            REQUIRE_NOTHROW(async.GetResults());
+        }
+        else
+        {
+            REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        }
 
         async.Completed([&](auto&& sender, AsyncStatus status)
             {

--- a/test/test/async_suspend.cpp
+++ b/test/test/async_suspend.cpp
@@ -49,7 +49,15 @@ namespace
         handle completed{ CreateEvent(nullptr, true, false, nullptr) };
         auto async = make(start.get());
         REQUIRE(async.Status() == AsyncStatus::Started);
-        REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        if constexpr (has_async_progress<decltype(async)>)
+        {
+            // You're allowed to peek at partial results of IAsyncXxxWithProgress.
+            REQUIRE_NOTHROW(async.GetResults());
+        }
+        else
+        {
+            REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        }
 
         async.Completed([&](auto&& sender, AsyncStatus status)
             {

--- a/test/test/pch.h
+++ b/test/test/pch.h
@@ -10,3 +10,39 @@
 #include "catch.hpp"
 
 using namespace std::literals;
+
+// Extracts return and progress types from IAsyncXxx.
+
+template<typename T>
+struct async_traits;
+
+template<>
+struct async_traits<winrt::Windows::Foundation::IAsyncAction>
+{
+    using progress_type = void;
+};
+
+template<typename P>
+struct async_traits<winrt::Windows::Foundation::IAsyncActionWithProgress<P>>
+{
+    using progress_type = P;
+};
+
+template<typename R>
+struct async_traits<winrt::Windows::Foundation::IAsyncOperation<R>>
+{
+    using progress_type = void;
+};
+
+template<typename R, typename P>
+struct async_traits<winrt::Windows::Foundation::IAsyncOperationWithProgress<R, P>>
+{
+    using progress_type = P;
+};
+
+template<typename T>
+using async_return_type = decltype(std::declval<T>().GetResults());
+template<typename T>
+using async_progress_type = typename async_traits<std::decay_t<T>>::progress_type;
+template<typename T>
+inline constexpr bool has_async_progress = !std::is_same_v<void, async_traits<std::decay_t<T>>::progress_type>;

--- a/test/test_win7/async_result.cpp
+++ b/test/test_win7/async_result.cpp
@@ -40,7 +40,15 @@ namespace
         handle completed{ CreateEvent(nullptr, true, false, nullptr) };
         auto async = make(start.get());
         REQUIRE(async.Status() == AsyncStatus::Started);
-        REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        if constexpr (has_async_progress<decltype(async)>)
+        {
+            // You're allowed to peek at partial results of IAsyncXxxWithProgress.
+            REQUIRE_NOTHROW(async.GetResults());
+        }
+        else
+        {
+            REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        }
 
         async.Completed([&](auto&& sender, AsyncStatus status)
             {

--- a/test/test_win7/async_suspend.cpp
+++ b/test/test_win7/async_suspend.cpp
@@ -49,7 +49,15 @@ namespace
         handle completed{ CreateEvent(nullptr, true, false, nullptr) };
         auto async = make(start.get());
         REQUIRE(async.Status() == AsyncStatus::Started);
-        REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        if constexpr (has_async_progress<decltype(async)>)
+        {
+            // You're allowed to peek at partial results of IAsyncXxxWithProgress.
+            REQUIRE_NOTHROW(async.GetResults());
+        }
+        else
+        {
+            REQUIRE_THROWS_AS(async.GetResults(), hresult_illegal_method_call);
+        }
 
         async.Completed([&](auto&& sender, AsyncStatus status)
             {

--- a/test/test_win7/pch.h
+++ b/test/test_win7/pch.h
@@ -7,3 +7,39 @@
 #include "catch.hpp"
 
 using namespace std::literals;
+
+// Extracts return and progress types from IAsyncXxx.
+
+template<typename T>
+struct async_traits;
+
+template<>
+struct async_traits<winrt::Windows::Foundation::IAsyncAction>
+{
+    using progress_type = void;
+};
+
+template<typename P>
+struct async_traits<winrt::Windows::Foundation::IAsyncActionWithProgress<P>>
+{
+    using progress_type = P;
+};
+
+template<typename R>
+struct async_traits<winrt::Windows::Foundation::IAsyncOperation<R>>
+{
+    using progress_type = void;
+};
+
+template<typename R, typename P>
+struct async_traits<winrt::Windows::Foundation::IAsyncOperationWithProgress<R, P>>
+{
+    using progress_type = P;
+};
+
+template<typename T>
+using async_return_type = decltype(std::declval<T>().GetResults());
+template<typename T>
+using async_progress_type = typename async_traits<std::decay_t<T>>::progress_type;
+template<typename T>
+inline constexpr bool has_async_progress = !std::is_same_v<void, async_traits<std::decay_t<T>>::progress_type>;


### PR DESCRIPTION
Clients of IAsync...WithProgress are permitted to call GetResults() before the operation has completed, allowing them to observe partial results. This behavior is necessary because the Progress type must be a value type, but the operation may want to report reference types in their progress reports. The way to do that is to report the reference type as the GetResults().

The coroutine itself can use the `set_result()` method on the progress token to report a result prior to completion, and can set a new intermediate result as often as desired prior to the completion of the coroutine. The value passed to `co_return` acts as the final result of the coroutine. If `set_result()` is never called, then the intermediate result is an empty result (null for reference types, default-initialized for value types).

In practice, the result of the coroutine is usually a reference type, and the common pattern for coroutines that want to report a reference type as progress is to create the result object, pass it to `set_result()` at the start of the coroutine, update the result object as the coroutine progresses, and (redundantly) pass the same result object to `co_return` when the coroutine completes.

```cpp
IAsyncOperationWithProgress<Muffin, double> BakeMuffinAsync()
{
    auto progress = co_await get_progress_token();

    Muffin muffin;
    Muffin.Diameter(5);
    progress.set_result(muffin);
    progress(0.0);

    muffin.Diameter(5.2);
    progress(0.5);

    muffin.Diameter(6);
    progress(1.0);

    co_return muffin;
}
```

Since clients of ...WithProgress are permitted to call GetResults() prior to completion, this introduces a few new wrinkles.

1. We need to use the lock to ensure a client doesn't try to read a partial result at the same time we are writing a new one.
2. The GetResults() method must return a copy of the result. This is true even if the coroutine has completed, because a progress handler might go off and do some asynchronous work, and then come back and ask for the intermediate result. If GetResults() on a completed coroutine consumes the result, then the async progress handler and the co_await will compete to retrieve the completed results, and somebody will lose.

As a result, ...WithProgress coroutines are slightly more expensive than non-progress coroutines due to the extra locking and copying. Fortunately, it's mostly pay-for-play. If a coroutine never calls `set_result()`, and the client never calls `GetResults()` from its progress handler, then there is no new lock contention. The final copy is unavoidable, but fortunately, the result is usually a reference type, so you just pay an extra AddRef/Release pair.