### PR TITLE
Improve diagnostics when implements<> is used incorectly

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1437,7 +1437,7 @@ WINRT_EXPORT namespace winrt
 
         hstring GetRuntimeClassName() const override
         {
-            static_assert(std::is_base_of_v<implements_type, D>, "First template parameter to implements<> or ClassT<> must be derived class name, e.g. struct X : implements<X, ...>");
+            static_assert(std::is_base_of_v<implements_type, D>, "Class must derive from implements<> or ClassT<> where the first template parameter is the derived class name, e.g. struct D : implements<D, ...>");
             return impl::runtime_class_name<typename impl::implements_default_interface<D>::type>::get();
         }
 

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1437,6 +1437,7 @@ WINRT_EXPORT namespace winrt
 
         hstring GetRuntimeClassName() const override
         {
+            static_assert(std::is_base_of_v<implements_type, D>, "First template parameter to implements<> or ClassT<> must be derived class name, e.g. struct X : implements<X, ...>");
             return impl::runtime_class_name<typename impl::implements_default_interface<D>::type>::get();
         }
 


### PR DESCRIPTION
A common error is forgetting to provide the name of the derived class as the first `implements<>` template parameter. This results in a strange `'implements_type' is not a member of any direct or indirect base class of 'MyClass'` error. Detect this case with a `static_assert` with a more help error message.

Note that we have to put the `static_assert` inside the implementation of `GetRuntimeClassName` rather than putting it in the class definition of `implements`. That's because `implements` is sometimes used with an incomplete type, and we cannot use `is_base_of` with incomplete types. Wait until `GetRuntimeClassName` is generated, at which point the class is complete.