### PR TITLE
Ensure the Xaml designer can find out WinMD

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -222,6 +222,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          we need to keep the CX logic as well. -->
     <Target Name="CppWinRTGetResolvedWinMD"
             DependsOnTargets="CppWinRTComputeGetResolvedWinMD"
+            BeforeTargets="WinMDArtifactsProjectOutputGroup;CopyWinMDArtifactsOutputGroup;PrimaryWinMDOutputGroup"
             Returns="@(WinMDFullPath)">
 
         <!-- Add C++/WinRT primary WinMD to the WinMDFullPath if CppWinRTGenerateWindowsMetadata is true -->

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -222,7 +222,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          we need to keep the CX logic as well. -->
     <Target Name="CppWinRTGetResolvedWinMD"
             DependsOnTargets="CppWinRTComputeGetResolvedWinMD"
-            BeforeTargets="WinMDArtifactsProjectOutputGroup;CopyWinMDArtifactsOutputGroup;PrimaryWinMDOutputGroup"
+            BeforeTargets="GetResolvedWinMD"
             Returns="@(WinMDFullPath)">
 
         <!-- Add C++/WinRT primary WinMD to the WinMDFullPath if CppWinRTGenerateWindowsMetadata is true -->

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -216,10 +216,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CallTarget Targets="CppWinRTComputeGenerateWindowsMetadata" />
     </Target>
 
-    <!-- This target overrides the GetResolvedWinMD target used to resolve the WinMD for native projects
+    <!-- This target hooks into the GetResolvedWinMD target used to resolve the WinMD for native projects
          so it is aware of the C++/WinRT generated WinMD.
-         Since not every project that consumes C++/WinRT uses it to generate a WinMD,
-         we need to keep the CX logic as well. -->
+         There is no good way to hook GetResolvedWinMD so we use BeforeTargets. -->
     <Target Name="CppWinRTGetResolvedWinMD"
             DependsOnTargets="CppWinRTComputeGetResolvedWinMD"
             BeforeTargets="GetResolvedWinMD"


### PR DESCRIPTION
#977 removed an override of a built-in CX target that wasn't working reliably. Because of this, various targets to resolve the WinMD would no longer find the WinMD file. This never worked reliably but it turns out the Xaml designer uses one of these targets. This PR adds a BeforeTargets to ensure the WinMD will be resolved.

Fixes #981

Verified that the test solution builds and the designer works as well.