### PR TITLE
Support binding `std::optional<T>` implementation to `IReference<T>` parameters

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1507,13 +1507,25 @@ namespace cppwinrt
         }
         else if (type_name == "Windows.Foundation.IReference`1")
         {
-            w.write(R"(        IReference(T const& value) : IReference<T>(impl::reference_traits<T>::make(value))
+            w.write(R"(        IReference(T const& value) : IReference(impl::reference_traits<T>::make(value))
         {
         }
-
+        IReference(std::optional<T> const& value) : IReference(value ? IReference(value.value()) : nullptr)
+        {
+        }
+        operator std::optional<T>() const
+        {
+            if (*this)
+            {
+                return this->Value();
+            }
+            else
+            {
+                return std::nullopt;
+            }
+        }
     private:
-
-        IReference<T>(IInspectable const& value) : IReference<T>(value.as<IReference<T>>())
+        IReference(IInspectable const& value) : IReference(value.as<IReference>())
         {
         }
 )");

--- a/test/test/optional.cpp
+++ b/test/test/optional.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include "winrt/test_component.h"
+
+using namespace winrt;
+
+TEST_CASE("optional")
+{
+    test_component::Optional object;
+
+    object.Property(Windows::Foundation::IReference(123));
+    REQUIRE(object.Property().Value() == 123);
+
+    object.Property(nullptr);
+    REQUIRE(object.Property() == nullptr);
+
+    object.Property(456);
+    REQUIRE(object.Property().Value() == 456);
+
+    object.Property(std::optional(789));
+    std::optional<int32_t> value = object.Property();
+    REQUIRE(value == std::optional(789));
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -418,6 +418,7 @@
     <ClCompile Include="no_make_detection.cpp" />
     <ClCompile Include="numerics.cpp" />
     <ClCompile Include="observable_index_of.cpp" />
+    <ClCompile Include="optional.cpp" />
     <ClCompile Include="out_params.cpp" />
     <ClCompile Include="out_params_abi.cpp" />
     <ClCompile Include="out_params_bad.cpp" />

--- a/test/test_component/Optional.cpp
+++ b/test/test_component/Optional.cpp
@@ -1,0 +1,3 @@
+#include "pch.h"
+#include "Optional.h"
+#include "Optional.g.cpp"

--- a/test/test_component/Optional.h
+++ b/test/test_component/Optional.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "Optional.g.h"
+
+namespace winrt::test_component::implementation
+{
+    struct Optional : OptionalT<Optional>
+    {
+        Optional() = default;
+
+        Windows::Foundation::IReference<int32_t> Property()
+        {
+            return m_property;
+        }
+
+        void Property(Windows::Foundation::IReference<int32_t> const& value)
+        {
+            m_property = value;
+        }
+
+        std::optional<int32_t> m_property;
+    };
+}
+namespace winrt::test_component::factory_implementation
+{
+    struct Optional : OptionalT<Optional, implementation::Optional>
+    {
+    };
+}

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -64,6 +64,12 @@ namespace test_component
         void IncrementCounter();
     }
 
+    runtimeclass Optional
+    {
+        Optional();
+        Windows.Foundation.IReference<Int32> Property;
+    }
+
     runtimeclass Class
     {
         Class();

--- a/test/test_component/test_component.vcxproj
+++ b/test/test_component/test_component.vcxproj
@@ -612,6 +612,7 @@
     <ClCompile Include="Class.cpp" />
     <ClCompile Include="Generated Files\module.g.cpp" />
     <ClCompile Include="module.cpp" />
+    <ClCompile Include="Optional.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -624,6 +625,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Class.h" />
+    <ClInclude Include="Optional.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Simple.h" />
     <ClInclude Include="Velocity.Class1.h" />


### PR DESCRIPTION
Fixes #1006