### PR TITLE
Properly report failure to switch to target apartment

### DIFF
--- a/test/old_tests/UnitTests/apartment_context.cpp
+++ b/test/old_tests/UnitTests/apartment_context.cpp
@@ -77,6 +77,19 @@ namespace
         return (type == APTTYPE_NA) && (qualifier == APTTYPEQUALIFIER_NA_ON_MTA || qualifier == APTTYPEQUALIFIER_NA_ON_IMPLICIT_MTA);
     }
 
+    bool is_mta()
+    {
+        APTTYPE type;
+        APTTYPEQUALIFIER qualifier;
+        check_hresult(CoGetApartmentType(&type, &qualifier));
+        return type == APTTYPE_MTA;
+    }
+
+    bool is_invalid_context_error(HRESULT hr)
+    {
+        return (hr == RPC_E_SERVER_DIED_DNE) || (hr == RPC_E_DISCONNECTED);
+    }
+
     IAsyncAction TestNeutralApartmentContext()
     {
         auto controller = DispatcherQueueController::CreateOnDedicatedThread();
@@ -144,10 +157,89 @@ namespace
 
         co_await controller1.ShutdownQueueAsync();
         co_await controller2.ShutdownQueueAsync();
-    }
-
 }
 
+IAsyncAction TestDisconnectedApartmentContext()
+{
+    // Create an STA thread and switch to it.
+    auto controller1 = DispatcherQueueController::CreateOnDedicatedThread();
+    co_await resume_foreground(controller1.DispatcherQueue());
+
+    // Create another STA thread.
+    auto controller2 = DispatcherQueueController::CreateOnDedicatedThread();
+
+    // Test returning to a destroyed context after IAsyncXxx completion on STA.
+    HRESULT error = S_OK;
+    try
+    {
+        co_await[](auto controller1, auto controller2) -> IAsyncAction
+        {
+            co_await resume_foreground(controller2.DispatcherQueue());
+            co_await controller1.ShutdownQueueAsync();
+        }(controller1, controller2);
+    }
+    catch (...)
+    {
+        error = winrt::to_hresult();
+        REQUIRE(is_mta());
+    }
+    REQUIRE(is_invalid_context_error(error));
+
+    // Re-create the STA thread for the next test.
+    controller1 = DispatcherQueueController::CreateOnDedicatedThread();
+    co_await resume_foreground(controller1.DispatcherQueue());
+
+    // Save the COM context for the first STA thread.
+    apartment_context context1;
+
+    // Test returning to a destroyed context after IAsyncXxx completion on MTA.
+    error = S_OK;
+    try
+    {
+        co_await[](auto controller1) -> IAsyncAction
+        {
+            co_await resume_background(); // doesn't work
+            co_await controller1.ShutdownQueueAsync();
+        }(controller1);
+    }
+    catch (...)
+    {
+        error = winrt::to_hresult();
+        REQUIRE(is_mta());
+    }
+    REQUIRE(is_invalid_context_error(error));
+
+    // Test switching to a destroyed context from an STA.
+    co_await resume_foreground(controller2.DispatcherQueue());
+
+    error = S_OK;
+    try {
+        co_await context1;
+    }
+    catch (...)
+    {
+        error = winrt::to_hresult();
+        REQUIRE(is_mta());
+    }
+    REQUIRE(is_invalid_context_error(error));
+
+    // Test switching to a destroyed context from an MTA.
+    error = S_OK;
+    try {
+        co_await context1;
+    }
+    catch (...)
+    {
+        error = winrt::to_hresult();
+        REQUIRE(is_mta());
+    }
+    REQUIRE(is_invalid_context_error(error));
+
+    // Clean up.
+    co_await controller2.ShutdownQueueAsync();
+}
+
+}
 TEST_CASE("apartment_context coverage")
 {
     Async().get();
@@ -161,4 +253,9 @@ TEST_CASE("apartment_context nta")
 TEST_CASE("apartment_context sta")
 {
     TestStaToStaApartmentContext().get();
+}
+
+TEST_CASE("apartment_context disconnected")
+{
+    TestDisconnectedApartmentContext().get();
 }


### PR DESCRIPTION
If we were unable to switch to a target apartment (either by an explicit `co_await apartment_context` or implicitly at the completion of ` co_await IAsyncInfo`), we now report the exception in the `co_await`'ing coroutine, so it can be caught and handled.

Note that when this error occurs, we are stuck in limbo. We left the original apartment for the MTA, and now we can't get from the MTA to the target apartment. We have no choice but to raise the exception on the MTA, even though the coroutine may not have expected to be running there.

```cpp
IAsyncAction Trapped()
{
    Object o; // some object with a destructor
    co_await destroyed_ui_context; // throws an exception
}
```

The destructor for `Object` will run on the MTA, even though the `Trapped` coroutine never runs on the MTA under normal conditions.

This is making the best of a bad situation. We need to raise the exception into the coroutine so that the coroutine can enter a failure state and allow the coroutine chain to proceed.

Since the object `o` already had to be prepared for destruction on the original apartment or the switched-to apartment (in case an exception occurs in either apartment), we know that the object cannot have apartment affinity anyway. So we're probably okay to destruct it on the MTA.

The old code raised the exception on whatever thread happened to notice that something bad happened. Sometimes that's okay, for example if you do a `co_await destroyed_ui_context` from an MTA thread, in which case the exception is thrown into the coroutine and can be caught, or left uncaught and send the coroutine into an error state.

However, all of the other cases weren't quite so happy. To avoid deadlocks, the apartment switch is routed through the threadpool, and that means that the failure is raised on a threadpool thread. There's nobody around to catch that exception, so the process fails fast.

We solve the problem by having an atomic hresult in the awaiter, which is initialized to 0 (`S_OK`) and transitions to error when we are about to resume the coroutine on the wrong apartment, so that the error can be propagated during `await_resume()`, which happens in the context of the awaiting coroutine and therefore can be caught by the coroutine (or sent to `unhandled_exception`).

The hresult in which we record the failure needs to be atomic to avoid data races in case multiple threads detect failure simultaneously. However, the access to it can be relaxed, because it is set and consumed by the same thread.

The current implementation pulls a sneaky trick: To avoid having to create an `operator co_await` for the `apartment_context` object, we continue to let it be its own awaiter. This means that if the apartment switch fails, we record the failure in the `apartment_context` itself. We are making the assumption that once an apartment context goes bad, it is unrecoverably broken.