### PR TITLE
Draft support for CRTP in class default interface

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -992,9 +992,8 @@ namespace cppwinrt
         auto method_name = get_name(method);
         auto type = method.Parent();
 
-        w.write("        %WINRT_IMPL_AUTO(%) %(%) const%;\n",
+        w.write("        %auto %(%) const%;\n",
             is_get_overload(method) ? "[[nodiscard]] " : "",
-            signature.return_signature(),
             method_name,
             bind<write_consume_params>(signature),
             is_noexcept(method) ? " noexcept" : "");
@@ -1133,7 +1132,7 @@ namespace cppwinrt
             if (is_remove_overload(method))
             {
                 // we intentionally ignore errors when unregistering event handlers to be consistent with event_revoker
-                format = R"(    template <typename D%> WINRT_IMPL_AUTO(%) consume_%<D%>::%(%) const noexcept
+                format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
     {%
         WINRT_IMPL_SHIM(%)->%(%);%
     }
@@ -1141,7 +1140,7 @@ namespace cppwinrt
             }
             else
             {
-                format = R"(    template <typename D%> WINRT_IMPL_AUTO(%) consume_%<D%>::%(%) const noexcept
+                format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
     {%
         WINRT_VERIFY_(0, WINRT_IMPL_SHIM(%)->%(%));%
     }
@@ -1150,7 +1149,7 @@ namespace cppwinrt
         }
         else
         {
-            format = R"(    template <typename D%> WINRT_IMPL_AUTO(%) consume_%<D%>::%(%) const
+            format = R"(    template <typename D%> auto consume_%<D%>::%(%) const
     {%
         check_hresult(WINRT_IMPL_SHIM(%)->%(%));%
     }
@@ -1159,7 +1158,6 @@ namespace cppwinrt
 
         w.write(format,
             bind<write_comma_generic_typenames>(generics),
-            signature.return_signature(),
             type_impl_name,
             bind<write_comma_generic_types>(generics),
             method_name,
@@ -1207,14 +1205,13 @@ namespace cppwinrt
         // return static_cast<% const&>(*this).%(%);
         //
 
-        std::string_view format = R"(    inline WINRT_IMPL_AUTO(%) %::%(%) const%
+        std::string_view format = R"(    inline auto %::%(%) const%
     {
         return [&](% const& winrt_impl_base) { return winrt_impl_base.%(%); }(*this);
     }
 )";
 
         w.write(format,
-            signature.return_signature(),
             class_type.TypeName(),
             method_name,
             bind<write_consume_params>(signature),
@@ -1999,7 +1996,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 
     static void write_interface_override_method(writer& w, MethodDef const& method, std::string_view const& interface_name)
     {
-        auto format = R"(    template <typename D> WINRT_IMPL_AUTO(%) %T<D>::%(%) const%
+        auto format = R"(    template <typename D> auto %T<D>::%(%) const%
     {
         return shim().template try_as<%>().%(%);
     }
@@ -2009,7 +2006,6 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         auto method_name = get_name(method);
 
         w.write(format,
-            signature.return_signature(),
             interface_name,
             method_name,
             bind<write_consume_params>(signature),

--- a/scratch/main.cpp
+++ b/scratch/main.cpp
@@ -1,7 +1,13 @@
 #include "pch.h"
 
 using namespace winrt;
+using namespace Windows::UI;
+using namespace Windows::UI::Composition;
 
 int main()
 {
+    Compositor compositor;
+    AmbientLight light = compositor.CreateAmbientLight();
+
+    light.Color(Colors::Red()).Intensity(0.5f);
 }

--- a/scratch/pch.h
+++ b/scratch/pch.h
@@ -1,3 +1,4 @@
 #pragma once
 
-#include "winrt/Windows.Foundation.Collections.h"
+#include "winrt/Windows.Foundation.h"
+#include "winrt/Windows.UI.Composition.h"

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -15,12 +15,6 @@
 
 #define WINRT_IMPL_SHIM(...) (*(abi_t<__VA_ARGS__>**)&static_cast<__VA_ARGS__ const&>(static_cast<D const&>(*this)))
 
-#ifdef __INTELLISENSE__
-#define WINRT_IMPL_AUTO(...) __VA_ARGS__
-#else
-#define WINRT_IMPL_AUTO(...) auto
-#endif
-
 // Note: this is a workaround for a false-positive warning produced by the Visual C++ 15.9 compiler.
 #pragma warning(disable : 5046)
 

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -171,6 +171,15 @@ namespace winrt::impl
     struct __declspec(empty_bases) base : base_one<D, I>...
     {};
 
+    template <typename D, typename I>
+    struct class_default : consume_t<D, I>
+    {
+        operator I const& () const noexcept
+        {
+            return reinterpret_cast<I const&>(*this);
+        }
+    };
+
     template <typename T>
     T empty_value() noexcept
     {

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -24,11 +24,11 @@ static IAsyncOperation<IDataReader> CreateDataReader(std::initializer_list<byte>
     writer.WriteByte(1);
     writer.WriteByte(2);
     writer.WriteByte(3);
-    co_await writer.StoreAsync();
+    co_await static_cast<IAsyncOperation<uint32_t>>(writer.StoreAsync());
 
     stream.Seek(0);
     DataReader reader(stream);
-    co_await reader.LoadAsync(3);
+    co_await static_cast<IAsyncOperation<uint32_t>>(reader.LoadAsync(3));
     co_return reader;
 }
 

--- a/test/test_component_derived/Nested.HierarchyD.cpp
+++ b/test/test_component_derived/Nested.HierarchyD.cpp
@@ -21,10 +21,10 @@ namespace winrt::test_component_derived::Nested::implementation
         test_component_base::HierarchyA a = *this;
         assert(a);
 
-        Nested::IHierarchyD id = *this;
+        Nested::IHierarchyD id = d;
         assert(id);
 
-        Nested::IHierarchyC ic = *this;
+        Nested::IHierarchyC ic = c;
         assert(ic);
 
         test_component_base::IHierarchyB ib = *this;


### PR DESCRIPTION
This isn't quite ready but illustrates what's involved in providing CRTP support for a default interface so that it may in turn take advantage of CRTP to return the most derived type from property setters. 

The trouble is that it breaks a few assumptions that C++/WinRT makes around a runtime class actually being its default interface type. Those broken assumptions are highlighted in the tests I had to hack up to build and pass. 

I also removed `WINRT_IMPL_AUTO` as that was just a workaround for an IntelliSense bug that has long since been fixed.

But this change lets you successfully write code like this:

```C++
int main()
{
    Compositor compositor;
    AmbientLight light = compositor.CreateAmbientLight();

    light.Color(Colors::Red()).Intensity(0.5f);
}
```