### PR TITLE
Allow non-void static setter methods when compiling with `-opt`

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -502,13 +502,14 @@ catch (...) { return winrt::to_hresult(); }
     }
 )";
 
+                        bool ignore_return = is_put_overload(method) || !signature.return_signature();
 
                         w.write(format,
                             signature.return_signature(),
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),
-                            is_put_overload(method) ? "" : "return ",
+                            ignore_return ? "" : "return ",
                             type_namespace,
                             type_name,
                             method_name,

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -498,7 +498,7 @@ catch (...) { return winrt::to_hresult(); }
                     {
                         auto format = R"(    % %::%(%)
     {
-        return @::implementation::%::%(%);
+        %@::implementation::%::%(%);
     }
 )";
 
@@ -508,6 +508,7 @@ catch (...) { return winrt::to_hresult(); }
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),
+                            is_put_overload(method) ? "" : "return ",
                             type_namespace,
                             type_name,
                             method_name,

--- a/test/test_component/Class.h
+++ b/test/test_component/Class.h
@@ -124,6 +124,11 @@ namespace winrt::test_component::implementation
             co_return;
         }
 
+        static fire_and_forget StaticMethodWithAsyncReturn()
+        {
+            co_return;
+        }
+
     private:
 
         bool m_fail{};

--- a/test/test_component/Class.h
+++ b/test/test_component/Class.h
@@ -113,6 +113,17 @@ namespace winrt::test_component::implementation
         Windows::Foundation::IAsyncOperation<int> RaiseDeferrableEventAsync();
 
         static bool TestNoMakeDetection();
+
+        static int32_t StaticPropertyWithAsyncSetter()
+        {
+            return 0;
+        }
+
+        static fire_and_forget StaticPropertyWithAsyncSetter(int32_t)
+        {
+            co_return;
+        }
+
     private:
 
         bool m_fail{};

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -157,6 +157,7 @@ namespace test_component
 
         static Boolean TestNoMakeDetection();
         static Int32 StaticPropertyWithAsyncSetter;
+        static void StaticMethodWithAsyncReturn();
     }
 
     namespace Structs

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -156,6 +156,7 @@ namespace test_component
         Windows.Foundation.IAsyncOperation<Int32> RaiseDeferrableEventAsync();
 
         static Boolean TestNoMakeDetection();
+        static Int32 StaticPropertyWithAsyncSetter;
     }
 
     namespace Structs


### PR DESCRIPTION
Fixes #1062