### PR TITLE
Restore Win7 functionality (more correctly this time)

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -34,7 +34,7 @@ namespace winrt::impl
         }
 
         static int32_t(__stdcall * handler)(void* classId, winrt::guid const& iid, void** factory) noexcept;
-        impl::load_runtime_function("RoGetActivationFactory", handler, fallback_RoGetActivationFactory);
+        impl::load_runtime_function(L"combase.dll", "RoGetActivationFactory", handler, fallback_RoGetActivationFactory);
         hresult hr = handler(*(void**)(&name), guid, result);
 
         if (hr == impl::error_not_initialized)

--- a/strings/base_agile_ref.h
+++ b/strings/base_agile_ref.h
@@ -122,14 +122,14 @@ namespace winrt::impl
     };
 
     template <typename F, typename L>
-    void load_runtime_function(char const* name, F& result, L fallback) noexcept
+    void load_runtime_function(wchar_t const* library, char const* name, F& result, L fallback) noexcept
     {
         if (result)
         {
             return;
         }
 
-        result = reinterpret_cast<F>(WINRT_IMPL_GetProcAddress(WINRT_IMPL_LoadLibraryW(L"combase.dll"), name));
+        result = reinterpret_cast<F>(WINRT_IMPL_GetProcAddress(WINRT_IMPL_LoadLibraryW(library), name));
 
         if (result)
         {
@@ -167,7 +167,7 @@ namespace winrt::impl
     inline hresult get_agile_reference(winrt::guid const& iid, void* object, void** reference) noexcept
     {
         static int32_t(__stdcall * handler)(uint32_t options, winrt::guid const& iid, void* object, void** reference) noexcept;
-        load_runtime_function("RoGetAgileReference", handler, fallback_RoGetAgileReference);
+        load_runtime_function(L"combase.dll", "RoGetAgileReference", handler, fallback_RoGetAgileReference);
         return handler(0, iid, object, reference);
     }
 }

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -433,9 +433,17 @@ WINRT_EXPORT namespace winrt
 
         private:
 
+            static int32_t __stdcall fallback_SetThreadpoolTimerEx(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept
+            {
+                return 0; // pretend timer has already triggered and a callback is on its way
+            }
+
             void fire_immediately() noexcept
             {
-                if (WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), nullptr, 0, 0))
+                static int32_t(__stdcall* handler)(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept;
+                impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolTimerEx", handler, fallback_SetThreadpoolTimerEx);
+
+                if (handler(m_timer.get(), nullptr, 0, 0))
                 {
                     int64_t now = 0;
                     WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &now, 0, 0);
@@ -532,10 +540,17 @@ WINRT_EXPORT namespace winrt
             }
 
         private:
+            static int32_t __stdcall fallback_SetThreadpoolWaitEx(winrt::impl::ptp_wait, void*, void*, void*) noexcept
+            {
+                return 0; // pretend wait has already triggered and a callback is on its way
+            }
 
             void fire_immediately() noexcept
             {
-                if (WINRT_IMPL_SetThreadpoolWait(m_wait.get(), nullptr, nullptr))
+                static int32_t(__stdcall* handler)(winrt::impl::ptp_wait, void*, void*, void*) noexcept;
+                impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolWaitEx", handler, fallback_SetThreadpoolWaitEx);
+
+                if (handler(m_wait.get(), nullptr, nullptr, nullptr))
                 {
                     int64_t now = 0;
                     WINRT_IMPL_SetThreadpoolWait(m_wait.get(), WINRT_IMPL_GetCurrentProcess(), &now);

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -312,7 +312,7 @@ WINRT_EXPORT namespace winrt
         void originate(hresult const code, void* message) noexcept
         {
             static int32_t(__stdcall* handler)(int32_t error, void* message, void* exception) noexcept;
-            impl::load_runtime_function("RoOriginateLanguageException", handler, fallback_RoOriginateLanguageException);
+            impl::load_runtime_function(L"combase.dll", "RoOriginateLanguageException", handler, fallback_RoOriginateLanguageException);
             WINRT_VERIFY(handler(code, message, nullptr));
 
             com_ptr<impl::IErrorInfo> info;
@@ -625,7 +625,7 @@ WINRT_EXPORT namespace winrt
     [[noreturn]] inline void terminate() noexcept
     {
         static void(__stdcall * handler)(int32_t) noexcept;
-        impl::load_runtime_function("RoFailFastWithErrorContext", handler, impl::fallback_RoFailFastWithErrorContext);
+        impl::load_runtime_function(L"combase.dll", "RoFailFastWithErrorContext", handler, impl::fallback_RoFailFastWithErrorContext);
         handler(to_hresult());
         abort();
     }

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -352,7 +352,7 @@ namespace winrt::impl
             int32_t const code = to_hresult();
 
             static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
-            impl::load_runtime_function("RoTransformError", handler, fallback_RoTransformError);
+            impl::load_runtime_function(L"combase.dll", "RoTransformError", handler, fallback_RoTransformError);
             handler(code, 0, nullptr);
 
             if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -65,10 +65,10 @@ extern "C"
 
     int32_t  __stdcall WINRT_IMPL_TrySubmitThreadpoolCallback(void(__stdcall *callback)(void*, void* context), void* context, void*) noexcept;
     winrt::impl::ptp_timer __stdcall WINRT_IMPL_CreateThreadpoolTimer(void(__stdcall *callback)(void*, void* context, void*), void* context, void*) noexcept;
-    int32_t  __stdcall WINRT_IMPL_SetThreadpoolTimer(winrt::impl::ptp_timer timer, void* time, uint32_t period, uint32_t window) noexcept;
+    void     __stdcall WINRT_IMPL_SetThreadpoolTimer(winrt::impl::ptp_timer timer, void* time, uint32_t period, uint32_t window) noexcept;
     void     __stdcall WINRT_IMPL_CloseThreadpoolTimer(winrt::impl::ptp_timer timer) noexcept;
     winrt::impl::ptp_wait __stdcall WINRT_IMPL_CreateThreadpoolWait(void(__stdcall *callback)(void*, void* context, void*, uint32_t result), void* context, void*) noexcept;
-    int32_t  __stdcall WINRT_IMPL_SetThreadpoolWait(winrt::impl::ptp_wait wait, void* handle, void* timeout) noexcept;
+    void     __stdcall WINRT_IMPL_SetThreadpoolWait(winrt::impl::ptp_wait wait, void* handle, void* timeout) noexcept;
     void     __stdcall WINRT_IMPL_CloseThreadpoolWait(winrt::impl::ptp_wait wait) noexcept;
     winrt::impl::ptp_io __stdcall WINRT_IMPL_CreateThreadpoolIo(void* object, void(__stdcall *callback)(void*, void* context, void* overlapped, uint32_t result, std::size_t bytes, void*) noexcept, void* context, void*) noexcept;
     void     __stdcall WINRT_IMPL_StartThreadpoolIo(winrt::impl::ptp_io io) noexcept;


### PR DESCRIPTION
Win7 cannot cancel threadpool timers or threadpool waits atomically, so we simply disable cancellation of resume_after and resume_on_signal when running downlevel. Sorry, Win7.

Most of the work in this PR is updating `load_runtime_function` so is no longer hard-coded to combase.