### PR TITLE
Provide implementation-side visualization (per request), and always show raw data

### DIFF
--- a/natvis/cppwinrt.natvis
+++ b/natvis/cppwinrt.natvis
@@ -14,6 +14,11 @@
     <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>
     <DisplayString Condition="this == 0">null</DisplayString>
   </Type>
+  <!-- Visualize C++/WinRT object implementations -->
+  <Type Name="winrt::impl::producer&lt;*&gt;">
+    <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>
+    <DisplayString Condition="this == 0">null</DisplayString>
+  </Type>
   <!--Visualize all raw IInspectable pointers-->
   <Type Name="IInspectable">
     <CustomVisualizer Condition="this != 0" VisualizerId="2ec1a02f-997c-4693-840e-88ffa1e21b56"/>

--- a/natvis/cppwinrt_visualizer.cpp
+++ b/natvis/cppwinrt_visualizer.cpp
@@ -207,21 +207,26 @@ HRESULT cppwinrt_visualizer::EvaluateVisualizedExpression(
         IF_FAIL_RET(pTypeSymbol->get_name(&bstrTypeName));
 
         // Visualize top-level C++/WinRT objects containing ABI pointers
-        bool isAbiObject;
+        ObjectType objectType;
         if (wcscmp(bstrTypeName, L"winrt::Windows::Foundation::IInspectable") == 0)
         {
-            isAbiObject = false;
+            objectType = ObjectType::Projection;
         }
         // Visualize nested object properties via raw ABI pointers
         else if ((wcscmp(bstrTypeName, L"winrt::impl::IInspectable") == 0) ||
                  (wcscmp(bstrTypeName, L"winrt::impl::inspectable_abi") == 0))
         {
-            isAbiObject = true;
+            objectType = ObjectType::Abi;
+        }
+        // Visualize C++/WinRT object implementations
+        else if (wcsncmp(bstrTypeName, L"winrt::impl::producer<", wcslen(L"winrt::impl::producer<")) == 0)
+        {
+            objectType = ObjectType::Abi;
         }
         // Visualize all raw IInspectable pointers
         else if (wcscmp(bstrTypeName, L"IInspectable") == 0)
         {
-            isAbiObject = true;
+            objectType = ObjectType::Abi;
         }
         else
         {
@@ -231,7 +236,7 @@ HRESULT cppwinrt_visualizer::EvaluateVisualizedExpression(
             return S_OK;
         }
 
-        IF_FAIL_RET(object_visualizer::CreateEvaluationResult(pVisualizedExpression, isAbiObject, ppResultObject));
+        IF_FAIL_RET(object_visualizer::CreateEvaluationResult(pVisualizedExpression, objectType, ppResultObject));
 
         return S_OK;
     }

--- a/natvis/object_visualizer.h
+++ b/natvis/object_visualizer.h
@@ -20,6 +20,12 @@ enum class PropertyCategory
     Class,
 };
 
+enum class ObjectType
+{
+    Abi,
+    Projection,
+};
+
 // Metatdata for resolving a runtime class property value
 struct PropertyData 
 {
@@ -36,17 +42,17 @@ struct PropertyData
 struct __declspec(uuid("c7da92da-3bc9-4312-8a93-46f480663980"))
 object_visualizer : winrt::implements<object_visualizer, ::IUnknown>
 {
-    object_visualizer(Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression* pVisualizedExpression, bool isAbiObject)
+    object_visualizer(Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression* pVisualizedExpression, ObjectType objectType)
     {
         m_pVisualizedExpression = make_com_ptr(pVisualizedExpression);
-        m_isAbiObject = isAbiObject;
+        m_objectType = objectType;
     }
 
     ~object_visualizer()
     {
     }
 
-    static HRESULT CreateEvaluationResult(_In_ Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression* pVisualizedExpression, _In_ bool isAbiObject, _Deref_out_ Microsoft::VisualStudio::Debugger::Evaluation::DkmEvaluationResult** ppResultObject);
+    static HRESULT CreateEvaluationResult(_In_ Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression* pVisualizedExpression, _In_ ObjectType objectType, _Deref_out_ Microsoft::VisualStudio::Debugger::Evaluation::DkmEvaluationResult** ppResultObject);
 
     HRESULT CreateEvaluationResult(_Deref_out_ Microsoft::VisualStudio::Debugger::Evaluation::DkmEvaluationResult** ppResultObject);
 
@@ -69,7 +75,7 @@ private:
     void GetPropertyData();
     void GetTypeProperties(Microsoft::VisualStudio::Debugger::DkmProcess* process, std::string_view const& type_name);
     winrt::com_ptr<Microsoft::VisualStudio::Debugger::Evaluation::DkmVisualizedExpression> m_pVisualizedExpression;
-    bool m_isAbiObject;
+    ObjectType m_objectType;
     std::vector<PropertyData> m_propertyData;
     bool m_isStringable{ false };
 };


### PR DESCRIPTION
Added visualization for winrt::impl::producer<...> subclasses (implementations), per several requests
Always show raw data, for classes that inherit IInspectable but metadata is not available