### PR TITLE
Add IMemoryBufferByteAccess accessor

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1310,6 +1310,18 @@ namespace cppwinrt
         }
 )");
         }
+        else if (type_name == "Windows.Foundation.IMemoryBufferReference")
+        {
+            w.write(R"(
+        auto data() const
+        {
+            uint8_t* data{};
+            uint32_t capacity{};
+            check_hresult(static_cast<D const&>(*this).template as<IMemoryBufferByteAccess>()->GetBuffer(&data, &capacity));
+            return data;
+        }
+)");
+        }
         else if (type_name == "Windows.Foundation.Collections.IIterator`1")
         {
             w.write(R"(

--- a/strings/base_abi.h
+++ b/strings/base_abi.h
@@ -127,6 +127,11 @@ namespace winrt::impl
         virtual int32_t __stdcall Buffer(uint8_t** value) noexcept = 0;
     };
 
+    struct __declspec(novtable) IMemoryBufferByteAccess : unknown_abi
+    {
+        virtual int32_t __stdcall GetBuffer(uint8_t** value, uint32_t* capacity) noexcept = 0;
+    };
+
     template <> struct abi<Windows::Foundation::TimeSpan>
     {
         using type = int64_t;
@@ -155,4 +160,5 @@ namespace winrt::impl
     template <> inline constexpr guid guid_v<IContextCallback>{ 0x000001da, 0x0000, 0x0000, { 0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46 } };
     template <> inline constexpr guid guid_v<IServerSecurity>{ 0x0000013E, 0x0000, 0x0000, { 0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46 } };
     template <> inline constexpr guid guid_v<IBufferByteAccess>{ 0x905a0fef, 0xbc53, 0x11df, { 0x8c,0x49,0x00,0x1e,0x4f,0xc6,0x86,0xda } };
+    template <> inline constexpr guid guid_v<IMemoryBufferByteAccess>{ 0x5b0d3235, 0x4dba, 0x4d44, { 0x86,0x5e,0x8f,0x1d,0x0e,0x4f,0xd0,0x4d } };
 }

--- a/test/test/memory_buffer.cpp
+++ b/test/test/memory_buffer.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "catch.hpp"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+TEST_CASE("memory_buffer")
+{
+    MemoryBuffer buffer{ 3 };
+    auto reference = buffer.CreateReference();
+    uint8_t* ptr = reference.data();
+    ptr[0] = 1;
+    ptr[1] = 2;
+    ptr[2] = 3;
+    REQUIRE(ptr != nullptr);
+    REQUIRE(reference.Capacity() == 3);
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -398,6 +398,7 @@
     <ClCompile Include="main.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="memory_buffer.cpp" />
     <ClCompile Include="module_lock_dll.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
This adds a new `data()` method to get the data pointer returned by the `IMemoryBufferByteAccess::GetBuffer()` method for `Windows.Foundation.IMemoryBufferReference`.

Fixes #944.