### PR TITLE
Extend weak reference support to classic COM

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1123,9 +1123,16 @@ namespace winrt::impl
             return query_interface_tearoff(id, object);
         }
 
+        static constexpr bool assert_weak_ref_support() noexcept
+        {
+            static_assert(is_inspectable::value, "Weak references are not supported because object does not implement IInspectable.");
+            static_assert(!std::disjunction<std::is_same<no_weak_ref, I>...>::value, "Weak references are not supported because no_weak_ref was specified.");
+            return is_weak_ref_source::value;
+        }
+
         impl::IWeakReferenceSource* make_weak_ref() noexcept
         {
-            static_assert(is_weak_ref_source::value, "This is only for weak ref support.");
+            static_assert(assert_weak_ref_support(), "Weak references are not supported by this class.");
             uintptr_t count_or_pointer = m_references.load(std::memory_order_relaxed);
 
             if (is_weak_ref(count_or_pointer))
@@ -1163,19 +1170,19 @@ namespace winrt::impl
 
         static bool is_weak_ref(intptr_t const value) noexcept
         {
-            static_assert(is_weak_ref_source::value, "This is only for weak ref support.");
+            static_assert(assert_weak_ref_support(), "Weak references are not supported by this class.");
             return value < 0;
         }
 
         static weak_ref_t* decode_weak_ref(uintptr_t const value) noexcept
         {
-            static_assert(is_weak_ref_source::value, "This is only for weak ref support.");
+            static_assert(assert_weak_ref_support(), "Weak references are not supported by this class.");
             return reinterpret_cast<weak_ref_t*>(value << 1);
         }
 
         static uintptr_t encode_weak_ref(weak_ref_t* value) noexcept
         {
-            static_assert(is_weak_ref_source::value, "This is only for weak ref support.");
+            static_assert(assert_weak_ref_support(), "Weak references are not supported by this class.");
             constexpr uintptr_t pointer_flag = static_cast<uintptr_t>(1) << ((sizeof(uintptr_t) * 8) - 1);
             WINRT_ASSERT((reinterpret_cast<uintptr_t>(value) & 1) == 0);
             return (reinterpret_cast<uintptr_t>(value) >> 1) | pointer_flag;


### PR DESCRIPTION
Turns out that `IWeakReference` does work for classic COM: Even though the output pointer of `IWeakReference::Resolve` is typed as `IInspectable**`, it is annotated as `iid_is(riid)`, so COM ignores the formal type and relies on the IID, which is not constrained to derive from IInspectable. Verified that the COM marshaling metadata for the Resolve method is unaffected by the formal type of the output pointer. In particular, querying the resulting object for `IInspectable` will send a request over the wire (if never requested before), proving the COM did not infer `IInspectable` support.

This is a behavior change: Previously, pure classic COM objects did not support weak references. However, it removes developer surprise, since they see a method called `get_weak()` and expect it to work.

Also improved the diagnostic in the case where you call `get_weak()` from a class that does not support weak references. The old error message was

> This is only for weak ref support.

This message appears to be some sort of internal error and creates developer confusion.

Updated the error so that you get

> Weak references are not supported because no_weak_ref was specified.

Used `if constexpr` in `make_weak_ref` to generate the assertion only once per violation. The previous code generated the assertion but tried to compile the code anyway, resulting in confusing cascade errors which obscured the root cause.