### PR TITLE
Runtime class name for bare IInspectable should not be "Object"

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -430,6 +430,15 @@ namespace winrt::impl
         }
     };
 
+    template <>
+    struct runtime_class_name<Windows::Foundation::IInspectable>
+    {
+        static hstring get()
+        {
+            return {};
+        }
+    };
+
     template <typename D, typename I, typename Enable>
     struct producer
     {

--- a/test/old_tests/UnitTests/IInspectable_GetRuntimeClassName.cpp
+++ b/test/old_tests/UnitTests/IInspectable_GetRuntimeClassName.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Test_GetRuntimeClassName_NoOverride")
 {
     Windows::Foundation::IInspectable i = make<Test_GetRuntimeClassName_NoOverride>();
 
-    REQUIRE(get_class_name(i) == L"Object");
+    REQUIRE(get_class_name(i) == L"");
 }
 
 TEST_CASE("Test_GetRuntimeClassName_Override")

--- a/test/old_tests/UnitTests/constexpr.cpp
+++ b/test/old_tests/UnitTests/constexpr.cpp
@@ -35,7 +35,7 @@ TEST_CASE("constexpr")
     REQUIRE(winrt::guid_of<winrt::IInspectable>() == winrt::guid(__uuidof(::IInspectable)));
     REQUIRE(winrt::guid_of<winrt_container>() == winrt::guid(__uuidof(midl_container)));
     REQUIRE(winrt::name_of<winrt::IInspectable>() == L"Object"sv);
-    REQUIRE(winrt::name_of<winrt::IAsyncOperation<winrt::IInspectable>>() == L"Windows.Foundation.IAsyncOperation`1<Object>");
+    REQUIRE(winrt::name_of<winrt::IAsyncOperation<winrt::IInspectable>>() == L"Windows.Foundation.IAsyncOperation`1<Object>"sv);
 
     REQUIRE(winrt::name_of<winrt_container>() == midl_container::z_get_rc_name_impl());
 

--- a/test/old_tests/UnitTests/constexpr.cpp
+++ b/test/old_tests/UnitTests/constexpr.cpp
@@ -35,6 +35,7 @@ TEST_CASE("constexpr")
     REQUIRE(winrt::guid_of<winrt::IInspectable>() == winrt::guid(__uuidof(::IInspectable)));
     REQUIRE(winrt::guid_of<winrt_container>() == winrt::guid(__uuidof(midl_container)));
     REQUIRE(winrt::name_of<winrt::IInspectable>() == L"Object"sv);
+    REQUIRE(winrt::name_of<winrt::IAsyncOperation<winrt::IInspectable>>() == L"Windows.Foundation.IAsyncOperation`1<Object>");
 
     REQUIRE(winrt::name_of<winrt_container>() == midl_container::z_get_rc_name_impl());
 

--- a/test/old_tests/UnitTests/produce.cpp
+++ b/test/old_tests/UnitTests/produce.cpp
@@ -133,7 +133,7 @@ struct produce_IInspectable_RuntimeClassName : implements<produce_IInspectable_R
 TEST_CASE("produce_IInspectable_RuntimeClassName")
 {
     Windows::Foundation::IInspectable without = make<produce_IInspectable_No_RuntimeClassName>();
-    REQUIRE(get_class_name(without) == L"Object");
+    REQUIRE(get_class_name(without) == L"");
 
     Windows::Foundation::IInspectable with = make<produce_IInspectable_RuntimeClassName>();
     REQUIRE(get_class_name(with) == L"produce_IInspectable_RuntimeClassName");


### PR DESCRIPTION
This tickles an edge case in the metadata-based marshaller. Use an empty string instead.