### PR TITLE
Harden `put` functions against misuse

### DIFF
--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -111,7 +111,7 @@ WINRT_EXPORT namespace winrt
 
         type** put() noexcept
         {
-            WINRT_ASSERT(m_ptr == nullptr);
+            release_ref();
             return &m_ptr;
         }
 

--- a/strings/base_handle.h
+++ b/strings/base_handle.h
@@ -52,7 +52,7 @@ WINRT_EXPORT namespace winrt
 
         type* put() noexcept
         {
-            WINRT_ASSERT(m_value == T::invalid());
+            close();
             return &m_value;
         }
 


### PR DESCRIPTION
The `put_abi` functions are already hardened in this way. 