### PR TITLE
Add #pragma once in addition to header guard.

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -69,6 +69,8 @@ namespace cppwinrt
 
     static void write_open_file_guard(writer& w, std::string_view const& file_name, char impl = 0)
     {
+        write_include_guard(w);
+            
         std::string mangled_name;
 
         for (auto&& c : file_name)


### PR DESCRIPTION
Fixes #945. Given that the component headers already use this I don't think this would break C++/WinRT compatibility with compilers that don't support this (technically it's non-standard). 

Question is if we need to keep the open file guard?