### PR TITLE
Support the format returned by StringFromGUID2 in guid.parse.

### DIFF
--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -87,8 +87,12 @@ WINRT_EXPORT namespace winrt
         template <typename TStringView>
         static constexpr guid parse(TStringView value)
         {
-            value.remove_prefix(std::min(value.find_first_not_of(" {("), v.size()));
-            value.remove_suffix(std::min(value.find_last_not_of(" })"), v.size()));
+            // Handle {} and ()
+            if (value.size() == 38 && ((value[0] == '{' && value[37] == '}') || (value[0] == '(' && value[37] == ')')))
+            {
+                value.remove_prefix(1);
+                value.remove_suffix(1);
+            }
 
             if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
             {

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -85,8 +85,11 @@ WINRT_EXPORT namespace winrt
     private:
 
         template <typename TStringView>
-        static constexpr guid parse(TStringView const value)
+        static constexpr guid parse(TStringView value)
         {
+            value.remove_prefix(std::min(value.find_first_not_of(" {("), v.size()));
+            value.remove_suffix(std::min(value.find_last_not_of(" })"), v.size()));
+
             if (value.size() != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-')
             {
                 throw std::invalid_argument("value is not a valid GUID string");

--- a/test/test/guid.cpp
+++ b/test/test/guid.cpp
@@ -23,7 +23,6 @@ TEST_CASE("guid")
     REQUIRE(winrt::guid({ "{00112233-4455-6677-8899-aabbccddeeff}" + 1, 36 }) == expected);
     REQUIRE(winrt::guid("{00112233-4455-6677-8899-aabbccddeeff}") == expected);
     REQUIRE(winrt::guid("(00112233-4455-6677-8899-aabbccddeeff)") == expected);
-    REQUIRE(winrt::guid(" 00112233-4455-6677-8899-aabbccddeeff ") == expected);
 
     REQUIRE_THROWS_AS(winrt::guid(""), std::invalid_argument);
     REQUIRE_THROWS_AS(winrt::guid("not a guid"), std::invalid_argument);

--- a/test/test/guid.cpp
+++ b/test/test/guid.cpp
@@ -21,6 +21,9 @@ TEST_CASE("guid")
 
     REQUIRE(winrt::guid("00112233-4455-6677-8899-aabbccddeeff") == expected);
     REQUIRE(winrt::guid({ "{00112233-4455-6677-8899-aabbccddeeff}" + 1, 36 }) == expected);
+    REQUIRE(winrt::guid("{00112233-4455-6677-8899-aabbccddeeff}") == expected);
+    REQUIRE(winrt::guid("(00112233-4455-6677-8899-aabbccddeeff)") == expected);
+    REQUIRE(winrt::guid(" 00112233-4455-6677-8899-aabbccddeeff ") == expected);
 
     REQUIRE_THROWS_AS(winrt::guid(""), std::invalid_argument);
     REQUIRE_THROWS_AS(winrt::guid("not a guid"), std::invalid_argument);
@@ -28,7 +31,6 @@ TEST_CASE("guid")
     REQUIRE_THROWS_AS(winrt::guid("too long string that's also not a guid"), std::invalid_argument);
     REQUIRE_THROWS_AS(winrt::guid("00112233-4455-6677-8899-aabbccddeeff with extra"), std::invalid_argument);
     REQUIRE_THROWS_AS(winrt::guid("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"), std::invalid_argument);
-    REQUIRE_THROWS_AS(winrt::guid("{00112233-4455-6677-8899-aabbccddeeff}"), std::invalid_argument);
 
     // Verify that you can constexpr-construct a guid from a GUID.
     constexpr winrt::guid from_abi_guid = GUID{ 0x00112233, 0x4455, 0x6677, { 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff } };


### PR DESCRIPTION
Support the format returned by StringFromGUID2 in guid.parse. ```{(})```  are common characters used in guid formats and it would be convenient if cppwinrt would automatically handle them.

