### PR TITLE
Fix edge case in nested Windows namespace 

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -2426,10 +2426,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             w.write(format, bind<write_generic_typenames>(generics));
         }
 
-        auto format = R"(    struct % : Windows::Foundation::IUnknown
+        auto format = R"(    struct % : winrt::Windows::Foundation::IUnknown
     {%
         %(std::nullptr_t = nullptr) noexcept {}
-        %(void* ptr, take_ownership_from_abi_t) noexcept : Windows::Foundation::IUnknown(ptr, take_ownership_from_abi) {}
+        %(void* ptr, take_ownership_from_abi_t) noexcept : winrt::Windows::Foundation::IUnknown(ptr, take_ownership_from_abi) {}
         template <typename L> %(L lambda);
         template <typename F> %(F* function);
         template <typename O, typename M> %(O* object, M method);

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -293,5 +293,7 @@ namespace test_component
             static void StaticMethod(Struct param);
             void Method(Windows.Foundation.Uri param);
         }
+
+        delegate void Delegate();
     }
 }


### PR DESCRIPTION
The previous testing didn't cover delegates.