### PR TITLE
Enable /await opt-out so users can manually enable /await:strict.

### DIFF
--- a/nuget/CppWinrtRules.Project.xml
+++ b/nuget/CppWinrtRules.Project.xml
@@ -81,4 +81,9 @@
                 Description="Enables or disables the default for copying binaries to the output folder to be false"
                 Category="General" />
 
+  <BoolProperty Name="CppWinRTEnableLegacyCoroutines"
+                DisplayName="Enable legacy coroutines (C++17)"
+                Description="Enables the /await compiler option (disable this if you want to pass this yourself)"
+                Category="General" />
+
 </Rule>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -871,7 +871,7 @@ $(XamlMetaDataProviderPch)
     <ItemDefinitionGroup>
         <ClCompile>
             <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-            <AdditionalOptions Condition="'%(ClCompile.LanguageStandard)' == 'stdcpp17'">%(AdditionalOptions) /await:strict</AdditionalOptions>
+            <AdditionalOptions Condition="'%(ClCompile.LanguageStandard)' == 'stdcpp17' And '$(CppWinRTEnableLegacyCoroutines)' != 'false'">%(AdditionalOptions) /await</AdditionalOptions>
             <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(GeneratedFilesDir)</AdditionalIncludeDirectories>
         </ClCompile>
         <Midl Condition="'$(CppWinRTModernIDL)' != 'false'">

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -871,7 +871,7 @@ $(XamlMetaDataProviderPch)
     <ItemDefinitionGroup>
         <ClCompile>
             <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
-            <AdditionalOptions Condition="'%(ClCompile.LanguageStandard)' == 'stdcpp17'">%(AdditionalOptions) /await</AdditionalOptions>
+            <AdditionalOptions Condition="'%(ClCompile.LanguageStandard)' == 'stdcpp17'">%(AdditionalOptions) /await:strict</AdditionalOptions>
             <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(GeneratedFilesDir)</AdditionalIncludeDirectories>
         </ClCompile>
         <Midl Condition="'$(CppWinRTModernIDL)' != 'false'">


### PR DESCRIPTION
/await:strict is binary compatible with c++20 coroutines. Instead of adding new logic to the C++/WinRT build targets, allow opt-out of the current default so users can set this manually.

For details, see: https://docs.microsoft.com/en-us/cpp/build/reference/await-enable-coroutine-support?view=msvc-160 and https://devblogs.microsoft.com/cppblog/cpp20-coroutine-improvements-in-visual-studio-2019-version-16-11/

Fixes #1014 