### PR TITLE
Support borrowed ranges

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -158,8 +158,15 @@ namespace cppwinrt
         }
     }
 
+    template<std::size_t indents = 0>
     static void write_close_namespace(writer& w)
     {
+        for (std::size_t i = 0; i < indents; ++i)
+        {
+            auto format = R"(    )";
+            w.write(format);
+        }
+
         auto format = R"(}
 )";
 
@@ -184,6 +191,15 @@ namespace cppwinrt
 )");
 
         return { w, write_close_namespace };
+    }
+
+    [[nodiscard]] static finish_with wrap_ranges_namespace(writer& w)
+    {
+        w.write(R"(    namespace ranges
+    {
+)");
+
+        return { w, write_close_namespace<1> };
     }
 
     [[nodiscard]] static finish_with wrap_type_namespace(writer& w, std::string_view const& ns)
@@ -3247,6 +3263,19 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             auto generics = type.GenericParam();
 
             w.write("    template<%> struct formatter<%, wchar_t> : formatter<winrt::Windows::Foundation::IStringable, wchar_t> {};\n",
+                bind<write_generic_typenames>(generics),
+                type);
+        }
+    }
+
+    static void write_std_enable_borrowed_range(writer& w, TypeDef const& type)
+    {
+        std::string_view iiterable = "Windows.Foundation.Collections.IIterable`1";
+        if (type_name(type) == iiterable || implements_interface(type, iiterable))
+        {
+            auto generics = type.GenericParam();
+
+            w.write("        template<%> inline constexpr bool enable_borrowed_range<%> = true;\n",
                 bind<write_generic_typenames>(generics),
                 type);
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -158,15 +158,8 @@ namespace cppwinrt
         }
     }
 
-    template<std::size_t indents = 0>
     static void write_close_namespace(writer& w)
     {
-        for (std::size_t i = 0; i < indents; ++i)
-        {
-            auto format = R"(    )";
-            w.write(format);
-        }
-
         auto format = R"(}
 )";
 
@@ -193,13 +186,13 @@ namespace cppwinrt
         return { w, write_close_namespace };
     }
 
-    [[nodiscard]] static finish_with wrap_ranges_namespace(writer& w)
+    [[nodiscard]] static finish_with wrap_std_ranges_namespace(writer& w)
     {
-        w.write(R"(    namespace ranges
-    {
+        w.write(R"(namespace std::ranges
+{
 )");
 
-        return { w, write_close_namespace<1> };
+        return { w, write_close_namespace };
     }
 
     [[nodiscard]] static finish_with wrap_type_namespace(writer& w, std::string_view const& ns)
@@ -3268,14 +3261,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         }
     }
 
-    static void write_std_enable_borrowed_range(writer& w, TypeDef const& type)
+    static void write_enable_borrowed_range(writer& w, TypeDef const& type)
     {
         std::string_view iiterable = "Windows.Foundation.Collections.IIterable`1";
         if (type_name(type) == iiterable || implements_interface(type, iiterable))
         {
             auto generics = type.GenericParam();
 
-            w.write("        template<%> inline constexpr bool enable_borrowed_range<%> = true;\n",
+            w.write("    template<%> inline constexpr bool enable_borrowed_range<%> = true;\n",
                 bind<write_generic_typenames>(generics),
                 type);
         }

--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -208,12 +208,12 @@ namespace cppwinrt
                 w.write_each<write_std_formatter>(members.interfaces);
                 w.write_each<write_std_formatter>(members.classes);   
             }
-            {
-                auto wrap_ranges = wrap_ifdef(w, "__cpp_lib_ranges");
-                auto wrap_ranges_ns = wrap_ranges_namespace(w);
-                w.write_each<write_std_enable_borrowed_range>(members.interfaces);
-                w.write_each<write_std_enable_borrowed_range>(members.classes);   
-            }
+        }
+        {
+            auto wrap_ranges_ifdef = wrap_ifdef(w, "__cpp_lib_ranges");
+            auto wrap_ranges_ns = wrap_std_ranges_namespace(w);
+            w.write_each<write_enable_borrowed_range>(members.interfaces);
+            w.write_each<write_enable_borrowed_range>(members.classes);   
         }
 
         write_namespace_special(w, ns);

--- a/cppwinrt/file_writers.h
+++ b/cppwinrt/file_writers.h
@@ -208,6 +208,12 @@ namespace cppwinrt
                 w.write_each<write_std_formatter>(members.interfaces);
                 w.write_each<write_std_formatter>(members.classes);   
             }
