### PR TITLE
check_hresult returns the hresult as a convenience

### DIFF
--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -576,12 +576,13 @@ WINRT_EXPORT namespace winrt
         throw_hresult(impl::hresult_from_win32(WINRT_IMPL_GetLastError()));
     }
 
-    inline void check_hresult(hresult const result)
+    inline hresult check_hresult(hresult const result)
     {
         if (result < 0)
         {
             throw_hresult(result);
         }
+        return result;
     }
 
     template<typename T>

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -1,7 +1,7 @@
 
 WINRT_EXPORT namespace winrt
 {
-    void check_hresult(hresult const result);
+    hresult check_hresult(hresult const result);
     hresult to_hresult() noexcept;
 
     template <typename D, typename I>

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -10,7 +10,7 @@ TEST_CASE("hresult,S_OK")
 {
     // This won't throw
 
-    check_hresult(S_OK);
+    REQUIRE(check_hresult(S_OK) == S_OK);
 }
 
 TEST_CASE("hresult,S_FALSE")
@@ -18,7 +18,7 @@ TEST_CASE("hresult,S_FALSE")
     // This won't throw (unless you define WINRT_STRICT_HRESULT)
 
 #ifndef WINRT_STRICT_HRESULT
-    check_hresult(S_FALSE);
+    REQUIRE(check_hresult(S_FALSE) == S_FALSE);
 #else
     try
     {


### PR DESCRIPTION
Like `check_pointer`, `check_hresult` accepts multiple successful values. The `check_pointer` function returns the successful pointer, but `check_hresult` swallows the successful result, which makes using `check_hresult` inconvenient to use with COM methods that return `S_FALSE`. For example:

```cpp
if (hresult error = root->SelectSingleNode(query, node.put()); check_hresult(error), error == S_OK)
{
    process(node);
}
```

Extending `check_hresult` to return the successful `hresult` simplifies the code:

```cpp
if (check_hresult(root->SelectSingleNode(query, node.put())) == S_OK)
{
    process(node);
}
```

I think it is unlikely that anybody has been doing `decltype(check_hresult())`, so changing the return value should be non-breaking.