### PR TITLE
Restore Win7 compat by using old versions of threadpool functions

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -414,7 +414,7 @@ WINRT_EXPORT namespace winrt
                 m_handle = handle;
                 m_timer.attach(check_pointer(WINRT_IMPL_CreateThreadpoolTimer(callback, this, nullptr)));
                 int64_t relative_count = -m_duration.count();
-                WINRT_IMPL_SetThreadpoolTimerEx(m_timer.get(), &relative_count, 0, 0);
+                WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &relative_count, 0, 0);
 
                 state expected = state::idle;
                 if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
@@ -435,10 +435,10 @@ WINRT_EXPORT namespace winrt
 
             void fire_immediately() noexcept
             {
-                if (WINRT_IMPL_SetThreadpoolTimerEx(m_timer.get(), nullptr, 0, 0))
+                if (WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), nullptr, 0, 0))
                 {
                     int64_t now = 0;
-                    WINRT_IMPL_SetThreadpoolTimerEx(m_timer.get(), &now, 0, 0);
+                    WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &now, 0, 0);
                 }
             }
 
@@ -513,7 +513,7 @@ WINRT_EXPORT namespace winrt
                 m_wait.attach(check_pointer(WINRT_IMPL_CreateThreadpoolWait(callback, this, nullptr)));
                 int64_t relative_count = -m_timeout.count();
                 int64_t* file_time = relative_count != 0 ? &relative_count : nullptr;
-                WINRT_IMPL_SetThreadpoolWaitEx(m_wait.get(), m_handle, file_time, nullptr);
+                WINRT_IMPL_SetThreadpoolWait(m_wait.get(), m_handle, file_time);
 
                 state expected = state::idle;
                 if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
@@ -535,10 +535,10 @@ WINRT_EXPORT namespace winrt
 
             void fire_immediately() noexcept
             {
-                if (WINRT_IMPL_SetThreadpoolWaitEx(m_wait.get(), nullptr, nullptr, nullptr))
+                if (WINRT_IMPL_SetThreadpoolWait(m_wait.get(), nullptr, nullptr))
                 {
                     int64_t now = 0;
-                    WINRT_IMPL_SetThreadpoolWaitEx(m_wait.get(), WINRT_IMPL_GetCurrentProcess(), &now, nullptr);
+                    WINRT_IMPL_SetThreadpoolWait(m_wait.get(), WINRT_IMPL_GetCurrentProcess(), &now);
                 }
             }
 

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -65,10 +65,10 @@ extern "C"
 
     int32_t  __stdcall WINRT_IMPL_TrySubmitThreadpoolCallback(void(__stdcall *callback)(void*, void* context), void* context, void*) noexcept;
     winrt::impl::ptp_timer __stdcall WINRT_IMPL_CreateThreadpoolTimer(void(__stdcall *callback)(void*, void* context, void*), void* context, void*) noexcept;
-    int32_t  __stdcall WINRT_IMPL_SetThreadpoolTimerEx(winrt::impl::ptp_timer timer, void* time, uint32_t period, uint32_t window) noexcept;
+    int32_t  __stdcall WINRT_IMPL_SetThreadpoolTimer(winrt::impl::ptp_timer timer, void* time, uint32_t period, uint32_t window) noexcept;
     void     __stdcall WINRT_IMPL_CloseThreadpoolTimer(winrt::impl::ptp_timer timer) noexcept;
     winrt::impl::ptp_wait __stdcall WINRT_IMPL_CreateThreadpoolWait(void(__stdcall *callback)(void*, void* context, void*, uint32_t result), void* context, void*) noexcept;
-    int32_t  __stdcall WINRT_IMPL_SetThreadpoolWaitEx(winrt::impl::ptp_wait wait, void* handle, void* timeout, void* reserved) noexcept;
+    int32_t  __stdcall WINRT_IMPL_SetThreadpoolWait(winrt::impl::ptp_wait wait, void* handle, void* timeout) noexcept;
     void     __stdcall WINRT_IMPL_CloseThreadpoolWait(winrt::impl::ptp_wait wait) noexcept;
     winrt::impl::ptp_io __stdcall WINRT_IMPL_CreateThreadpoolIo(void* object, void(__stdcall *callback)(void*, void* context, void* overlapped, uint32_t result, std::size_t bytes, void*) noexcept, void* context, void*) noexcept;
     void     __stdcall WINRT_IMPL_StartThreadpoolIo(winrt::impl::ptp_io io) noexcept;
@@ -149,10 +149,10 @@ WINRT_IMPL_LINK(WaitForSingleObject, 8)
 
 WINRT_IMPL_LINK(TrySubmitThreadpoolCallback, 12)
 WINRT_IMPL_LINK(CreateThreadpoolTimer, 12)
-WINRT_IMPL_LINK(SetThreadpoolTimerEx, 16)
+WINRT_IMPL_LINK(SetThreadpoolTimer, 16)
 WINRT_IMPL_LINK(CloseThreadpoolTimer, 4)
 WINRT_IMPL_LINK(CreateThreadpoolWait, 12)
-WINRT_IMPL_LINK(SetThreadpoolWaitEx, 16)
+WINRT_IMPL_LINK(SetThreadpoolWait, 12)
 WINRT_IMPL_LINK(CloseThreadpoolWait, 4)
 WINRT_IMPL_LINK(CreateThreadpoolIo, 16)
 WINRT_IMPL_LINK(StartThreadpoolIo, 4)


### PR DESCRIPTION
Fortunately, the Ex versions behave the same as the Win7 versions, so we can just switch everybody to the Win7 versions.

Fixes #894 