### PR TITLE
Simplify use of `WINRT_NO_MODULE_LOCK` in DLLs

### DIFF
--- a/cppwinrt.sln
+++ b/cppwinrt.sln
@@ -87,6 +87,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_module_lock_none", "test\test_module_lock_none\test_module_lock_none.vcxproj", "{D48A96C2-8512-4CC3-B6E4-7CFF07ED8ED3}"
 	ProjectSection(ProjectDependencies) = postProject
 		{D613FB39-5035-4043-91E2-BAB323908AF4} = {D613FB39-5035-4043-91E2-BAB323908AF4}
+		{13333A6F-6A4A-48CD-865C-0F65135EB018} = {13333A6F-6A4A-48CD-865C-0F65135EB018}
+		{0080F6D1-AEC3-4F89-ADE1-3D22A7EBF99E} = {0080F6D1-AEC3-4F89-ADE1-3D22A7EBF99E}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_module_lock_custom", "test\test_module_lock_custom\test_module_lock_custom.vcxproj", "{08C40663-B6A3-481E-8755-AE32BAD99501}"

--- a/strings/base_agile_ref.h
+++ b/strings/base_agile_ref.h
@@ -3,7 +3,7 @@ WINRT_EXPORT namespace winrt
 {
 #if defined (WINRT_NO_MODULE_LOCK)
 
-    // Defining WINRT_NO_MODULE_LOCK is appropriate for apps (executables) that don't implement something like DllCanUnloadNow
+    // Defining WINRT_NO_MODULE_LOCK is appropriate for apps (executables) or pinned DLLs (that don't support unloading)
     // and can thus avoid the synchronization overhead imposed by the default module lock.
 
     constexpr auto get_module_lock() noexcept
@@ -18,6 +18,11 @@ WINRT_EXPORT namespace winrt
             constexpr uint32_t operator--() noexcept
             {
                 return 0;
+            }
+
+            constexpr explicit operator bool() noexcept
+            {
+                return true;
             }
         };
 

--- a/test/test_component_base/pch.h
+++ b/test/test_component_base/pch.h
@@ -1,1 +1,9 @@
 #pragma once
+
+#define WINRT_NO_MODULE_LOCK
+#include "winrt/base.h"
+
+// get_module_lock will always return true if WINRT_NO_MODULE_LOCK is defined.
+// This ensures that if the DLL unecessarily exports DllCanUnloadNow that it
+// will in turn return S_FALSE.
+static_assert(winrt::get_module_lock());

--- a/test/test_module_lock_none/main.cpp
+++ b/test/test_module_lock_none/main.cpp
@@ -58,6 +58,9 @@ TEST_CASE("module_lock_none")
 
     auto can_unload = reinterpret_cast<HRESULT(__stdcall*)()>(GetProcAddress(LoadLibraryA("test_component_base.dll"), "DllCanUnloadNow"));
     REQUIRE(can_unload() == S_FALSE);
+
+    auto cannot_unload = reinterpret_cast<HRESULT(__stdcall*)()>(GetProcAddress(LoadLibraryA("test_component_derived.dll"), "DllCanUnloadNow"));
+    REQUIRE(cannot_unload() == S_OK);
 }
 
 int main(int const argc, char** argv)

--- a/test/test_module_lock_none/main.cpp
+++ b/test/test_module_lock_none/main.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+#include <windows.h>
 
 // Defining WINRT_NO_MODULE_LOCK means that winrt::get_module_lock is not defined and calls to it are elided from C++/WinRT.
 // This is an optimization for apps (executables) that don't implement something like DllCanUnloadNow.
@@ -52,6 +53,11 @@ TEST_CASE("module_lock_none")
     winrt::clear_factory_cache();
 
     REQUIRE(first == second);
+
+    // Validates that test_component_base is pinned by virtue of it defining WINRT_NO_MODULE_LOCK.
+
+    auto can_unload = reinterpret_cast<HRESULT(__stdcall*)()>(GetProcAddress(LoadLibraryA("test_component_base.dll"), "DllCanUnloadNow"));
+    REQUIRE(can_unload() == S_FALSE);
 }
 
 int main(int const argc, char** argv)


### PR DESCRIPTION
I also noticed that this combination had no test.