### PR TITLE
Fix target override as it doesn't work when the target import order changes.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -63,7 +63,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PrepareForBuildDependsOn>
             $(PrepareForBuildDependsOn);
             CppWinRTVerifyKitVersion;
-            CppWinRTGetResolvedWinMD;
         </PrepareForBuildDependsOn>
         <!-- Note: Before* targets run before Compute* targets. -->
         <BeforeMidlCompileTargets>
@@ -108,6 +107,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <GetTargetPathDependsOn>
             $(GetTargetPathDependsOn);CppWinRTGetResolvedWinMD
         </GetTargetPathDependsOn>
+        <GetPackagingOutputsDependsOn>
+            $(GetPackagingOutputsDependsOn);CppWinRTGetResolvedWinMD
+        </GetPackagingOutputsDependsOn>
 
     </PropertyGroup>
 

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -63,6 +63,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <PrepareForBuildDependsOn>
             $(PrepareForBuildDependsOn);
             CppWinRTVerifyKitVersion;
+            CppWinRTGetResolvedWinMD;
         </PrepareForBuildDependsOn>
         <!-- Note: Before* targets run before Compute* targets. -->
         <BeforeMidlCompileTargets>
@@ -75,7 +76,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             $(AfterMidlTargets);
             GetCppWinRTMdMergeInputs;
             CppWinRTMergeProjectWinMDInputs;
-            GetResolvedWinMD;
+            CppWinRTGetResolvedWinMD;
             CppWinRTCopyWinMDToOutputDirectory;
         </AfterMidlTargets>
         <ResolveReferencesDependsOn>
@@ -104,6 +105,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CleanDependsOn>
             $(CleanDependsOn);CppWinRTClean
         </CleanDependsOn>
+        <GetTargetPathDependsOn>
+            $(GetTargetPathDependsOn);CppWinRTGetResolvedWinMD
+        </GetTargetPathDependsOn>
 
     </PropertyGroup>
 
@@ -202,7 +206,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </Target>
 
-    <Target Name="ComputeGetResolvedWinMD"
+    <Target Name="CppWinRTComputeGetResolvedWinMD"
             Condition="'$(CppWinRTGenerateWindowsMetadata)' == ''">
         <!-- If CppWinRTGenerateWindowsMetadata is not defined, compute it.-->
         <!-- We use Calltarget, so we don't run anything including DependsOnTargets
@@ -214,33 +218,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          so it is aware of the C++/WinRT generated WinMD.
          Since not every project that consumes C++/WinRT uses it to generate a WinMD,
          we need to keep the CX logic as well. -->
-    <Target Name="GetResolvedWinMD"
-            DependsOnTargets="ComputeGetResolvedWinMD"
+    <Target Name="CppWinRTGetResolvedWinMD"
+            DependsOnTargets="CppWinRTComputeGetResolvedWinMD"
             Returns="@(WinMDFullPath)">
-
-        <!-- Copied from the CX GetResolvedWinMD target in Microsoft.CppBuild.targets -->
-        <ItemGroup>
-            <!-- To evaluate the GenerateWindowsMetadata value we need @(Link) to contains at least one element-->
-            <Link Include="tmp" Condition="'@(Link)'==''">
-                <DeleteSoon>true</DeleteSoon>
-            </Link>
-
-            <!-- Condition is modified to only do this if CppWinRTGenerateWindowsMetadata is not true. -->
-            <WinMDFullPath Condition="'%(Link.GenerateWindowsMetadata)' == 'true' AND '$(CppWinRTGenerateWindowsMetadata)' != 'true'"
-                           Include="@(Link->Metadata('WindowsMetadataFile')->FullPath()->Distinct()->ClearMetadata())">
-                <TargetPath>$([System.IO.Path]::GetFileName('%(Link.WindowsMetadataFile)'))</TargetPath>
-                <Primary>true</Primary>
-            </WinMDFullPath>
-
-            <WinMDFullPath>
-                <Implementation>$(WinMDImplementationPath)$(TargetName)$(TargetExt)</Implementation>
-                <FileType>winmd</FileType>
-                <WinMDFile>true</WinMDFile>
-                <ProjectType>$(ConfigurationType)</ProjectType>
-            </WinMDFullPath>
-
-            <Link Remove="@(Link)" Condition="'%(Link.DeleteSoon)' == 'true'" />
-        </ItemGroup>
 
         <!-- Add C++/WinRT primary WinMD to the WinMDFullPath if CppWinRTGenerateWindowsMetadata is true -->
         <ItemGroup>

--- a/test/nuget/TestApp/TestApp.vcxproj
+++ b/test/nuget/TestApp/TestApp.vcxproj
@@ -13,7 +13,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -76,8 +76,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>
       </DisableSpecificWarnings>
     </ClCompile>

--- a/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
+++ b/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
@@ -80,8 +80,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>

--- a/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
+++ b/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
@@ -81,8 +81,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>

--- a/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
+++ b/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
@@ -81,8 +81,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>

--- a/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
+++ b/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
@@ -81,8 +81,6 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-      <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
-      <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>


### PR DESCRIPTION
Current C++/WinRT override the GetResolvedWinMD target. However if the import order changes this override can easily break, like it does when NuGet imports the targets as part of PackageReference. 

This PR removes the override.

Validation:

- [x] OS
- [x] WinUI
- [x] Terminal
- [x] YourPhone
- [ ] React-Native