### PR TITLE
Add support for boxing and unboxing most kinds of arrays

### DIFF
--- a/strings/base_reference_produce.h
+++ b/strings/base_reference_produce.h
@@ -111,90 +111,105 @@ namespace winrt::impl
     struct reference_traits
     {
         static auto make(T const& value) { return winrt::make<impl::reference<T>>(value); }
+        using itf = Windows::Foundation::IReference<T>;
     };
 
     template <>
     struct reference_traits<uint8_t>
     {
         static auto make(uint8_t value) { return Windows::Foundation::PropertyValue::CreateUInt8(value); }
+        using itf = Windows::Foundation::IReference<uint8_t>;
     };
 
     template <>
     struct reference_traits<uint16_t>
     {
         static auto make(uint16_t value) { return Windows::Foundation::PropertyValue::CreateUInt16(value); }
+        using itf = Windows::Foundation::IReference<uint16_t>;
     };
 
     template <>
     struct reference_traits<int16_t>
     {
         static auto make(int16_t value) { return Windows::Foundation::PropertyValue::CreateInt16(value); }
+        using itf = Windows::Foundation::IReference<int16_t>;
     };
 
     template <>
     struct reference_traits<uint32_t>
     {
         static auto make(uint32_t value) { return Windows::Foundation::PropertyValue::CreateUInt32(value); }
+        using itf = Windows::Foundation::IReference<uint32_t>;
     };
 
     template <>
     struct reference_traits<int32_t>
     {
         static auto make(int32_t value) { return Windows::Foundation::PropertyValue::CreateInt32(value); }
+        using itf = Windows::Foundation::IReference<int32_t>;
     };
 
     template <>
     struct reference_traits<uint64_t>
     {
         static auto make(uint64_t value) { return Windows::Foundation::PropertyValue::CreateUInt64(value); }
+        using itf = Windows::Foundation::IReference<uint64_t>;
     };
 
     template <>
     struct reference_traits<int64_t>
     {
         static auto make(int64_t value) { return Windows::Foundation::PropertyValue::CreateInt64(value); }
+        using itf = Windows::Foundation::IReference<int64_t>;
     };
 
     template <>
     struct reference_traits<float>
     {
         static auto make(float value) { return Windows::Foundation::PropertyValue::CreateSingle(value); }
+        using itf = Windows::Foundation::IReference<float>;
     };
 
     template <>
     struct reference_traits<double>
     {
         static auto make(double value) { return Windows::Foundation::PropertyValue::CreateDouble(value); }
+        using itf = Windows::Foundation::IReference<double>;
     };
 
     template <>
     struct reference_traits<char16_t>
     {
         static auto make(char16_t value) { return Windows::Foundation::PropertyValue::CreateChar16(value); }
+        using itf = Windows::Foundation::IReference<char16_t>;
     };
 
     template <>
     struct reference_traits<bool>
     {
         static auto make(bool value) { return Windows::Foundation::PropertyValue::CreateBoolean(value); }
+        using itf = Windows::Foundation::IReference<bool>;
     };
 
     template <>
     struct reference_traits<hstring>
     {
         static auto make(hstring const& value) { return Windows::Foundation::PropertyValue::CreateString(value); }
+        using itf = Windows::Foundation::IReference<hstring>;
     };
 
     template <>
     struct reference_traits<Windows::Foundation::IInspectable>
     {
         static auto make(Windows::Foundation::IInspectable const& value) { return Windows::Foundation::PropertyValue::CreateInspectable(value); }
+        using itf = Windows::Foundation::IInspectable;
     };
 
     template <>
     struct reference_traits<guid>
     {
         static auto make(guid const& value) { return Windows::Foundation::PropertyValue::CreateGuid(value); }
+        using itf = Windows::Foundation::IReference<guid>;
     };
 
 #ifdef WINRT_IMPL_IUNKNOWN_DEFINED