+            {
+                auto wrap_ranges = wrap_ifdef(w, "__cpp_lib_ranges");
+                auto wrap_ranges_ns = wrap_ranges_namespace(w);
+                w.write_each<write_std_enable_borrowed_range>(members.interfaces);
+                w.write_each<write_std_enable_borrowed_range>(members.classes);   
+            }
         }
 
         write_namespace_special(w, ns);

--- a/cppwinrt/helpers.h
+++ b/cppwinrt/helpers.h
@@ -502,8 +502,13 @@ namespace cppwinrt
     {
         for (auto&& impl : type.InterfaceImpl())
         {
-            const auto iface = impl.Interface();
-            if (iface.type() != TypeDefOrRef::TypeSpec && type_name(iface) == name)
+            auto iface = impl.Interface();
+            if (iface.type() == TypeDefOrRef::TypeSpec)
+            {
+                iface = iface.TypeSpec().Signature().GenericTypeInst().GenericType();
+            }
+
+            if (type_name(iface) == name)
             {
                 return true;
             }

--- a/natvis/cppwinrt.natvis
+++ b/natvis/cppwinrt.natvis
@@ -20,12 +20,15 @@
     <DisplayString Condition="this == 0">null</DisplayString>
   </Type>
   <!--Primitive type visualizers-->
+  <Type Name="winrt::Windows::UI::Color">
+    <DisplayString>#{A,nvoXb}{R,nvoXb}{G,nvoXb}{B,nvoXb}</DisplayString>
+  </Type>
   <Type Name="winrt::array_view&lt;*&gt;">
     <DisplayString>{{size = {m_size}, {m_data,[m_size]}}}</DisplayString>
     <Expand>
       <ArrayItems>
-          <Size>m_size</Size>
-          <ValuePointer>m_data</ValuePointer>
+        <Size>m_size</Size>
+        <ValuePointer>m_data</ValuePointer>
       </ArrayItems>
     </Expand>
   </Type>

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -28,6 +28,10 @@
 #include <format>
 #endif
 
+#ifdef __cpp_lib_ranges
+#include <ranges>
+#endif
+
 #ifdef __cpp_lib_coroutine
 
 #include <coroutine>

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -24,6 +24,12 @@
 #include <directxmath.h>
 #endif
 
+#ifdef __has_include
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+
 #ifdef __cpp_lib_format
 #include <format>
 #endif

--- a/strings/base_iterator.h
+++ b/strings/base_iterator.h
@@ -119,11 +119,6 @@ namespace winrt::impl
             return it + n;
         }
 
-        friend fast_iterator operator-(difference_type n, fast_iterator it) noexcept
-        {
-            return it - n;
-        }
-
     private:
 
         T m_collection = nullptr;

--- a/strings/base_iterator.h
+++ b/strings/base_iterator.h
@@ -14,7 +14,7 @@ namespace winrt::impl
         fast_iterator() noexcept = default;
 
         fast_iterator(T const& collection, uint32_t const index) noexcept :
-            m_collection(&collection),
+            m_collection(collection),
             m_index(index)
         {}
 
@@ -73,12 +73,12 @@ namespace winrt::impl
 
         reference operator*() const
         {
-            return m_collection->GetAt(m_index);
+            return m_collection.GetAt(m_index);
         }
 
         reference operator[](difference_type n) const
         {
-            return m_collection->GetAt(m_index + static_cast<uint32_t>(n));
+            return m_collection.GetAt(m_index + static_cast<uint32_t>(n));
         }
 
         bool operator==(fast_iterator const& other) const noexcept
@@ -126,7 +126,7 @@ namespace winrt::impl
 
     private:
 
-        T const* m_collection = nullptr;
+        T m_collection = nullptr;
         uint32_t m_index = 0;
     };
 

