### PR TITLE
Don't fail file open/writes silently

### DIFF
--- a/cppwinrt/main.cpp
+++ b/cppwinrt/main.cpp
@@ -8,6 +8,7 @@
 #include "component_writers.h"
 #include "file_writers.h"
 #include "type_writers.h"
+#include <winternl.h>
 
 namespace cppwinrt
 {
@@ -374,5 +375,7 @@ Where <spec> is one or more of:
 
 int main(int const argc, char** argv)
 {
+    // Dynamically enable long path support
+    ((unsigned char*)(NtCurrentTeb()->ProcessEnvironmentBlock))[3] |= 0x80;
     return cppwinrt::run(argc, argv);
 }

--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -157,9 +157,16 @@ namespace cppwinrt
         {
             if (!file_equal(filename))
             {
-                std::ofstream file{ filename, std::ios::out | std::ios::binary };
-                file.write(m_first.data(), m_first.size());
-                file.write(m_second.data(), m_second.size());
+                std::ofstream file;
+                file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+                try {
+                  file.open(filename, std::ios::out | std::ios::binary);
+                  file.write(m_first.data(), m_first.size());
+                  file.write(m_second.data(), m_second.size());
+                }
+                catch (std::ofstream::failure const& e) {
+                  throw std::filesystem::filesystem_error(e.what(), filename, std::io_errc::stream);
+                }
             }
             m_first.clear();
             m_second.clear();


### PR DESCRIPTION
Fixes #877 

## Context
React Native for Windows creates apps that can end up with some paths that need to be built that are too long (e.g. `C:\users\myname\source\repos\MyAppProject\node_modules\react-native-windows\Microsoft.ReactNative\Generated Files\winrt\Insert.Your.Favorite.Long.Namespace.Here.h` ). We see lots of issues where people are creating their project starting in an already pretty deeply-nested folder, and the build fails. 

## Root cause
The reason the build fails is because certain headers that cppwinrt is supposed to generate are not on disk. After tracing this down, it turns out that this comes from the fact that the `std::ofstream` constructor does not throw on error. Instead, it will set its internal handle to null, and you have to check `myofstream.good()` before continuing. The alternative is to construct an empty `ofstream`, set a flag that says you want exceptions, and then call `open()`, which is what I ended up doing.

With that part of the fix, you now get an error instead of "silently failing and returning success" which today causes the build to fail later on:

![image](https://user-images.githubusercontent.com/22989529/110621642-4e3dbb00-814f-11eb-9c7e-ab139e716951.png)

The second part of the fix is to turn on Long Path support. This normally requires a manifest. I tried embedding the manifest through VS and jumping through all them hoopz, but in the end the alternative is one line in `main()` to set a bit in the PEB. With that fix, at least long path errors won't be a thing (as long as you have the per-machine setting turned on too); but now also if we fail to write a file (e.g. file was held open exclusively), we will now correctly get an error instead of silently failing/succeeding.
