### PR TITLE
Fix compilation under Clang

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -3259,6 +3259,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             w.write(strings::base_reference_produce);
             w.write(strings::base_deferral);
             w.write(strings::base_coroutine_foundation);
+            w.write(strings::base_stringable_format);
         }
         else if (namespace_name == "Windows.Foundation.Collections")
         {
@@ -3295,7 +3296,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         if (namespace_name == "Windows.Foundation")
         {
             w.write(strings::base_reference_produce_1);
-            w.write(strings::base_stringable_format);
+            w.write(strings::base_stringable_format_1);
         }
     }
 }

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -79,9 +79,10 @@
     <ClInclude Include="..\strings\base_security.h" />
     <ClInclude Include="..\strings\base_std_hash.h" />
     <ClInclude Include="..\strings\base_string.h" />
+    <ClInclude Include="..\strings\base_stringable_format.h" />
     <ClInclude Include="..\strings\base_string_input.h" />
     <ClInclude Include="..\strings\base_string_operators.h" />
-    <ClInclude Include="..\strings\base_stringable_format.h" />
+    <ClInclude Include="..\strings\base_stringable_format_1.h" />
     <ClInclude Include="..\strings\base_types.h" />
     <ClInclude Include="..\strings\base_version.h" />
     <ClInclude Include="..\strings\base_version_odr.h" />

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClInclude Include="..\strings\base_iterator.h">
       <Filter>strings</Filter>
     </ClInclude>
+    <ClInclude Include="..\strings\base_stringable_format_1.h">
+      <Filter>strings</Filter>
+    </ClInclude>
     <ClInclude Include="..\strings\base_stringable_format.h">
       <Filter>strings</Filter>
     </ClInclude>

--- a/strings/base_stringable_format.h
+++ b/strings/base_stringable_format.h
@@ -1,7 +1,7 @@
 
 #ifdef __cpp_lib_format
 template <typename FormatContext>
-WINRT_IMPL_AUTO(void) std::formatter<winrt::Windows::Foundation::IStringable, wchar_t>::format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc)
+auto std::formatter<winrt::Windows::Foundation::IStringable, wchar_t>::format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc)
 {
     return std::formatter<winrt::hstring, wchar_t>::format(obj.ToString(), fc);
 }

--- a/strings/base_stringable_format.h
+++ b/strings/base_stringable_format.h
@@ -1,12 +1,8 @@
 
 #ifdef __cpp_lib_format
-template<>
-struct std::formatter<winrt::Windows::Foundation::IStringable, wchar_t> : std::formatter<winrt::hstring, wchar_t>
+template <typename FormatContext>
+WINRT_IMPL_AUTO(void) std::formatter<winrt::Windows::Foundation::IStringable, wchar_t>::format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc)
 {
-    template<typename FormatContext>
-    auto format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc)
-    {
-        return std::formatter<winrt::hstring, wchar_t>::format(obj.ToString(), fc);
-    }
-};
+    return std::formatter<winrt::hstring, wchar_t>::format(obj.ToString(), fc);
+}
 #endif

--- a/strings/base_stringable_format_1.h
+++ b/strings/base_stringable_format_1.h
@@ -1,0 +1,9 @@
+
+#ifdef __cpp_lib_format
+template <>
+struct std::formatter<winrt::Windows::Foundation::IStringable, wchar_t> : std::formatter<winrt::hstring, wchar_t>
+{
+    template <typename FormatContext>
+    WINRT_IMPL_AUTO(void) format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc);
+};
+#endif

--- a/strings/base_stringable_format_1.h
+++ b/strings/base_stringable_format_1.h
@@ -4,6 +4,6 @@ template <>
 struct std::formatter<winrt::Windows::Foundation::IStringable, wchar_t> : std::formatter<winrt::hstring, wchar_t>
 {
     template <typename FormatContext>
-    WINRT_IMPL_AUTO(void) format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc);
+    auto format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc);
 };
 #endif


### PR DESCRIPTION
Fixes #1069

Was manually tested by building and running this snippet:
```cpp
// silence a clang coroutine warning caused by cppwinrt. we don't actually use coroutines here.
#define _SILENCE_CLANG_COROUTINE_MESSAGE

// std::format is hidden behind /std:c++latest due to ABI concerns right now
// but the headers don't detect Clang's -std=c++2b, so manually have them believe we are using C++23.
#define _HAS_CXX23 1

#include <format>
#include <iostream>

// required for cppwinrt to not fail building with clang
#include <guiddef.h>

#include "winrt/Windows.Foundation.h"

#pragma comment(lib, "onecore.lib")

struct stringable : winrt::implements<stringable, winrt::Windows::Foundation::IStringable>
{
    winrt::hstring ToString()
    {
        return L"a stringable object";
    }
};

int main()
{
    winrt::Windows::Foundation::IStringable obj = winrt::make<stringable>();
    std::wcout << std::format(L"This is {}", obj);
}
```

With `clang -Icppwinrt/_build/x64/Debug -std=c++2b test.cpp`