### PR TITLE
Optimize factory caching for apps and pinned DLLs

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -233,19 +233,23 @@ namespace winrt::impl
 
         explicit factory_count_guard(size_t& count) noexcept : m_count(count)
         {
+#ifndef WINRT_NO_MODULE_LOCK
 #ifdef _WIN64
             _InterlockedIncrement64((int64_t*)&m_count);
 #else
             _InterlockedIncrement((long*)&m_count);
 #endif
+#endif
         }
 
         ~factory_count_guard() noexcept
         {
+#ifndef WINRT_NO_MODULE_LOCK
 #ifdef _WIN64
             _InterlockedDecrement64((int64_t*)&m_count);
 #else
             _InterlockedDecrement((long*)&m_count);
+#endif
 #endif
         }
 
@@ -362,7 +366,9 @@ namespace winrt::impl
                 if (nullptr == _InterlockedCompareExchangePointer(reinterpret_cast<void**>(&m_value.object), *reinterpret_cast<void**>(&object), nullptr))
                 {
                     *reinterpret_cast<void**>(&object) = nullptr;
+#ifndef WINRT_NO_MODULE_LOCK
                     get_factory_cache().add(this);
+#endif
                 }
 
                 return callback(*reinterpret_cast<com_ref<Interface> const*>(&m_value.object));


### PR DESCRIPTION
C++/WinRT provides `WINRT_NO_MODULE_LOCK` that may be used by apps or pinned DLLs (that don't support unloading) to avoid the overhead of tracking of a module reference count. This update further optimizes the factory cache in such cases since unloading has an impact on caching performance. With this change, C++/WinRT is on par with [the Rust language](https://github.com/microsoft/windows-rs). Previously, Rust was just slightly faster. 

<img width="746" alt="compare" src="https://user-images.githubusercontent.com/9845234/135517517-879d2fe6-f979-40f7-9903-139b557e4ea8.png">

Data from: https://github.com/kennykerr/lang-perf

cc @axelandrejs