--- a/test/nuget/ConsoleApplication1/ConsoleApplication1.vcxproj
+++ b/test/nuget/ConsoleApplication1/ConsoleApplication1.vcxproj
@@ -35,9 +35,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/test/nuget/TestApp/TestApp.vcxproj
+++ b/test/nuget/TestApp/TestApp.vcxproj
@@ -45,9 +45,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
+++ b/test/nuget/TestRuntimeComponent1/TestRuntimeComponent1.vcxproj
@@ -45,9 +45,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
+++ b/test/nuget/TestRuntimeComponent2/TestRuntimeComponent2.vcxproj
@@ -46,9 +46,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
+++ b/test/nuget/TestRuntimeComponent3/TestRuntimeComponent3.vcxproj
@@ -46,9 +46,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/nuget/TestRuntimeComponentCX/TestRuntimeComponentCX.vcxproj
+++ b/test/nuget/TestRuntimeComponentCX/TestRuntimeComponentCX.vcxproj
@@ -50,8 +50,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestRuntimeComponentCXReferencingWinRTStaticLibrary/TestRuntimeComponentCXReferencingWinRTStaticLibrary.vcxproj
+++ b/test/nuget/TestRuntimeComponentCXReferencingWinRTStaticLibrary/TestRuntimeComponentCXReferencingWinRTStaticLibrary.vcxproj
@@ -49,49 +49,21 @@
     <CppWinRTProjectLanguage>C++/CX</CppWinRTProjectLanguage>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
+++ b/test/nuget/TestRuntimeComponentEmpty/TestRuntimeComponentEmpty.vcxproj
@@ -46,9 +46,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/nuget/TestRuntimeComponentNamespaceUnderscore/TestRuntimeComponentNamespaceUnderscore.vcxproj
+++ b/test/nuget/TestRuntimeComponentNamespaceUnderscore/TestRuntimeComponentNamespaceUnderscore.vcxproj
@@ -46,9 +46,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/nuget/TestStaticLibrary1/TestStaticLibrary1.vcxproj
+++ b/test/nuget/TestStaticLibrary1/TestStaticLibrary1.vcxproj
@@ -47,8 +47,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary2/TestStaticLibrary2.vcxproj
+++ b/test/nuget/TestStaticLibrary2/TestStaticLibrary2.vcxproj
@@ -47,8 +47,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary3/TestStaticLibrary3.vcxproj
+++ b/test/nuget/TestStaticLibrary3/TestStaticLibrary3.vcxproj
@@ -47,8 +47,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary4/TestStaticLibrary4.vcxproj
+++ b/test/nuget/TestStaticLibrary4/TestStaticLibrary4.vcxproj
@@ -46,8 +46,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary5/TestStaticLibrary5.vcxproj
+++ b/test/nuget/TestStaticLibrary5/TestStaticLibrary5.vcxproj
@@ -46,8 +46,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary6/TestStaticLibrary6.vcxproj
+++ b/test/nuget/TestStaticLibrary6/TestStaticLibrary6.vcxproj
@@ -46,8 +46,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/nuget/TestStaticLibrary7/TestStaticLibrary7.vcxproj
+++ b/test/nuget/TestStaticLibrary7/TestStaticLibrary7.vcxproj
@@ -47,9 +47,10 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>

--- a/test/test/fast_iterator.cpp
+++ b/test/test/fast_iterator.cpp
@@ -45,7 +45,7 @@ TEST_CASE("fast_iterator")
         REQUIRE(vbegin[2] == 4);
         REQUIRE(vbegin + 2 > vbegin);
         REQUIRE(2 + vbegin > vbegin);
