### PR TITLE
Automatically enable App SDK 0.8 coroutine support when present

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -3300,6 +3300,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             w.write(strings::base_xaml_typename);
         }
+        else if (namespace_name == "Microsoft.UI.Dispatching")
+        {
+            w.write(strings::base_coroutine_dispatching_winui);
+        }
     }
 
     static void write_namespace_special_1(writer& w, std::string_view const& namespace_name)

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -52,6 +52,7 @@
     <ClInclude Include="..\strings\base_collections_vector.h" />
     <ClInclude Include="..\strings\base_composable.h" />
     <ClInclude Include="..\strings\base_com_ptr.h" />
+    <ClInclude Include="..\strings\base_coroutine_dispatching_winui.h" />
     <ClInclude Include="..\strings\base_coroutine_foundation.h" />
     <ClInclude Include="..\strings\base_coroutine_system.h" />
     <ClInclude Include="..\strings\base_coroutine_threadpool.h" />

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClInclude Include="..\strings\base_iterator.h">
       <Filter>strings</Filter>
     </ClInclude>
+    <ClInclude Include="..\strings\base_coroutine_dispatching_winui.h">
+      <Filter>strings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="$(OutDir)version.rc" />

--- a/strings/base_coroutine_dispatching_winui.h
+++ b/strings/base_coroutine_dispatching_winui.h
@@ -1,0 +1,4 @@
+
+#if __has_include(<microsoft.ui.dispatching.co_await.h>)
+#include <microsoft.ui.dispatching.co_await.h>
+#endif


### PR DESCRIPTION
Fixes https://github.com/microsoft/WindowsAppSDK/issues/957 by automatically including the header from the App SDK

Keeps behavior consistent with other Microsoft-provided dispatcher types, and allows the App SDK to version the header themselves still

Testing methodology:
 - Create a new console app
 - Install CppWinRT and WinUI 3 NuGet packages
 - Replace cppwinrt.exe from NuGet with self-built binary
 - Ensure the following code compiles:
   ```cpp
   #include <winrt/Microsoft.UI.Dispatching.h>
   
   winrt::fire_and_forget test(const winrt::Microsoft::UI::Dispatching::DispatcherQueue& queue)
   {
       co_await queue;
   }
   ```