### PR TITLE
Ignore MIDL files which are excluded from the build

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -349,7 +349,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 Returns="@(CppWinRTMdMergeMetadataDirectories);@(CppWinRTMdMergeInputs)">
         <ItemGroup>
             <_MdMergeInputs Remove="@(_MdMergeInputs)"/>
-            <_MdMergeInputs Include="@(Midl)">
+            <_MdMergeInputs Include="@(Midl)" Condition="'%(Midl.ExcludedFromBuild)' != 'true'">
                 <WinMDPath>%(Midl.OutputDirectory)%(Midl.MetadataFileName)</WinMDPath>
                 <MdMergeOutputFile>$(CppWinRTProjectWinMD)</MdMergeOutputFile>
             </_MdMergeInputs>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -190,16 +190,24 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </ItemGroup>
     </Target>
 
+    <Target Name="CppWinRTGetBuildingMidl"
+            DependsOnTargets="CppWinRTComputeXamlGeneratedMidlInputs"
+            Returns="@(_BuildingMidl)">
+        <ItemGroup>
+            <_BuildingMidl Include="@(Midl)" Condition="'%(Midl.ExcludedFromBuild)' != 'true'" />
+        </ItemGroup>
+    </Target>
+
     <!-- Target used only to evaluate CppWinRTGenerateWindowsMetadata if it doesn't already have a value -->
     <Target Name="CppWinRTComputeGenerateWindowsMetadata"
-            DependsOnTargets="CppWinRTComputeXamlGeneratedMidlInputs;GetCppWinRTProjectWinMDReferences;$(CppWinRTComputeGenerateWindowsMetadataDependsOn)">
+            DependsOnTargets="CppWinRTGetBuildingMidl;GetCppWinRTProjectWinMDReferences;$(CppWinRTComputeGenerateWindowsMetadataDependsOn)">
 
         <PropertyGroup>
             <!-- For static libraries, only idl causes a winmd to be generated. 
                  For exe/dll, static libraries that produce a WinMD will be merged, 
                  so they also cause a WinMD to be generated-->
-            <CppWinRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' != 'StaticLibrary' AND '@(CppWinRTStaticProjectWinMDReferences)@(Midl)'!= ''">true</CppWinRTGenerateWindowsMetadata>
-            <CppWinRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' == 'StaticLibrary' AND '@(Midl)'!= ''">true</CppWinRTGenerateWindowsMetadata>
+            <CppWinRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' != 'StaticLibrary' AND '@(CppWinRTStaticProjectWinMDReferences)@(_BuildingMidl)'!= ''">true</CppWinRTGenerateWindowsMetadata>
+            <CppWinRTGenerateWindowsMetadata Condition="'$(ConfigurationType)' == 'StaticLibrary' AND '@(_BuildingMidl)'!= ''">true</CppWinRTGenerateWindowsMetadata>
 
             <!-- At this point we checked all cases where we do generate a WinMD.
                  The remaining option is no WinMD. -->
@@ -345,12 +353,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Calculates the input files and metadata directories to be passed to MdMerge -->
     <Target Name="GetCppWinRTMdMergeInputs"
-                DependsOnTargets="CppWinRTComputeXamlGeneratedMidlInputs;CppWinRTResolveReferences;"
-                Returns="@(CppWinRTMdMergeMetadataDirectories);@(CppWinRTMdMergeInputs)">
+            DependsOnTargets="CppWinRTGetBuildingMidl;CppWinRTResolveReferences"
+            Returns="@(CppWinRTMdMergeMetadataDirectories);@(CppWinRTMdMergeInputs)">
         <ItemGroup>
             <_MdMergeInputs Remove="@(_MdMergeInputs)"/>
-            <_MdMergeInputs Include="@(Midl)" Condition="'%(Midl.ExcludedFromBuild)' != 'true'">
-                <WinMDPath>%(Midl.OutputDirectory)%(Midl.MetadataFileName)</WinMDPath>
+            <_MdMergeInputs Include="@(_BuildingMidl)">
+                <WinMDPath>%(_BuildingMidl.OutputDirectory)%(_BuildingMidl.MetadataFileName)</WinMDPath>
                 <MdMergeOutputFile>$(CppWinRTProjectWinMD)</MdMergeOutputFile>
             </_MdMergeInputs>
             <!-- Static libraries don't mdmerge other static libraries.
@@ -387,7 +395,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <ItemGroup>
             <Midl Remove="$(XamlMetaDataProviderIdl)" />
             <Midl Include="$(XamlMetaDataProviderIdl)">
-                <DisableReferences Condition="$(_DisableReferences)">>true</DisableReferences>
+                <DisableReferences Condition="$(_DisableReferences)">true</DisableReferences>
             </Midl>
         </ItemGroup>
     </Target>


### PR DESCRIPTION
Without this, cppwinrt would attempt to use the output of MIDL files which where excluded from the build, resuting in mdmerge either erroring due to missing files, or using partially outdated build output.