### PR TITLE
Fix time_point compilation error with Clang

### DIFF
--- a/strings/base_chrono.h
+++ b/strings/base_chrono.h
@@ -42,7 +42,7 @@ WINRT_EXPORT namespace winrt
 
         static time_t to_time_t(time_point const& time) noexcept
         {
-            return static_cast<time_t>(std::chrono::system_clock::to_time_t(to_sys(time)));
+            return static_cast<time_t>(std::chrono::system_clock::to_time_t(to_sys(std::chrono::time_point_cast<std::chrono::system_clock::duration>(time))));
         }
 
         static time_point from_time_t(time_t time) noexcept


### PR DESCRIPTION
Attempting to compile the [example code](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/faq#can-i-use-llvm-clang-to-compile-with-c---winrt-) in C++/WinRT FAQ with Clang (LLVM 14) and C++/WinRT 2.0.220224.4 results in the following compilation error:
```
winrt/base.h(8272,77): error: no viable conversion from 'time_point<[...], duration<[...], ratio<[...], __static_lcm<ratio<1, 10000000>::den, ratio<1, 1>::den>::value aka 10000000>>>' to 'const time_point<[...], duration<[...], ratio<[...], 1000000>>>'
            return static_cast<time_t>(std::chrono::system_clock::to_time_t(to_sys(time)));
                                                                            ^~~~~~~~~~~~
```

This originates from the fact that `system_clock` uses [microseconds in libc++](https://github.com/llvm/llvm-project/blob/3e6cfc631b816144d1ddfb4bb9f84af43367835c/libcxx/include/__chrono/system_clock.h#L31) instead of the [100 nanoseconds in STL of MSVC](https://github.com/microsoft/STL/blob/7b2c54be012f998736ebb6b72c7804a3f6c5f8e5/stl/inc/chrono#L658). A `time_point_cast` solves the problem. With this change, the example code is able to be compiled in Clang with no other compilation errors.