### PR TITLE
use app manifest

### DIFF
--- a/cppwinrt/app.manifest
+++ b/cppwinrt/app.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+</application>
+</assembly>

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -111,6 +111,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D613FB39-5035-4043-91E2-BAB323908AF4}</ProjectGuid>
@@ -265,6 +268,9 @@
       <Command>
       </Command>
     </PostBuildEvent>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -175,4 +175,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
 </Project>

--- a/cppwinrt/main.cpp
+++ b/cppwinrt/main.cpp
@@ -8,7 +8,6 @@
 #include "component_writers.h"
 #include "file_writers.h"
 #include "type_writers.h"
-#include <winternl.h>
 
 namespace cppwinrt
 {
@@ -375,7 +374,5 @@ Where <spec> is one or more of:
 
 int main(int const argc, char** argv)
 {
-    // Dynamically enable long path support
-    ((unsigned char*)(NtCurrentTeb()->ProcessEnvironmentBlock))[3] |= 0x80;
     return cppwinrt::run(argc, argv);
 }


### PR DESCRIPTION
In #880 we had a hacky way to enable long path support; here we do it via manifest
CC @oldnewthing