### PR TITLE
Fix weak references to coroutines

### DIFF
--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -466,9 +466,9 @@ TEST_CASE("weak,create_weak_in_destructor")
     REQUIRE(magic.get() == nullptr);
 }
 
+#ifdef WINRT_IMPL_COROUTINES
 TEST_CASE("weak,coroutine")
 {
-#ifdef WINRT_IMPL_COROUTINES
     // Run a coroutine to completion. Confirm that weak references fail to resolve.
     auto weak = winrt::weak_ref(Action());
     REQUIRE(weak.get() == nullptr);
@@ -482,7 +482,11 @@ TEST_CASE("weak,coroutine")
     resume();
     REQUIRE(weak.get() == nullptr);
 
-#else
-    WARN("Test skipped, no coroutine support");
-#endif
+    // Verify that weak reference resolves as long as strong reference exists.
+    auto action = Action();
+    weak = winrt::weak_ref(action);
+    REQUIRE(weak.get() == action);
+    action = nullptr;
+    REQUIRE(weak.get() == nullptr);
 }
+#endif

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -68,6 +68,49 @@ namespace
             REQUIRE(weak_self.get() == nullptr);
         }
     };
+
+    struct WeakCreateWeakInDestructor : implements<WeakCreateWeakInDestructor, IStringable>
+    {
+        winrt::weak_ref<WeakCreateWeakInDestructor>& weak_self;
+
+        WeakCreateWeakInDestructor(winrt::weak_ref<WeakCreateWeakInDestructor>& magic) : weak_self(magic) {}
+
+        ~WeakCreateWeakInDestructor()
+        {
+            // Creates a weak reference to itself in the destructor.
+            weak_self = get_weak();
+        }
+
+        hstring ToString()
+        {
+            return L"WeakCreateWeakInDestructor";
+        }
+    };
+
+#ifdef WINRT_IMPL_COROUTINES
+    // Returns an IAsyncAction that has already completed.
+    winrt::Windows::Foundation::IAsyncAction Action()
+    {
+        co_return;
+    }
+
+    // Returns an IAsyncAction that has not completed.
+    // Call the resume() handle to complete it.
+    winrt::Windows::Foundation::IAsyncAction SuspendAction(impl::coroutine_handle<>& resume)
+    {
+        struct awaiter
+        {
+            impl::coroutine_handle<>& resume;
+            bool await_ready() { return false; }
+            void await_suspend(impl::coroutine_handle<> handle) { resume = handle; }
+            void await_resume() {}
+        };
+
+        co_await awaiter{ resume };
+        co_return;
+    }
+
+#endif
 }
 
 TEST_CASE("weak,source")
@@ -412,4 +455,34 @@ TEST_CASE("weak,self")
     IStringable a = make<WeakWithSelfReference>();
     a.ToString();
     a = nullptr;
+}
+
+TEST_CASE("weak,create_weak_in_destructor")
+{
+    weak_ref<WeakCreateWeakInDestructor> magic;
+    IStringable a = make<WeakCreateWeakInDestructor>(magic);
+    a.ToString();
+    a = nullptr;
+    REQUIRE(magic.get() == nullptr);
+}
+
+TEST_CASE("weak,coroutine")
+{
+#ifdef WINRT_IMPL_COROUTINES
+    // Run a coroutine to completion. Confirm that weak references fail to resolve.
+    auto weak = winrt::weak_ref(Action());
+    REQUIRE(weak.get() == nullptr);
+
+    // Start a coroutine but don't complete it yet.
+    // Confirm that weak references resolve.
+    impl::coroutine_handle<> resume;
+    weak = winrt::weak_ref(SuspendAction(resume));
+    REQUIRE(weak.get() != nullptr);
+    // Now complete the coroutine. Confirm that weak references no longer resolve.
+    resume();
+    REQUIRE(weak.get() == nullptr);
+
+#else
+    WARN("Test skipped, no coroutine support");
+#endif
 }


### PR DESCRIPTION
`root_implements::NonDelegatingRelease` sets `m_references = 1` prior to initiating destruction so that the destructor sees a nonzero reference count. As a side effect, it also breaks the connection to the weak reference control block.

`~root_implements` performs a bonus `subtract_reference` to clean up any weak reference control block that may have re-materialized during destruction. The extra decrement is safe because we set `m_references = 1` earlier.

However, if the `root_implements::Release` was overriden by a derived class, the derived class's `Release` may not do the same `m_references = 1` trick, and then the bonus decrement in the destructor will decrement below zero.

Who would override `root_implements::Release`? `promise_base`, that's who. As a result, a weak reference to a coroutine turns into poison when the coroutine destructs, because the control block now has a strong reference of 4 billion and a pointer to an already-destroyed object.

The logic to set `m_references` to 1 is now moved into `subtract_reference` so that derived classes don't have to know this One Weird Trick. The actual decrementing happens in `subtract_final_reference`, which is the version that the `root_implements` destructor calls, since it knows that the object is finally going away and isn't preparing for destruction.

Setting `m_references` to 1 had been done with `memory_order_cst` (default), but I think `memory_order_relaxed` is sufficient. Since the external reference count is zero, there are no other threads with access to the object (outstanding weak references will not resolve), so there are no data dependencies.

Created new tests to validate the "weak reference created during destruction" code path, as well as to validate that weak references to coroutines work. (The `weak,coroutine` test failed prior to the fix.)
