### PR TITLE
Avoid spurious WINRT_NATVIS redefinition warning

### DIFF
--- a/strings/base_natvis.h
+++ b/strings/base_natvis.h
@@ -1,5 +1,5 @@
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(WINRT_NATVIS)
 #define WINRT_NATVIS
 #endif
 


### PR DESCRIPTION
If you pass `-DWINRT_NATVIS` to the compiler (to force natvis support even in retail builds), it defines the preprocessor symbol to `1`, as if you had written

```cpp
#define WINRT_NATVIS 1
```

This causes debug builds to generate a macro redefinition warning because the debug build force-defines `WINRT_NATVIS` as the empty macro.

We don't really care what it defined to, as long as it's defined. Guard the redefinition to avoid the spurious warning.