### PR TITLE
Fix delegates with return value passed as fptr or {p,mfptr}

### DIFF
--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -162,11 +162,11 @@ namespace winrt::impl
         {}
 
         template <typename F> delegate_base(F* handler) :
-            delegate_base([=](auto&& ... args) { handler(args...); })
+            delegate_base([=](auto&& ... args) { return handler(args...); })
         {}
 
         template <typename O, typename M> delegate_base(O* object, M method) :
-            delegate_base([=](auto&& ... args) { ((*object).*(method))(args...); })
+            delegate_base([=](auto&& ... args) { return ((*object).*(method))(args...); })
         {}
 
         template <typename O, typename M> delegate_base(com_ptr<O>&& object, M method) :

--- a/test/test/delegate.cpp
+++ b/test/test/delegate.cpp
@@ -69,4 +69,48 @@ TEST_CASE("delegate")
         delegate<int(int, int)> d = [](int a, int b) {return a + b; };
         REQUIRE(d(4, 5) == 9);
     }
+
+    // void(int*) with function pointer
+    {
+        struct S
+        {
+            static void Invoke(int* p) { *p = 123; }
+        };
+        int value = 0;
+        delegate<void(int*)> d = &S::Invoke;
+        d(&value);
+        REQUIRE(value == 123);
+    }
+
+    // void(int*) with object and method pointer
+    {
+        struct S
+        {
+            void Invoke(int* p) { *p = 123; }
+        } s;
+        delegate<void(int*)> d{ &s, &S::Invoke };
+        int value = 0;
+        d(&value);
+        REQUIRE(value == 123);
+    }
+
+    // int() with function pointer
+    {
+        struct S
+        {
+            static int Value() { return 123; }
+        };
+        delegate<int()> d = &S::Value;
+        REQUIRE(d() == 123);
+    }
+
+    // int() with object and method pointer
+    {
+        struct S
+        {
+            int Value() { return 123; }
+        } s;
+        delegate<int()> d{ &s, &S::Value };
+        REQUIRE(d() == 123);
+    }
 }


### PR DESCRIPTION
Missing `return` statement prevented creation of delegates with non-void return value from a function pointer or raw pointer + member function pointer.