### PR TITLE
Support non top-level root namespaces in item templates

### DIFF
--- a/vsix/ItemTemplates/BlankPage/BlankPage.cpp
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.cpp
@@ -7,7 +7,7 @@
 using namespace winrt;
 using namespace Windows::UI::Xaml;
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     $safeitemname$::$safeitemname$()
     {

--- a/vsix/ItemTemplates/BlankPage/BlankPage.h
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.h
@@ -2,7 +2,7 @@
 
 #include "$safeitemname$.g.h"
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
@@ -15,7 +15,7 @@ namespace winrt::$rootnamespace$::implementation
     };
 }
 
-namespace winrt::$rootnamespace$::factory_implementation
+namespace winrt::$cpprootnamespace$::factory_implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$, implementation::$safeitemname$>
     {

--- a/vsix/ItemTemplates/BlankPage/cppwinrt_BlankPage.vstemplate
+++ b/vsix/ItemTemplates/BlankPage/cppwinrt_BlankPage.vstemplate
@@ -17,8 +17,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.xaml\$fileinputname$.idl" ReplaceParameters="true">BlankPage.idl</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.WizardExtension</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
@@ -7,7 +7,7 @@
 using namespace winrt;
 using namespace Windows::UI::Xaml;
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     $safeitemname$::$safeitemname$()
     {

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
@@ -6,7 +6,7 @@
 #include "winrt/Windows.UI.Xaml.Controls.Primitives.h"
 #include "$safeitemname$.g.h"
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
@@ -19,7 +19,7 @@ namespace winrt::$rootnamespace$::implementation
     };
 }
 
-namespace winrt::$rootnamespace$::factory_implementation
+namespace winrt::$cpprootnamespace$::factory_implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$, implementation::$safeitemname$>
     {

--- a/vsix/ItemTemplates/BlankUserControl/cppwinrt_BlankUserControl.vstemplate
+++ b/vsix/ItemTemplates/BlankUserControl/cppwinrt_BlankUserControl.vstemplate
@@ -17,8 +17,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.xaml\$fileinputname$.idl" ReplaceParameters="true">BlankUserControl.idl</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.WizardExtension</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/ItemTemplates/ViewModel/ViewModel.cpp
+++ b/vsix/ItemTemplates/ViewModel/ViewModel.cpp
@@ -4,7 +4,7 @@
 #include "$safeitemname$.g.cpp"
 #endif
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     int32_t $safeitemname$::MyProperty()
     {

--- a/vsix/ItemTemplates/ViewModel/ViewModel.h
+++ b/vsix/ItemTemplates/ViewModel/ViewModel.h
@@ -2,7 +2,7 @@
 
 #include "$safeitemname$.g.h"
 
-namespace winrt::$rootnamespace$::implementation
+namespace winrt::$cpprootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
@@ -13,7 +13,7 @@ namespace winrt::$rootnamespace$::implementation
     };
 }
 
-namespace winrt::$rootnamespace$::factory_implementation
+namespace winrt::$cpprootnamespace$::factory_implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$, implementation::$safeitemname$>
     {

--- a/vsix/ItemTemplates/ViewModel/cppwinrt_ViewModel.vstemplate
+++ b/vsix/ItemTemplates/ViewModel/cppwinrt_ViewModel.vstemplate
@@ -16,8 +16,8 @@
     <ProjectItem SubType="Code" TargetFileName="$fileinputname$.idl\$fileinputname$.h" ReplaceParameters="true">ViewModel.h</ProjectItem>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
-    <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+    <Assembly>Microsoft.Windows.CppWinRT, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.Windows.CppWinRT.WizardExtension</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Microsoft.Windows.CppWinRT">

--- a/vsix/WizardExtension.cs
+++ b/vsix/WizardExtension.cs
@@ -1,0 +1,70 @@
+﻿using EnvDTE;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.TemplateWizard;
+using NuGet.VisualStudio;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+
+namespace Microsoft.Windows.CppWinRT
+{
+    internal sealed class WizardExtension : IWizard
+    {
+        [Import]
+        internal IVsTemplateWizard Wizard { get; set; }
+
+        private void Initialize(object automationObject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            using (var serviceProvider = new ServiceProvider((IServiceProvider)automationObject))
+            {
+                var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+                Assumes.Present(componentModel);
+                using (var container = new CompositionContainer(componentModel.DefaultExportProvider))
+                {
+                    container.ComposeParts(this);
+                }
+            }
+        }
+
+        void IWizard.BeforeOpeningFile(ProjectItem projectItem)
+        {
+            Wizard.BeforeOpeningFile(projectItem);
+        }
+
+        void IWizard.ProjectFinishedGenerating(Project project)
+        {
+            Wizard.ProjectFinishedGenerating(project);
+        }
+
+        void IWizard.ProjectItemFinishedGenerating(ProjectItem projectItem)
+        {
+            Wizard.ProjectItemFinishedGenerating(projectItem);
+        }
+
+        void IWizard.RunFinished()
+        {
+            Wizard.RunFinished();
+        }
+
+        void IWizard.RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Initialize(automationObject);
+
+            if (replacementsDictionary.TryGetValue("$rootnamespace$", out var rootNamespace))
+            {
+                replacementsDictionary.Add("$cpprootnamespace$", rootNamespace.Replace(".", "::"));
+            }
+
+            Wizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+        }
+
+        bool IWizard.ShouldAddProjectItem(string filePath)
+        {
+            return Wizard.ShouldAddProjectItem(filePath);
+        }
+    }
+}

--- a/vsix/packages.config
+++ b/vsix/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="16.0.2258" targetFramework="net461" developmentDependency="true" />
-</packages>

