### PR TITLE
Some uses of `co_await` were not protected by `WINRT_IMPL_COROUTINES`

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -167,7 +167,9 @@ namespace winrt::impl
     private:
         static fire_and_forget cancel_asynchronously(Async async)
         {
+#ifdef WINRT_IMPL_COROUTINES
             co_await winrt::resume_background();
+#endif
             try
             {
                 async.Cancel();
@@ -793,6 +795,7 @@ namespace std::experimental
 
 WINRT_EXPORT namespace winrt
 {
+#ifdef WINRT_IMPL_COROUTINES
     template <typename... T>
     Windows::Foundation::IAsyncAction when_all(T... async)
     {
@@ -838,4 +841,5 @@ WINRT_EXPORT namespace winrt
         impl::check_status_canceled(shared->status);
         co_return shared->result.GetResults();
     }
+#endif
 }

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -127,6 +127,7 @@ namespace winrt::impl
         }
     };
 
+#ifdef WINRT_IMPL_COROUTINES
     template <typename Async>
     struct await_adapter : enable_await_cancellation
     {
@@ -165,15 +166,9 @@ namespace winrt::impl
         }
 
     private:
-        static void cancel_asynchronously(Async async)
+        static fire_and_forget cancel_asynchronously(Async async)
         {
-            submit_threadpool_callback(cancel_callback, get_abi(async));
-            detach_abi(async);
-        }
-
-        static void __stdcall cancel_callback(void*, void* context) noexcept
-        {
-            Async async(context, take_ownership_from_abi);
+            co_await winrt::resume_background();
             try
             {
                 async.Cancel();
@@ -183,6 +178,7 @@ namespace winrt::impl
             }
         }
     };
+#endif
 
     template <typename D>
     auto consume_Windows_Foundation_IAsyncAction<D>::get() const

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -165,11 +165,15 @@ namespace winrt::impl
         }
 
     private:
-        static fire_and_forget cancel_asynchronously(Async async)
+        static void cancel_asynchronously(Async async)
         {
-#ifdef WINRT_IMPL_COROUTINES
-            co_await winrt::resume_background();
-#endif
+            submit_threadpool_callback(cancel_callback, get_abi(async));
+            detach_abi(async);
+        }
+
+        static void __stdcall cancel_callback(void*, void* context) noexcept
+        {
+            Async async(context, take_ownership_from_abi);
             try
             {
                 async.Cancel();


### PR DESCRIPTION
Fixes #1001