### PR TITLE
Factories no longer default to no_weak_ref

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1041,8 +1041,6 @@ namespace winrt::impl
             return Windows::Foundation::TrustLevel::BaseTrust;
         }
 
-        using is_factory = std::disjunction<std::is_same<Windows::Foundation::IActivationFactory, I>...>;
-
     private:
 
         class has_final_release
@@ -1057,7 +1055,7 @@ namespace winrt::impl
 
         using is_agile = std::negation<std::disjunction<std::is_same<non_agile, I>...>>;
         using is_inspectable = std::disjunction<std::is_base_of<Windows::Foundation::IInspectable, I>...>;
-        using is_weak_ref_source = std::conjunction<is_inspectable, std::negation<is_factory>, std::negation<std::disjunction<std::is_same<no_weak_ref, I>...>>>;
+        using is_weak_ref_source = std::conjunction<is_inspectable, std::negation<std::disjunction<std::is_same<no_weak_ref, I>...>>>;
         using use_module_lock = std::negation<std::disjunction<std::is_same<no_module_lock, I>...>>;
         using weak_ref_t = impl::weak_ref<is_agile::value, use_module_lock::value>;
 
@@ -1333,7 +1331,6 @@ WINRT_EXPORT namespace winrt
 
         using base_type = typename impl::base_implements<D, I...>::type;
         using root_implements_type = typename base_type::root_implements_type;
-        using is_factory = typename root_implements_type::is_factory;
 
         using base_type::base_type;
 

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -150,7 +150,7 @@ TEST_CASE("weak,QI")
     {
         IActivationFactory object = make<Factory>();
         REQUIRE(object.try_as<Windows::Foundation::IInspectable>());
-        REQUIRE(!object.try_as<winrt::impl::IWeakReferenceSource>());
+        REQUIRE(object.try_as<winrt::impl::IWeakReferenceSource>());
     }
 
     SECTION("no_weak_ref")


### PR DESCRIPTION
Originally, factories defaulted to no_weak_ref because there wasn't believed to be any use case for weak references to factories, and the thought was that the weak reference support would be a performance penalty.

In practice, the weak reference support does not have a significant performance impact, so it's okay to leave it on even for factories.

Allowing weak references to factories is important because factories implement the static members of a runtime class, and those members may require taking weak references:

* Event handlers need weak references so that the event handler doesn't create a circular reference back to the factory.
* Queueing work to a background thread takes a weak reference so that the work can be abandoned if the factory has been destroyed. (We don't want to extend the lifetime of COM objects beyond the lifetime of COM itself.)

Furthermore, the ability to take a weak reference to a factory is required in order to use event_revoker for static events, since event_revoker requires that the event source support weak references.