--- a/vsix/source.extension.vsixmanifest
+++ b/vsix/source.extension.vsixmanifest
@@ -1,35 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="Microsoft.Windows.CppWinRT" Version="|%CurrentProject%;GetCppWinRTVersion|" Language="en-US" Publisher="Microsoft" />
-    <PackageId>Microsoft.Windows.CppWinRT</PackageId>
-    <DisplayName>C++/WinRT</DisplayName>
-    <Description xml:space="preserve">Tools for authoring and consuming Windows Runtime classes in standard C++.</Description>
-    <MoreInfo>https://go.microsoft.com/fwlink/?linkid=869449</MoreInfo>
-    <License>LICENSE</License>
-    <GettingStartedGuide>https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt</GettingStartedGuide>
-    <ReleaseNotes>https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/faq</ReleaseNotes>
-    <Icon>cppwinrt.ico</Icon>
-    <PreviewImage>cppwinrt.png</PreviewImage>
-    <Tags>WinRT, C++, cppwinrt, native</Tags>
-  </Metadata>
-  <Installation AllUsers="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[15.0,17.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="NativeVisualizer" Path="cppwinrt.natvis" />
-    <Asset Type="DebuggerEngineExtension" Path="CppWinrtVisualizer.vsdconfig" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="ItemTemplates" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="ProjectTemplates" />
-    <Asset Type="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" Source="File" Path="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" VsixSubPath="Packages" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.VC" Version="[15.0,)" DisplayName="C++ Universal Windows Platform tools" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="Microsoft.Windows.CppWinRT" Version="|%CurrentProject%;GetCppWinRTVersion|" Language="en-US" Publisher="Microsoft" />
+        <PackageId>Microsoft.Windows.CppWinRT</PackageId>
+        <DisplayName>C++/WinRT</DisplayName>
+        <Description xml:space="preserve">Tools for authoring and consuming Windows Runtime classes in standard C++.</Description>
+        <MoreInfo>https://go.microsoft.com/fwlink/?linkid=869449</MoreInfo>
+        <License>LICENSE</License>
+        <GettingStartedGuide>https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/intro-to-using-cpp-with-winrt</GettingStartedGuide>
+        <ReleaseNotes>https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/faq</ReleaseNotes>
+        <Icon>cppwinrt.ico</Icon>
+        <PreviewImage>cppwinrt.png</PreviewImage>
+        <Tags>WinRT, C++, cppwinrt, native</Tags>
+    </Metadata>
+    <Installation AllUsers="true">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[15.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="NativeVisualizer" Path="cppwinrt.natvis" />
+        <Asset Type="DebuggerEngineExtension" Path="CppWinrtVisualizer.vsdconfig" />
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="ItemTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="ProjectTemplates" />
+        <Asset Type="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" Source="File" Path="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" VsixSubPath="Packages" />
+        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.VC" Version="[15.0,)" DisplayName="C++ Universal Windows Platform tools" />
+    </Prerequisites>
 </PackageManifest>

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -1,29 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="PrepareBuild;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" />
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <UseCodebase>true</UseCodebase>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\$(Deployment)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\$(Deployment)\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -31,59 +10,79 @@
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <DeployExtension>false</DeployExtension>
     <Deployment Condition="'$(Deployment)' == '' ">Standalone</Deployment>
     <ProjectGuid>{2F0C4AFA-FEFA-4D37-B824-0426CEB32DBA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Windows.CppWinRT</RootNamespace>
     <AssemblyName>Microsoft.Windows.CppWinRT</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <UseCodebase>true</UseCodebase>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="LICENSE">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\ARM\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\ARM64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\Win32\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\x64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\ARM\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\ARM64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\Win32\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\x64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(NupkgDir)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion).nupkg">
@@ -117,23 +116,17 @@
     <Content Include="cppwinrt.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="x64\" />
+    <Compile Include="WizardExtension.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.0.2284" />
+    <PackageReference Include="NuGet.VisualStudio" Version="5.9.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets'))" />
-  </Target>
-  <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />
   <Target Name="PrepareBuild" BeforeTargets="PrepareForBuild">
     <Error Condition="'$(CppWinRTVersion)' == ''" Text="The project must be supplied with a CppWinRTVersion property value" />


### PR DESCRIPTION
This fixes the following issue reported on dev community: https://developercommunity.visualstudio.com/t/vsix-does-not-correctly-provide-rootnamespace-and/1153008

To achieve this, I had to write a custom template wizard so that I'm able to inject a custom root namespace replacement string with the dots replaced by `::`. The code was basically 1:1 taken from https://github.com/NuGet/NuGet.Client/blob/7e3b0e445edecbdb6c46895ee4375cf834f45d87/src/NuGet.Clients/NuGet.VisualStudio.Interop/TemplateWizard.cs, so the automatic package installation that happens when first using the template should still work.

The custom template wizard could enable better support for custom scenarios in the future as well, for example nested folders vs dotted prefix conventions for namespace hierarchy.

To make this correctly light up in the VSIX, some infrastructure work on the MS side will be required to strongly sign the `Microsoft.Windows.CppWinRT.dll` file, since otherwise VS refuses to load it.

The assembly version is `0.0.0.0` because it's carried around by the VSIX so there's no need to bind specific versions (the NuGet template wizard DLL already doesn't for example), but if desired this could most likely be updated to use proper versions.

Some changes where made to the `.csproj` file to enable a better inner loop (now running `build_vsix Debug`, opening the solution in VS and hitting F5 should "just work" to get the extension installed in the experimental instance).