### PR TITLE
Update VSIX to work with Dev17

### DIFF
--- a/vsix/Standalone/source.extension.vsixmanifest
+++ b/vsix/Standalone/source.extension.vsixmanifest
@@ -14,10 +14,24 @@
     <Tags>WinRT, C++, cppwinrt, native</Tags>
   </Metadata>
   <Installation AllUsers="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[15.0,17.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)" />
-  </Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)">
+      <ProductArchitecture>x86</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[16.0, 17.0)">
+      <ProductArchitecture>x86</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0, 18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0, 17.0)">
+      <ProductArchitecture>x86</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0, 18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>  </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
@@ -29,7 +43,7 @@
     <Asset Type="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" Source="File" Path="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" VsixSubPath="Packages" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.VC" Version="[15.0,)" DisplayName="C++ Universal Windows Platform tools" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.UWP.VC" Version="[16.0,)" DisplayName="C++ Universal Windows Platform tools" />
   </Prerequisites>
 </PackageManifest>

--- a/vsix/Standalone/source.extension.vsixmanifest
+++ b/vsix/Standalone/source.extension.vsixmanifest
@@ -31,7 +31,8 @@
     </InstallationTarget>
     <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0, 18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>  </Installation>
+    </InstallationTarget>    
+  </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>

--- a/vsix/packages.config
+++ b/vsix/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VSSDK.BuildTools" version="16.0.2258" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="17.0.1619-preview1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/vsix/vsix.csproj
+++ b/vsix/vsix.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="PrepareBuild;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <NuGetPackageImportStamp>
@@ -51,39 +51,48 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\ARM\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\ARM\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\ARM64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\ARM64\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\Win32\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\Win32\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Platforms\x64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Microsoft\VC\v160\Platforms\x64\ImportBefore</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\ARM\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Application Type\Windows Store\10.0\Platforms\ARM\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\ARM64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Application Type\Windows Store\10.0\Platforms\ARM64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\Win32\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Application Type\Windows Store\10.0\Platforms\Win32\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Application Type\Windows Store\10.0\Platforms\x64\ImportAfter\Microsoft.Cpp.CppWinRT.props">
-      <InstallRoot>VCTargets</InstallRoot>
+      <VSIXSubPath>Application Type\Windows Store\10.0\Platforms\x64\ImportAfter</VSIXSubPath>
+      <InstallRoot>MSBuild</InstallRoot>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="$(NupkgDir)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion).nupkg">
@@ -109,6 +118,7 @@
     <None Include="$(Deployment)\source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="cppwinrt.ico">
@@ -117,9 +127,6 @@
     <Content Include="cppwinrt.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="x64\" />
@@ -130,8 +137,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Import Project=".\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('.\packages\Microsoft.VSSDK.BuildTools.16.0.2258\build\Microsoft.VSSDK.BuildTools.targets')" />
   <Target Name="GetCppWinRTVersion" Outputs="$(CppWinRTVersion)" />
@@ -163,4 +170,5 @@
       <Content Include="@(TemplateItems)" />
     </ItemGroup>
   </Target>
+  <Import Project="packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('packages\Microsoft.VSSDK.BuildTools.17.0.1619-preview1\build\Microsoft.VSSDK.BuildTools.targets')" />
 </Project>


### PR DESCRIPTION
This updates the VSIX to work with Dev17 (VS 2022) Preview.

One thing I learned is that the VCTargets install path was deprecated starting in VS2019, so I had to update it to an explicit path under MSBuild.

See:
- https://docs.microsoft.com/en-us/visualstudio/extensibility/set-install-root?view=vs-2019
- https://docs.microsoft.com/en-us/cpp/build/reference/msbuild-visual-cpp-overview?view=msvc-160

The second link suggests that the new path won't work in VS2017, and I thought we didn't still support VS2017, so I've moved up the minimum VS version from 2017 to 2019.