### PR TITLE
Ensure we don't override XamlLanguage if it's already set.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -17,7 +17,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CanReferenceWinRT>true</CanReferenceWinRT>
         <CppWinRTPackage Condition="'$(CppWinRTEnabled)' != 'true'">true</CppWinRTPackage>
         <CppWinRTPackage Condition="'$(CppWinRTPackage)' != 'true'">false</CppWinRTPackage>
-        <XamlLanguage>CppWinRT</XamlLanguage>
+        <XamlLanguage Condition="'$(XamlLanguage)' == ''">CppWinRT</XamlLanguage>
         <IsNativeLanguage>true</IsNativeLanguage>
         <!-- This causes VS to add the platform WinMD references for the target SDK -->
         <WinMDAssembly>true</WinMDAssembly>


### PR DESCRIPTION
When NuGet imports the props as part of PackageReference, it easy to end up in situations where the project file defines XamlLanguage before the C++/WinRT props are imported.

We shouldn't override if the value is already set.