### PR TITLE
Awaiting an already-completed IAsyncAction does not consume stack (in C++20 mode)

### DIFF
--- a/test/test/async_completed.cpp
+++ b/test/test/async_completed.cpp
@@ -64,3 +64,65 @@ TEST_CASE("async_completed")
 {
     TestCompleted().get();
 }
+
+namespace
+{
+    //
+    // Checks that awaiting an already-completed async operation
+    // does not consume additional stack.
+    //
+    IAsyncAction AlreadyCompleted()
+    {
+        co_return;
+    }
+
+    uintptr_t approximate_stack_pointer()
+    {
+#ifdef _MSC_VER
+        return reinterpret_cast<uintptr_t>(_AddressOfReturnAddress());
+#else
+        // gcc, clang, and icc all support this.
+        return reinterpret_cast<uintptr_t>(__builtin_frame_address(0));
+#endif
+    }
+
+    // Simple awaiter that (inefficiently) resumes from inside
+    // await_suspend, for the purpose of measuring how much stack it consumes.
+    // This is the best we can do with MSVC prerelease coroutines prior to 16.11.
+    struct resume_sync_from_await_suspend
+    {
+        bool await_ready() { return false; }
+        void await_suspend(winrt::impl::coroutine_handle<> h) { h(); }
+        void await_resume() { }
+    };
+
+    IAsyncAction SyncCompletion()
+    {
+        uintptr_t initial = approximate_stack_pointer();
+        co_await resume_sync_from_await_suspend();
+        uintptr_t sync_usage = initial - approximate_stack_pointer();
+
+        initial = approximate_stack_pointer();
+        co_await AlreadyCompleted();
+        uintptr_t consumed = initial - approximate_stack_pointer();
+#ifdef _RESUMABLE_FUNCTIONS_SUPPORTED
+        // This branch is taken only for MSVC prerelease coroutines.
+        //
+        // MSVC prerelease coroutines prior to 16.11 do not implement "bool await_suspend" reliably,
+        // so we can't use it impl::await_adapter. We must resume inline inside await_suspend,
+        // so there is a small amount of stack usage. (Pre-16.11 and post-16.11 prerelease coroutines
+        // are interoperable, so we cannot change behavior based on which compiler we are using,
+        // because that would introduce ODR violations. Our first opportunity to change behavior
+        // is the ABI breaking change with MSVC standard-conforming coroutines.)
+        REQUIRE(consumed <= sync_usage);
+#else
+        // MSVC standard-conforming coroutines (as well as gcc and clang coroutines)
+        // support "bool await_suspend" just fine.
+        REQUIRE(consumed == 0);
+#endif
+    }
+}
+TEST_CASE("async_completed_await")
+{
+    SyncCompletion().get();
+}


### PR DESCRIPTION
Normally, when awaiting an IAsyncInfo, we register a completion handler and resume the coroutine from the handler. However, this results in stack build-up if the IAsyncInfo has already completed because the IAsyncInfo will call the completion handler synchronously. The stack is

* caller -> awaiter -> await_suspend -> Completed -> Handler -> caller

We want to avoid the deep stack that leads back to the caller.

One way to do this is to sniff the IAsyncInfo's Status in `await_ready` and return `false` if it is already in a terminal state. However, this adds a virtual call to the `co_await` code path.

Instead, we detect the situation by having the handler check whether it is being called while `await_suspend` is still running:

* caller -> awaiter -> await_suspend -> Completed -> Handler

If the Handler realizes that it's inside `await_suspend`, it delegates responsibility to resume the coroutine to `await_suspend` and returns immediately. This unwinds the stack back to `await_suspend`:

* caller -> awaiter -> await_suspend

The `await_suspend` detects that the Handler wants to resume the coroutine, so it just returns `false`. This unwinds the stack all the way to the caller:

* caller

which can now resume with no stack usage.

This works great, except that there is a code generation bug in MSVC C++17 prerelease coroutines that occurs if `await_suspend` returns `bool`. (Improper promotion decision.) This bug is [fixed in MSVC 16.11](https://devblogs.microsoft.com/cppblog/cpp20-coroutine-improvements-in-visual-studio-2019-version-16-11/).

However, MSVC 16.11 prerelease coroutines are ABI-compatible with pre-16.11 prerelease coroutines, and it's possible that somebody is going to mix some pre-16.11 coroutine code with post-16.11 coroutine code. Changing the the behavior of `await_suspend` based on the compiler version would introduce ODR violations.

Therefore, if we are using MSVC prerelease coroutines, we cannot have `await_suspend` return `bool`, just in case this code ever links against code compiled with pre-16.11. `await_suspend` must return `void`. The best we can do is have it resume the coroutine inline.

* caller -> awaiter -> await_suspend -> caller

This is not great, but it's the best we can do with MSVC prerelease coroutines. Hopefully, everybody will move to C++20 coroutines, either by compiling in C++20 mode or opting into C++20 style coroutines in C++17 mode via `/await:strict`. Or at least they will upgrade their toolchain to MSVC 16.11 or higher. Then we can finally drop support for MSVC prerelease coroutines less than 16.11.

We take this opportunity to simplify the `await_suspend` by consolidating the three things that the Completion handler has to manage into the single `disconnect_aware_handler`. (The three things are disconnection, apartment switching, and now synchronous completion.)

Note that the `suspending` flag must be atomic, because it's possible that the IAsyncInfo completes on another thread. The completion uses release semantics (and `await_suspend` uses acquire semantics) to ensure that all state is properly transferred from the completing thread to the awaiting thread. Normally, `resume_apartment` would establish the necessary memory barriers, but in this short-circuit, we can't use `resume_apartment`. (Fortunately, we don't need it because the `await_suspend` is already running in the correct apartment.)