### PR TITLE
Use compiler-specific WINRT_IMPL_NOINLINE macro for noinline functions

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -26,7 +26,7 @@ namespace winrt::impl
 
 
     template <bool isSameInterfaceAsIActivationFactory>
-    __declspec(noinline) hresult get_runtime_activation_factory_impl(param::hstring const& name, winrt::guid const& guid, void** result) noexcept
+    WINRT_IMPL_NOINLINE hresult get_runtime_activation_factory_impl(param::hstring const& name, winrt::guid const& guid, void** result) noexcept
     {
         if (winrt_activation_handler)
         {
@@ -339,7 +339,7 @@ namespace winrt::impl
     struct factory_cache_entry : factory_cache_entry_base
     {
         template <typename F>
-        __declspec(noinline) auto call(F&& callback)
+        WINRT_IMPL_NOINLINE auto call(F&& callback)
         {
 #ifdef WINRT_DIAGNOSTICS
             get_diagnostics_info().add_factory<Class>();

--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -214,7 +214,7 @@ WINRT_EXPORT namespace winrt
             }
         }
 
-        __declspec(noinline) void unconditional_release_ref() noexcept
+        WINRT_IMPL_NOINLINE void unconditional_release_ref() noexcept
         {
             std::exchange(m_ptr, {})->Release();
         }

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -433,7 +433,7 @@ WINRT_EXPORT namespace winrt
         hresult_canceled(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_canceled, take_ownership_from_abi) {}
     };
 
-    [[noreturn]] inline __declspec(noinline) void throw_hresult(hresult const result)
+    [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result)
     {
         if (winrt_throw_hresult_handler)
         {
@@ -513,7 +513,7 @@ WINRT_EXPORT namespace winrt
         throw hresult_error(result, take_ownership_from_abi);
     }
 
-    inline __declspec(noinline) hresult to_hresult() noexcept
+    inline WINRT_IMPL_NOINLINE hresult to_hresult() noexcept
     {
         if (winrt_to_hresult_handler)
         {
@@ -546,7 +546,7 @@ WINRT_EXPORT namespace winrt
         }
     }
 
-    inline __declspec(noinline) hstring to_message()
+    inline WINRT_IMPL_NOINLINE hstring to_message()
     {
         if (winrt_to_message_handler)
         {

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -45,6 +45,14 @@
 #undef _WINDOWS_NUMERICS_END_NAMESPACE_
 #endif
 
+#if defined(_MSC_VER)
+#define WINRT_IMPL_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define WINRT_IMPL_NOINLINE __attribute__((noinline))
+#else
+#define WINRT_IMPL_NOINLINE
+#endif
+
 #ifdef __IUnknown_INTERFACE_DEFINED__
 #define WINRT_IMPL_IUNKNOWN_DEFINED
 #endif

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -257,7 +257,7 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
             }
         }
 
-        __declspec(noinline) void unconditional_release_ref() noexcept
+        WINRT_IMPL_NOINLINE void unconditional_release_ref() noexcept
         {
             std::exchange(m_ptr, {})->Release();
         }


### PR DESCRIPTION
Different toolchains use different ways of marking a function as not inlinable. Wrap it inside a macro so we can accommodate the differences.

Fortunately, all of them insert the marker at the same place (between the "inline" keyword and the return type).