### PR TITLE
fix regression in nested visualizations with VS2019+

### DIFF
--- a/natvis/object_visualizer.cpp
+++ b/natvis/object_visualizer.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include <algorithm>
 #include <variant>
 #include "object_visualizer.h"
 #include "property_visualizer.h"
@@ -685,7 +684,7 @@ HRESULT object_visualizer::GetItems(
     IF_FAIL_RET(DkmAllocArray(std::min(m_propertyData.size(), size_t(Count)), &resultValues));
 
     auto pParent = pVisualizedExpression;
-    auto childCount = std::min(m_propertyData.size(), size_t(Count + StartIndex));
+    auto childCount = std::min(m_propertyData.size() - StartIndex, (size_t)Count);
     for(auto i = 0; i < childCount; ++i)
     {
         auto& prop = m_propertyData[i + (size_t)StartIndex];

--- a/natvis/object_visualizer.cpp
+++ b/natvis/object_visualizer.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include <algorithm>
 #include <variant>
 #include "object_visualizer.h"
 #include "property_visualizer.h"
@@ -631,11 +632,10 @@ HRESULT object_visualizer::CreateEvaluationResult(_Deref_out_ DkmEvaluationResul
 }
 
 HRESULT object_visualizer::GetChildren(
-    _In_ UINT32 /*InitialRequestSize*/,
+    _In_ UINT32 InitialRequestSize,
     _In_ DkmInspectionContext* pInspectionContext,
     _Out_ DkmArray<DkmChildVisualizedExpression*>* pInitialChildren,
-    _Deref_out_ DkmEvaluationResultEnumContext** ppEnumContext
-)
+    _Deref_out_ DkmEvaluationResultEnumContext** ppEnumContext)
 {
     // Ignore metadata errors to ensure that Raw Data is always available
     if (m_propertyData.empty())
@@ -667,32 +667,34 @@ HRESULT object_visualizer::GetChildren(
         this,
         pEnumContext.put()));
 
-    DkmAllocArray(0, pInitialChildren);
+    IF_FAIL_RET(GetItems(m_pVisualizedExpression.get(), pEnumContext.get(), 0, InitialRequestSize, pInitialChildren));
+
     *ppEnumContext = pEnumContext.detach();
 
     return S_OK;
 }
 
 HRESULT object_visualizer::GetItems(
-    _In_ DkmVisualizedExpression* /*pVisualizedExpression*/,
+    _In_ DkmVisualizedExpression* pVisualizedExpression,
     _In_ DkmEvaluationResultEnumContext* /*pEnumContext*/,
     _In_ UINT32 StartIndex,
     _In_ UINT32 Count,
-    _Out_ DkmArray<DkmChildVisualizedExpression*>* pItems
-)
+    _Out_ DkmArray<DkmChildVisualizedExpression*>* pItems)
 {
-    std::list<com_ptr<DkmChildVisualizedExpression>> childItems;
+    CAutoDkmArray<DkmChildVisualizedExpression*> resultValues;
+    IF_FAIL_RET(DkmAllocArray(std::min(m_propertyData.size(), size_t(Count)), &resultValues));
 
-    auto pParent = m_pVisualizedExpression.get();
-    for( auto childIndex = StartIndex; childIndex < StartIndex + Count; ++childIndex)
+    auto pParent = pVisualizedExpression;
+    auto childCount = std::min(m_propertyData.size(), size_t(Count + StartIndex));
+    for(auto i = 0; i < childCount; ++i)
     {
-        auto& prop = m_propertyData[childIndex];
+        auto& prop = m_propertyData[i + (size_t)StartIndex];
         com_ptr<DkmChildVisualizedExpression> pPropertyVisualized;
-        if(FAILED(CreateChildVisualizedExpression(prop, pParent, m_isAbiObject, pPropertyVisualized.put())))
+        if (FAILED(CreateChildVisualizedExpression(prop, pParent, m_isAbiObject, pPropertyVisualized.put())))
         {
             com_ptr<DkmString> pErrorMessage;
             IF_FAIL_RET(DkmString::Create(L"<Property evaluation failed>", pErrorMessage.put()));
-            
+
             com_ptr<DkmString> pDisplayName;
             IF_FAIL_RET(DkmString::Create(prop.displayName.c_str(), pDisplayName.put()));
 
@@ -701,9 +703,9 @@ HRESULT object_visualizer::GetItems(
                 pParent->InspectionContext(),
                 pParent->StackFrame(),
                 pDisplayName.get(),
-                nullptr, 
+                nullptr,
                 pErrorMessage.get(),
-                DkmEvaluationResultFlags::ExceptionThrown, 
+                DkmEvaluationResultFlags::ExceptionThrown,
                 DkmDataItem::Null(),
                 pVisualizedResult.put()
             ));
@@ -721,22 +723,9 @@ HRESULT object_visualizer::GetItems(
                 pPropertyVisualized.put()
             ));
         }
-        childItems.push_back(pPropertyVisualized);
-    }
-
-    CAutoDkmArray<DkmChildVisualizedExpression*> resultValues;
-    IF_FAIL_RET(DkmAllocArray(childItems.size(), &resultValues));
-
-    UINT32 j = 0;
-    auto pos = childItems.begin();
-    while (pos != childItems.end())
-    {
-        com_ptr<DkmChildVisualizedExpression> pCurr = *pos;
-        resultValues.Members[j++] = pCurr.detach();
-        pos++;
+        resultValues.Members[i] = pPropertyVisualized.detach();
     }
 
     *pItems = resultValues.Detach();
-
     return S_OK;
 }


### PR DESCRIPTION
per advice from the VSSDK team, made sure GetChildren returns requested items, not just relying on GetItems.  (this lazy technique worked for VS2017, but does not with VS2019+)