### PR TITLE
Add a missing 'typename' keyword in "test_win7\pch.h"

### DIFF
--- a/test/test_win7/pch.h
+++ b/test/test_win7/pch.h
@@ -42,4 +42,4 @@ using async_return_type = decltype(std::declval<T>().GetResults());
 template<typename T>
 using async_progress_type = typename async_traits<std::decay_t<T>>::progress_type;
 template<typename T>
-inline constexpr bool has_async_progress = !std::is_same_v<void, async_traits<std::decay_t<T>>::progress_type>;
+inline constexpr bool has_async_progress = !std::is_same_v<void, typename async_traits<std::decay_t<T>>::progress_type>;


### PR DESCRIPTION
Add a missing 'typename' keyword in "test_win7\pch.h" to fix the following error.

`F:\gitP\microsoft\cppwinrt\test\test_win7\pch.h(45,50): error C2923: 'std::is_same_v': 'async_traits<winrt::Windows::Foundation::IAsyncOperation<int>>::progress_type' is not a valid template type argument for parameter '<unnamed-symbol>' `