### PR TITLE
Natvis support for hresult_error and array_view

### DIFF
--- a/natvis/cppwinrt.natvis
+++ b/natvis/cppwinrt.natvis
@@ -20,6 +20,15 @@
     <DisplayString Condition="this == 0">null</DisplayString>
   </Type>
   <!--Primitive type visualizers-->
+  <Type Name="winrt::array_view&lt;*&gt;">
+    <DisplayString>{{size = {m_size}, {m_data,[m_size]}}}</DisplayString>
+    <Expand>
+      <ArrayItems>
+          <Size>m_size</Size>
+          <ValuePointer>m_data</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
   <Type Name="winrt::com_ptr&lt;*&gt;">
     <DisplayString>{m_ptr}</DisplayString>
     <Expand>
@@ -32,6 +41,9 @@
   </Type>
   <Type Name="winrt::hresult">
     <DisplayString>{value,hr}</DisplayString>
+  </Type>
+  <Type Name="winrt::hresult_error">
+    <DisplayString>{m_code}</DisplayString>
   </Type>
   <Type Name="winrt::hstring">
     <DisplayString>{m_handle.m_value,sh}</DisplayString>


### PR DESCRIPTION
hresult_error displays the wrapped hresult.

array_view displays the size and the first few elements. It expands to the elements in the view, in the form of an array.