### PR TITLE
Add type support for `Windows.Foundation.Numerics.Rational`

### DIFF
--- a/cppwinrt/type_writers.h
+++ b/cppwinrt/type_writers.h
@@ -277,7 +277,7 @@ namespace cppwinrt
                 return;
             }
 
-            // TODO: get rid of all these renames once parity with cppwinrt.exe has been reached...
+            // These renames are regrettable but must remain for compat.
 
             if (name == "EventRegistrationToken" && ns == "Windows.Foundation")
             {
@@ -291,7 +291,9 @@ namespace cppwinrt
             {
                 auto category = get_category(type);
 
-                if (ns == "Windows.Foundation.Numerics")
+                // Unfortunately someone added Rational without informing language projections, so it didn’t get
+                // the same special treatment as other numerics, and now it needs its own special handling.
+                if (ns == "Windows.Foundation.Numerics" && name != "Rational")
                 {
                     if (name == "Matrix3x2") { name = "float3x2"; }
                     else if (name == "Matrix4x4") { name = "float4x4"; }

--- a/cppwinrt/type_writers.h
+++ b/cppwinrt/type_writers.h
@@ -92,6 +92,18 @@ namespace cppwinrt
         return result;
     }
 
+    static bool transform_special_numeric_type(std::string_view& name)
+    {
+        if (name == "Matrix3x2") { name = "float3x2"; return true; }
+        else if (name == "Matrix4x4") { name = "float4x4"; return true; }
+        else if (name == "Plane") { name = "plane"; return true; }
+        else if (name == "Quaternion") { name = "quaternion"; return true; }
+        else if (name == "Vector2") { name = "float2"; return true; }
+        else if (name == "Vector3") { name = "float3"; return true; }
+        else if (name == "Vector4") { name = "float4"; return true; }
+        return false;
+    }
+
     struct writer : writer_base<writer>
     {
         using writer_base<writer>::write;
@@ -291,18 +303,8 @@ namespace cppwinrt
             {
                 auto category = get_category(type);
 
-                // Unfortunately someone added Rational without informing language projections, so it didn’t get
-                // the same special treatment as other numerics, and now it needs its own special handling.
-                if (ns == "Windows.Foundation.Numerics" && name != "Rational")
+                if (ns == "Windows.Foundation.Numerics" && transform_special_numeric_type(name))
                 {
-                    if (name == "Matrix3x2") { name = "float3x2"; }
-                    else if (name == "Matrix4x4") { name = "float4x4"; }
-                    else if (name == "Plane") { name = "plane"; }
-                    else if (name == "Quaternion") { name = "quaternion"; }
-                    else if (name == "Vector2") { name = "float2"; }
-                    else if (name == "Vector3") { name = "float3"; }
-                    else if (name == "Vector4") { name = "float4"; }
-
                     write("winrt::@::%", ns, name);
                 }
                 else if (category == category::struct_type)

--- a/test/test/rational.cpp
+++ b/test/test/rational.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "winrt/test_component.h"
+#include "winrt/Windows.Foundation.Numerics.h"
+
+using namespace winrt;
+using namespace test_component;
+
+TEST_CASE("rational")
+{
+    Simple simple;
+    Windows::Foundation::Numerics::Rational rational = simple.ReturnRational();
+    REQUIRE(rational.Numerator == 123);
+    REQUIRE(rational.Denominator == 456);
+
+    Windows::Foundation::Numerics::float2 vector2 = simple.ReturnVector2();
+    REQUIRE(vector2.x == 123.0);
+    REQUIRE(vector2.y == 456.0);
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -428,6 +428,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="rational.cpp" />
     <ClCompile Include="return_params.cpp" />
     <ClCompile Include="return_params_abi.cpp" />
     <ClCompile Include="single_threaded_observable_vector.cpp" />

--- a/test/test_component/Simple.h
+++ b/test/test_component/Simple.h
@@ -16,6 +16,16 @@ namespace winrt::test_component::implementation
         // All we care about static events (for now) is that they build.
         static event_token StaticEvent(Windows::Foundation::EventHandler<IInspectable> const&) { return {}; }
         static void StaticEvent(event_token) { }
+
+        Windows::Foundation::Numerics::float2 ReturnVector2()
+        {
+            return { 123.0, 456.0 };
+        }
+
+        Windows::Foundation::Numerics::Rational ReturnRational()
+        {
+            return { 123, 456 };
+        }
     };
 }
 namespace winrt::test_component::factory_implementation

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -56,6 +56,9 @@ namespace test_component
         Windows.Foundation.IAsyncAction Action(Windows.Foundation.DateTime value);
         Object Object(Windows.Foundation.DateTime value);
         static event Windows.Foundation.EventHandler<Object> StaticEvent;
+
+        Windows.Foundation.Numerics.Vector2 ReturnVector2();
+        Windows.Foundation.Numerics.Rational ReturnRational();
     }
 
     runtimeclass DeferrableEventArgs


### PR DESCRIPTION
Unfortunately someone added `Rational` without informing language projections, so it got caught in the Numerics net. Refine the Numerics namespace special-handling to transform only the types that need transforming.

Fixes #1105