### PR TITLE
IReference operators in level-1 header should be forward declarations

### DIFF
--- a/strings/base_reference_produce.h
+++ b/strings/base_reference_produce.h
@@ -397,7 +397,35 @@ namespace winrt::impl
         static auto make(array_view<Windows::Foundation::Rect const> const& value) { return Windows::Foundation::PropertyValue::CreateRectArray(value); }
         using itf = Windows::Foundation::IReferenceArray<Windows::Foundation::Rect>;
     };
+}
 
+WINRT_EXPORT namespace winrt::Windows::Foundation
+{
+    template <typename T>
+    bool operator==(IReference<T> const& left, IReference<T> const& right)
+    {
+        if (get_abi(left) == get_abi(right))
+        {
+            return true;
+        }
+
+        if (!left || !right)
+        {
+            return false;
+        }
+
+        return left.Value() == right.Value();
+    }
+
+    template <typename T>
+    bool operator!=(IReference<T> const& left, IReference<T> const& right)
+    {
+        return !(left == right);
+    }
+}
+
+namespace winrt::impl
+{
     template <typename T, typename From>
     T unbox_value_type(From&& value)
     {

--- a/strings/base_reference_produce_1.h
+++ b/strings/base_reference_produce_1.h
@@ -2,24 +2,8 @@
 WINRT_EXPORT namespace winrt::Windows::Foundation
 {
     template <typename T>
-    bool operator==(IReference<T> const& left, IReference<T> const& right)
-    {
-        if (get_abi(left) == get_abi(right))
-        {
-            return true;
-        }
-
-        if (!left || !right)
-        {
-            return false;
-        }
-
-        return left.Value() == right.Value();
-    }
+    bool operator==(IReference<T> const& left, IReference<T> const& right);
 
     template <typename T>
-    bool operator!=(IReference<T> const& left, IReference<T> const& right)
-    {
-        return !(left == right);
-    }
+    bool operator!=(IReference<T> const& left, IReference<T> const& right);
 }

--- a/test/test_component_no_pch/test_component_no_pch.idl
+++ b/test/test_component_no_pch/test_component_no_pch.idl
@@ -33,4 +33,11 @@ namespace test_component_no_pch
             Int32 Second;
         };
     }
+
+    // This structure verifies that the structure can at least be declared
+    // (but perhaps not meaningfully consumed) without having first included Windows.Foundation.h.
+    struct StructWithReference
+    {
+        Windows.Foundation.IReference<Int32> OptionalValue;
+    };
 }


### PR DESCRIPTION
Implementation relies on methods in the top-level header, so defer implementation to there.

This reverts the change to base_reference_produce.h from #906 and reduces base_reference_produce_1.h to merely forward references. This is enough to get structures to compile, although you cannot meaningfully use any IReferences in them until you include Windows.Foundation.h (which is consistent with existing rules for namespace headers).