### PR TITLE
Add deduction guides for agile_ref and weak_ref

### DIFF
--- a/strings/base_agile_ref.h
+++ b/strings/base_agile_ref.h
@@ -209,8 +209,10 @@ WINRT_EXPORT namespace winrt
         com_ptr<impl::IAgileReference> m_ref;
     };
 
+    template<typename T> agile_ref(T const&)->agile_ref<impl::wrapped_type_t<T>>;
+
     template <typename T>
-    agile_ref<T> make_agile(T const& object)
+    agile_ref<impl::wrapped_type_t<T>> make_agile(T const& object)
     {
         return object;
     }

--- a/strings/base_weak_ref.h
+++ b/strings/base_weak_ref.h
@@ -61,6 +61,8 @@ WINRT_EXPORT namespace winrt
         com_ptr<impl::IWeakReference> m_ref;
     };
 
+    template<typename T> weak_ref(T const&)->weak_ref<impl::wrapped_type_t<T>>;
+
     template<typename T>
     struct impl::abi<weak_ref<T>> : impl::abi<com_ptr<impl::IWeakReference>>
     {

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -98,6 +98,12 @@ TEST_CASE("weak,source")
         IStringable b = w.get();
         REQUIRE(b.ToString() == L"Weak");
     }
+
+    // Verify that deduction guides work.
+    static_assert(std::is_same_v<weak_ref<IStringable>, decltype(weak_ref(IStringable()))>);
+    static_assert(std::is_same_v<weak_ref<Uri>, decltype(weak_ref(std::declval<Uri>()))>);
+    static_assert(std::is_same_v<weak_ref<::IPersist>, decltype(weak_ref(com_ptr<::IPersist>()))>);
+    static_assert(std::is_same_v<weak_ref<::IPersist>, decltype(make_weak(com_ptr<::IPersist>()))>);
 }
 
 TEST_CASE("weak,nullptr")

--- a/test/test/agile_ref.cpp
+++ b/test/test/agile_ref.cpp
@@ -51,4 +51,10 @@ TEST_CASE("agile_ref")
     agile_ref<IStringable> empty;
     IStringable object = empty.get();
     REQUIRE(object == nullptr);
+
+    // Verify that deduction guides work.
+    static_assert(std::is_same_v<agile_ref<IStringable>, decltype(agile_ref(object))>);
+    static_assert(std::is_same_v<agile_ref<Uri>, decltype(agile_ref(std::declval<Uri>()))>);
+    static_assert(std::is_same_v<agile_ref<::IPersist>, decltype(agile_ref(com_ptr<::IPersist>()))>);
+    static_assert(std::is_same_v<agile_ref<::IPersist>, decltype(make_agile(com_ptr<::IPersist>()))>);
 }


### PR DESCRIPTION
This allows you to create agile and weak references to com_ptr much more conveniently. Given declarations

```cpp
Uri uri;
com_ptr<::IPersist> persist;
```

| Try this              | or this              | Before | After    |
|-----------------------|----------------------|--------|----------|
| `agile_ref(uri)`      | `weak_ref(uri)`      | Fail   | Works    |
| `make_agile(uri)`     | `make_weak(uri)`     | Works  | Works    |
| `agile_ref(persist)`  | `weak_ref(persist)`  | Fail   | Works    |
| `make_agile(persist)` | `make_weak(persist)` | Fail   | Works    |

With the addition of the deduction guides, `make_agile` and `make_weak` are now superfluous, but we keep them around for backward compatibility.