### PR TITLE
Generate test failure output on abnormal termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.c
 *.nupkg
 test*.xml
+test*_results.txt
 build
 packages
 Debug

--- a/run_tests.cmd
+++ b/run_tests.cmd
@@ -20,5 +20,6 @@ goto :eof
 
 :run_test
 if not "%target_version%"=="" set args=-o %1-%target_version%.xml -r junit
-_build\%target_platform%\%target_configuration%\%1.exe %args%
+rem Buffer output and redirect to stdout/stderr depending whether the test executable exits successfully. Pipeline will fail if there's any output to stderr.
+_build\%target_platform%\%target_configuration%\%1.exe %args% > %1_results.txt && type %1_results.txt || type %1_results.txt >&2
 goto :eof

--- a/test/old_tests/UnitTests/Main.cpp
+++ b/test/old_tests/UnitTests/Main.cpp
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
     using namespace winrt;
 
     init_apartment();
-    std::set_terminate([]{ ExitProcess(1); });
+    std::set_terminate([]{ reportFatal("Abnormal termination"); ExitProcess(1); });
     int const result = Catch::Session().run(argc, argv);
 
     // Completely unnecessary in an app, but useful for testing clear_factory_cache behavior.

--- a/test/test/main.cpp
+++ b/test/test/main.cpp
@@ -7,7 +7,7 @@ using namespace winrt;
 int main(int const argc, char** argv)
 {
     init_apartment();
-    std::set_terminate([] { ExitProcess(1); });
+    std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_win7/main.cpp
+++ b/test/test_win7/main.cpp
@@ -7,7 +7,7 @@ using namespace winrt;
 int main(int const argc, char** argv)
 {
     init_apartment();
-    std::set_terminate([] { ExitProcess(1); });
+    std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     return Catch::Session().run(argc, argv);
 }
 


### PR DESCRIPTION
Fixes #1010 by calling Catch2's `reportFatal()` in the `std::terminate` handler so that failure logging is generated before the process exits.