@@ -202,6 +217,7 @@ namespace winrt::impl
     struct reference_traits<GUID>
     {
         static auto make(GUID const& value) { return Windows::Foundation::PropertyValue::CreateGuid(value); }
+        using itf = Windows::Foundation::IReference<guid>;
     };
 #endif
 
@@ -209,30 +225,177 @@ namespace winrt::impl
     struct reference_traits<Windows::Foundation::DateTime>
     {
         static auto make(Windows::Foundation::DateTime value) { return Windows::Foundation::PropertyValue::CreateDateTime(value); }
+        using itf = Windows::Foundation::IReference<Windows::Foundation::DateTime>;
     };
 
     template <>
     struct reference_traits<Windows::Foundation::TimeSpan>
     {
         static auto make(Windows::Foundation::TimeSpan value) { return Windows::Foundation::PropertyValue::CreateTimeSpan(value); }
+        using itf = Windows::Foundation::IReference<Windows::Foundation::TimeSpan>;
     };
 
     template <>
     struct reference_traits<Windows::Foundation::Point>
     {
         static auto make(Windows::Foundation::Point const& value) { return Windows::Foundation::PropertyValue::CreatePoint(value); }
+        using itf = Windows::Foundation::IReference<Windows::Foundation::Point>;
     };
 
     template <>
     struct reference_traits<Windows::Foundation::Size>
     {
         static auto make(Windows::Foundation::Size const& value) { return Windows::Foundation::PropertyValue::CreateSize(value); }
+        using itf = Windows::Foundation::IReference<Windows::Foundation::Size>;
     };
 
     template <>
     struct reference_traits<Windows::Foundation::Rect>
     {
         static auto make(Windows::Foundation::Rect const& value) { return Windows::Foundation::PropertyValue::CreateRect(value); }
+        using itf = Windows::Foundation::IReference<Windows::Foundation::Rect>;
+    };
+
+    template <>
+    struct reference_traits<com_array<uint8_t>>
+    {
+        static auto make(array_view<uint8_t const> const& value) { return Windows::Foundation::PropertyValue::CreateUInt8Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<uint8_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<int16_t>>
+    {
+        static auto make(array_view<int16_t const> const& value) { return Windows::Foundation::PropertyValue::CreateInt16Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<int16_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<uint16_t>>
+    {
+        static auto make(array_view<uint16_t const> const& value) { return Windows::Foundation::PropertyValue::CreateUInt16Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<uint16_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<int32_t>>
+    {
+        static auto make(array_view<int32_t const> const& value) { return Windows::Foundation::PropertyValue::CreateInt32Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<int32_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<uint32_t>>
+    {
+        static auto make(com_array<uint32_t> const& value) { return Windows::Foundation::PropertyValue::CreateUInt32Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<uint32_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<int64_t>>
+    {
+        static auto make(array_view<int64_t const> const& value) { return Windows::Foundation::PropertyValue::CreateInt64Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<int64_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<uint64_t>>
+    {
+        static auto make(array_view<uint64_t const> const& value) { return Windows::Foundation::PropertyValue::CreateUInt64Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<uint64_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<float>>
+    {
+        static auto make(array_view<float const> const& value) { return Windows::Foundation::PropertyValue::CreateSingleArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<float>;
+    };
+
+    template <>
+    struct reference_traits<com_array<double>>
+    {
+        static auto make(array_view<double const> const& value) { return Windows::Foundation::PropertyValue::CreateDoubleArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<double>;
+    };
+
+    template <>
+    struct reference_traits<com_array<char16_t>>
+    {
+        static auto make(array_view<char16_t const> const& value) { return Windows::Foundation::PropertyValue::CreateChar16Array(value); }
+        using itf = Windows::Foundation::IReferenceArray<char16_t>;
+    };
+
+    template <>
+    struct reference_traits<com_array<bool>>
+    {
+        static auto make(array_view<bool const> const& value) { return Windows::Foundation::PropertyValue::CreateBooleanArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<bool>;
+    };
+
+    template <>
+    struct reference_traits<com_array<hstring>>
+    {
+        static auto make(array_view<hstring const> const& value) { return Windows::Foundation::PropertyValue::CreateStringArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<hstring>;
+    };
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::IInspectable>>
+    {
+        static auto make(array_view<Windows::Foundation::IInspectable const> const& value) { return Windows::Foundation::PropertyValue::CreateInspectableArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::IInspectable>;
+    };
+
+    template <>
+    struct reference_traits<com_array<guid>>
+    {
+        static auto make(array_view<guid const> const& value) { return Windows::Foundation::PropertyValue::CreateGuidArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<guid>;
+    };
+
+#ifdef WINRT_IMPL_IUNKNOWN_DEFINED
+    template <>
+    struct reference_traits<com_array<GUID>>
+    {
+        static auto make(array_view<GUID const> const& value) { return Windows::Foundation::PropertyValue::CreateGuidArray(reinterpret_cast<array_view<guid const> const&>(value)); }
+        using itf = Windows::Foundation::IReferenceArray<guid>;
+    };
+#endif
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::DateTime>>
+    {
+        static auto make(array_view<Windows::Foundation::DateTime const> const& value) { return Windows::Foundation::PropertyValue::CreateDateTimeArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::DateTime>;
+    };
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::TimeSpan>>
+    {
+        static auto make(array_view<Windows::Foundation::TimeSpan const> const& value) { return Windows::Foundation::PropertyValue::CreateTimeSpanArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::TimeSpan>;
+    };
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::Point>>
+    {
+        static auto make(array_view<Windows::Foundation::Point const> const& value) { return Windows::Foundation::PropertyValue::CreatePointArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::Point>;
+    };
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::Size>>
+    {
+        static auto make(array_view<Windows::Foundation::Size const> const& value) { return Windows::Foundation::PropertyValue::CreateSizeArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::Size>;
+    };
+
+    template <>
+    struct reference_traits<com_array<Windows::Foundation::Rect>>
+    {
+        static auto make(array_view<Windows::Foundation::Rect const> const& value) { return Windows::Foundation::PropertyValue::CreateRectArray(value); }
+        using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::Rect>;
     };
 }
 
@@ -282,14 +445,16 @@ namespace winrt::impl
             }
         }
 #ifdef WINRT_IMPL_IUNKNOWN_DEFINED
-        else if constexpr (std::is_same_v<T, GUID>)
+        else if constexpr (std::is_same_v<T, com_array<GUID>>)
         {
-            return value.template as<Windows::Foundation::IReference<guid>>().Value();
+            T result;
+            reinterpret_cast<com_array<guid>&>(result) = value.template as<typename impl::reference_traits<T>::itf>().Value();
+            return result;
         }
 #endif
         else
         {
-            return value.template as<Windows::Foundation::IReference<T>>().Value();
+            return value.template as<typename impl::reference_traits<T>::itf>().Value();
         }
     }
 
@@ -309,17 +474,19 @@ namespace winrt::impl
             }
         }
 #ifdef WINRT_IMPL_IUNKNOWN_DEFINED
-        else if constexpr (std::is_same_v<T, GUID>)
+        else if constexpr (std::is_same_v<T, com_array<GUID>>)
         {
-            if (auto temp = value.template try_as<Windows::Foundation::IReference<guid>>())
+            if (auto temp = value.template try_as<typename impl::reference_traits<T>::itf>())
             {
-                return temp.Value();
+                T result;
+                reinterpret_cast<com_array<guid>&>(result) = temp.Value();
+                return result;
             }
         }
 #endif
         else
         {
-            if (auto temp = value.template try_as<Windows::Foundation::IReference<T>>())
+            if (auto temp = value.template try_as<typename impl::reference_traits<T>::itf>())
             {
                 return temp.Value();
             }
@@ -416,5 +583,5 @@ WINRT_EXPORT namespace winrt
     }
 
     template <typename T>
-    using optional = Windows::Foundation::IReference<T>;
+    using optional = typename impl::reference_traits<T>::itf;
 }

--- a/test/test/box_array.cpp
+++ b/test/test/box_array.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+
+namespace
+{
+    template<typename T>
+    void Verify(T const& otherValue)
+    {
+        T defaultValue{};
+        winrt::com_array<T> ary{ otherValue, defaultValue };
+        auto box = winrt::box_value(ary);
+        winrt::com_array<T> unbox = box.try_as<winrt::com_array<T>>().value();
+        REQUIRE(unbox.size() == 2);
+        REQUIRE(unbox.at(0) == otherValue);
+        REQUIRE(unbox.at(1) == defaultValue);
+        unbox = box.as<winrt::com_array<T>>();
+        REQUIRE(unbox.size() == 2);
+        REQUIRE(unbox.at(0) == otherValue);
+        REQUIRE(unbox.at(1) == defaultValue);
+        if constexpr (!std::is_same_v<T, GUID>)
+        {
+            unbox = box.as<winrt::optional<winrt::com_array<T>>>().Value();
+            REQUIRE(unbox.size() == 2);
+            REQUIRE(unbox.at(0) == otherValue);
+            REQUIRE(unbox.at(1) == defaultValue);
+        }
+        unbox = winrt::unbox_value<winrt::com_array<T>>(box);
+        REQUIRE(unbox.size() == 2);
+        REQUIRE(unbox.at(0) == otherValue);
+        REQUIRE(unbox.at(1) == defaultValue);
+        // Cannot use unbox_value_or with arrays because com_array is not copyable.
+        // unbox = winrt::unbox_value_or(box, winrt::com_array<T>{});
+    }
+}
+TEST_CASE("box_array")
+{
+    Verify<uint8_t>(42);
+    Verify<int16_t>(42);
+    Verify<uint16_t>(42);
+    Verify<int32_t>(42);
+    Verify<uint32_t>(42);
+    Verify<int64_t>(42);
+    Verify<uint64_t>(42);
+    Verify<float>(42);
+    Verify<double>(42);
+    Verify<char16_t>(42);
+    Verify<bool>(true);
+    Verify<winrt::hstring>(L"42");
+    Verify<winrt::Windows::Foundation::IInspectable>(winrt::Windows::Foundation::Uri{ L"https://www.microsoft.com/" });
+    Verify<winrt::guid>({ 1,2,3, {4,5,6,7,8,9,10,11} });
+    Verify<GUID>(winrt::guid{ 1,2,3, {4,5,6,7,8,9,10,11} });
+    Verify<winrt::Windows::Foundation::DateTime>((winrt::Windows::Foundation::DateTime::max)());
+    Verify<winrt::Windows::Foundation::TimeSpan>((winrt::Windows::Foundation::TimeSpan::max)());
+    Verify<winrt::Windows::Foundation::Point>({ 1,1 });
+    Verify<winrt::Windows::Foundation::Size>({ 1,1 });
+    Verify<winrt::Windows::Foundation::Rect>({ 1,1,1,1 });
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -296,6 +296,7 @@
     <ClCompile Include="async_completed.cpp" />
     <ClCompile Include="async_propagate_cancel.cpp" />
     <ClCompile Include="async_ref_result.cpp" />
+    <ClCompile Include="box_array.cpp" />
     <ClCompile Include="box_delegate.cpp" />
     <ClCompile Include="box_guid.cpp" />
     <ClCompile Include="capture.cpp" />


### PR DESCRIPTION
The boxing and unboxing functions now support most kinds of arrays. The notable exception is arrays of enumerations. Nothing technically preventing it. Just lazy.

You can box and unbox arrays nearly anywhere you could box and unbox scalars, with one exception: You cannot unbox arrays with `unbox_value_or`. The reason is that `com_array` is not copyable, and `unbox_value_or` returns a copy of its second parameter on failure. We could try to address this by having `unbox_value_or` accept its second parameter as an `array_view` when asked to unbox an array type. But I didn't try. Just lazy.

One annoyance is the treatment of `com_array<GUID>`. This is identical to `com_array<guid>` but I had to play games to convert between them efficiently. Maybe it wasn't worth it. Perhaps I should have been lazy.