### PR TITLE
Fix cyclic dependency error when upgrading VS 2022

### DIFF
--- a/vsix/Component/source.extension.vsixmanifest
+++ b/vsix/Component/source.extension.vsixmanifest
@@ -29,6 +29,6 @@
     <Asset Type="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" Source="File" Path="Microsoft.Windows.CppWinRT.|%CurrentProject%;GetCppWinRTVersion|.nupkg" VsixSubPath="Packages" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CppWinRT" Version="[16.10,)" DisplayName="CppWinRT" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.VC.CoreBuildTools" Version="[16.0,18.0)" DisplayName="CppWinRT" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This will help prevent [this error](https://developercommunity.visualstudio.com/t/Unable-to-update-from-Preview-11-to-Pre/1476321) from happening in the future. #960 should be fully working after this.