-        REQUIRE(2 - (vbegin + 4) > vbegin);
+        REQUIRE(vbegin + 4 - 2 > vbegin);
         REQUIRE(vbegin < vbegin + 2);
         REQUIRE(vbegin + 2 - 2 == vbegin);
         REQUIRE(end(v) - begin(v) == v.Size());

--- a/test/test/fast_iterator.cpp
+++ b/test/test/fast_iterator.cpp
@@ -45,7 +45,6 @@ TEST_CASE("fast_iterator")
         REQUIRE(vbegin[2] == 4);
         REQUIRE(vbegin + 2 > vbegin);
         REQUIRE(2 + vbegin > vbegin);
-        REQUIRE(vbegin + 4 - 2 > vbegin);
         REQUIRE(vbegin < vbegin + 2);
         REQUIRE(vbegin + 2 - 2 == vbegin);
         REQUIRE(end(v) - begin(v) == v.Size());

--- a/test/test_cpp20/ranges.cpp
+++ b/test/test_cpp20/ranges.cpp
@@ -45,4 +45,20 @@ TEST_CASE("ranges")
 
         REQUIRE((result == std::vector{ 2, 4, 6 }));
     }
+
+    // borrowable ranges. without enabling them, *result would fail to compile.
+    {
+        // borrowable ranges, fast_iterator
+        auto result = std::ranges::max_element(winrt::single_threaded_vector<int>({ 1, 2, 4, 3, 6, 5 }));
+        REQUIRE((*result == 6));
+    }
+    {
+        // borrowable ranges, IIterator
+        auto result = std::ranges::find_if(winrt::single_threaded_map<int, int>(std::map<int, int>{ { 1, 2 }, { 2, 3 }, { 3, 4 } }),
+            [](auto const& kvp) { return kvp.Key() == 2 && kvp.Value() == 3; });
+
+        auto kvp = *result;
+
+        REQUIRE((kvp.Key() == 2 && kvp.Value() == 3));
+    }
 }

--- a/test/test_cpp20/ranges.cpp
+++ b/test/test_cpp20/ranges.cpp
@@ -46,14 +46,16 @@ TEST_CASE("ranges")
         REQUIRE((result == std::vector{ 2, 4, 6 }));
     }
 
-    // borrowable ranges. without enabling them, *result would fail to compile.
+    // Validate that rvalue WinRT collections are borrowed ranges.
+    // If they weren't, the ranges algorithms would return std::ranges::dangling
+    // which is a placeholder object that disallows dereferencing.
     {
-        // borrowable ranges, fast_iterator
+        // borrowed ranges, fast_iterator
         auto result = std::ranges::max_element(winrt::single_threaded_vector<int>({ 1, 2, 4, 3, 6, 5 }));
         REQUIRE((*result == 6));
     }
     {
-        // borrowable ranges, IIterator
+        // borrowed ranges, IIterator
         auto result = std::ranges::find_if(winrt::single_threaded_map<int, int>(std::map<int, int>{ { 1, 2 }, { 2, 3 }, { 3, 4 } }),
             [](auto const& kvp) { return kvp.Key() == 2 && kvp.Value() == 3; });
 


### PR DESCRIPTION
This marks C++/WinRT ranges as "borrowed": they can be taken by value and iterators to them can be returned without dangling. It's safe for C++/WinRT because collections are reference types, so the lifetime issues typical of C++ collections do not apply.

This enables range algorithms that would previously return `std::ranges::dangling` (a dummy object that isn't dereferencable) to return the appropriate iterator instead. For example, `std::ranges::max_element` or `std::ranges::find` would be quite useless without this, as you can't do anything useful without the returned iterator.

Added tests confirming this works, as well.

The inner range namespace in the codegen is a workaround for [a compiler bug](https://developercommunity.visualstudio.com/t/symbol-cannot-be-defined-within-namespa/1650563?entry=myfeedback).