### PR TITLE
two-phase initialization support to prevent double-destruction on handing out this pointer in ctor

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -862,14 +862,6 @@ catch (...) { return winrt::to_hresult(); }
 #if defined(WINRT_FORCE_INCLUDE_%_XAML_G_H) || __has_include("%.xaml.g.h")
 
 #include "%.xaml.g.h"
-namespace winrt::@::implementation
-{
-    template <typename D, typename... Args>
-    auto initialize_instance(%T<D, Args...>& instance)
-    {
-        static_cast<D&>(instance).InitializeComponent();
-    }
-}
 
 #else
 
@@ -891,8 +883,6 @@ namespace winrt::@::implementation
                 upper,
                 include_path,
                 include_path,
-                type_namespace,
-                type_name,
                 type_namespace,
                 type_name,
                 type_name);

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -860,7 +860,17 @@ catch (...) { return winrt::to_hresult(); }
         {
             auto format = R"(
 #if defined(WINRT_FORCE_INCLUDE_%_XAML_G_H) || __has_include("%.xaml.g.h")
+
 #include "%.xaml.g.h"
+namespace winrt::@::implementation
+{
+    template <typename D, typename... Args>
+    auto initialize_instance(%T<D, Args...>& instance)
+    {
+        static_cast<D&>(instance).InitializeComponent();
+    }
+}
+
 #else
 
 namespace winrt::@::implementation
@@ -881,6 +891,8 @@ namespace winrt::@::implementation
                 upper,
                 include_path,
                 include_path,
+                type_namespace,
+                type_name,
                 type_namespace,
                 type_name,
                 type_name);

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -77,6 +77,41 @@ To customize common C++/WinRT project properties:
 * expand the Common Properties item
 * select the C++/WinRT property page
 
+## InitializeComponent
+
+In older versions of C++/WinRT, Xaml objects called InitializeComponent from constructors. This can lead to memory corruption if InitializeComponent throws an exception.
+
+```cpp
+void MainPage::MainPage()
+{
+    // This pattern should no longer be used
+    InitializeComponent();
+}
+```
+
+C++/WinRT now calls InitializeComponent automatically and safely, after object construction. Explicit calls to InitializeComponent from constructors in existing code should now be removed. Multiple calls to InitializeComponent are idempotent.
+
+If a Xaml object needs to access a Xaml property during initialization, it should override InitializeComponent:
+
+```cpp
+void MainPage::InitializeComponent()
+{
+    // Call base InitializeComponent() to register with the Xaml runtime
+    MainPageT::InitializeComponent();
+    // Can now access Xaml properties
+    MyButton().Content(box_value(L"Click"));
+}
+```
+
+A non-Xaml object can also participate in two-phase construction by defining an InitializeComponent method.
+
+```cpp
+void MyComponent::InitializeComponent()
+{
+    // Execute initialization logic that may throw 
+}
+```
+
 ## Troubleshooting
 
 The msbuild verbosity level maps to msbuild message importance as follows:

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1240,7 +1240,7 @@ namespace winrt::impl
             }
             catch (...)
             {
-                delete instance;
+                instance->Release();
                 throw;
             }
         }

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1219,45 +1219,24 @@ namespace winrt::impl
 #endif
 
     template<typename T>
-    class has_initialize_instance_member
+    class has_initializer
     {
-        template <typename U, typename = decltype(std::declval<U>().initialize_instance())> static constexpr bool get_value(int) { return true; }
+        template <typename U, typename = decltype(std::declval<U>().InitializeComponent())> static constexpr bool get_value(int) { return true; }
         template <typename> static constexpr bool get_value(...) { return false; }
 
     public:
         static constexpr bool value = get_value<T>(0);
     };
 
-    template<typename T>
-    class has_initialize_instance_free
-    {
-        template <typename U, typename = decltype(initialize_instance(*(U*)nullptr))> static constexpr bool get_value(int) { return true; }
-        template <typename> static constexpr bool get_value(...) { return false; }
-
-    public:
-        static constexpr bool value = get_value<T>(0);
-    };
 
     template <typename T>
-    auto initialize_instance(T* instance)
+    auto initialize(T* instance)
     {
-        if constexpr (has_initialize_instance_member<T>::value)
+        if constexpr (has_initializer<T>::value)
         {
             try
             {
-                instance->initialize_instance();
-            }
-            catch (...)
-            {
-                delete instance;
-                throw;
-            }
-        }
-        else if constexpr (has_initialize_instance_free<T>::value)
-        {
-            try
-            {
-                initialize_instance(*instance);
+                instance->InitializeComponent();
             }
             catch (...)
             {
@@ -1283,7 +1262,7 @@ namespace winrt::impl
 
         if constexpr (!has_static_lifetime_v<D>)
         {
-            return { to_abi<result_type>(initialize_instance(new heap_implements<D>)), take_ownership_from_abi };
+            return { to_abi<result_type>(initialize(new heap_implements<D>)), take_ownership_from_abi };
         }
         else
         {
@@ -1297,7 +1276,7 @@ namespace winrt::impl
                 return { result, take_ownership_from_abi };
             }
 
-            result_type object{ to_abi<result_type>(initialize_instance(new heap_implements<D>)), take_ownership_from_abi };
+            result_type object{ to_abi<result_type>(initialize(new heap_implements<D>)), take_ownership_from_abi };
 
             static slim_mutex lock;
             slim_lock_guard const guard{ lock };
@@ -1343,17 +1322,17 @@ WINRT_EXPORT namespace winrt
         }
         else if constexpr (impl::has_composable<D>::value)
         {
-            impl::com_ref<I> result{ to_abi<I>(impl::initialize_instance(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
+            impl::com_ref<I> result{ to_abi<I>(impl::initialize(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
             return result.template as<typename D::composable>();
         }
         else if constexpr (impl::has_class_type<D>::value)
         {
             static_assert(std::is_same_v<I, default_interface<typename D::class_type>>);
-            return typename D::class_type{ to_abi<I>(impl::initialize_instance(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
+            return typename D::class_type{ to_abi<I>(impl::initialize(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
         }
         else
         {
-            return impl::com_ref<I>{ to_abi<I>(impl::initialize_instance(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
+            return impl::com_ref<I>{ to_abi<I>(impl::initialize(new impl::heap_implements<D>(std::forward<Args>(args)...))), take_ownership_from_abi };
         }
     }
 
@@ -1375,7 +1354,7 @@ WINRT_EXPORT namespace winrt
         }
         else
         {
-            return { impl::initialize_instance(new impl::heap_implements<D>(std::forward<Args>(args)...)), take_ownership_from_abi };
+            return { impl::initialize(new impl::heap_implements<D>(std::forward<Args>(args)...)), take_ownership_from_abi };
         }
     }
 

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1229,22 +1229,16 @@ namespace winrt::impl
     };
 
     template<typename T, typename... Args>
-    auto create_and_initialize(Args&&... args)
+    T* create_and_initialize(Args&&... args)
     {
-        auto instance = new heap_implements<T>(std::forward<Args>(args)...);
+        com_ptr<T> instance{ new heap_implements<T>(std::forward<Args>(args)...), take_ownership_from_abi };
+
         if constexpr (has_initializer<T>::value)
         {
-            try
-            {
-                instance->InitializeComponent();
-            }
-            catch (...)
-            {
-                instance->Release();
-                throw;
-            }
+            instance->InitializeComponent();
         }
-        return instance;
+
+        return instance.detach();
     }
 
     inline com_ptr<IStaticLifetimeCollection> get_static_lifetime_map()

--- a/test/test/initialize.cpp
+++ b/test/test/initialize.cpp
@@ -26,7 +26,7 @@ namespace
         {
         }
 
-        void initialize_instance()
+        void InitializeComponent()
         {
             m_initialize_called = true;
             throw some_exception();
@@ -70,12 +70,6 @@ namespace
         }
     };
 
-    template <typename D>
-    auto initialize_instance(FreeInitializeT<D>& instance)
-    {
-        static_cast<D&>(instance).InitializeComponent();
-    }
-
     struct ThrowingDerived : FreeInitializeT<ThrowingDerived>
     {
         ThrowingDerived(bool& initialize_called) : FreeInitializeT(initialize_called)
@@ -97,7 +91,7 @@ namespace
     };
 }
 
-TEST_CASE("initialize_instance")
+TEST_CASE("initialize")
 {
     // Ensure that failure to initialize is failure to instantiate, with no side effects
     {

--- a/test/test/initialize.cpp
+++ b/test/test/initialize.cpp
@@ -14,40 +14,16 @@ namespace
         }
     };
 
-    struct MemberInitialize : implements<MemberInitialize, IStringable>
-    {
-        bool& m_initialize_called;
-
-        MemberInitialize(bool& initialize_called) : m_initialize_called(initialize_called)
-        {
-        }
-
-        ~MemberInitialize()
-        {
-        }
-
-        void InitializeComponent()
-        {
-            m_initialize_called = true;
-            throw some_exception();
-        }
-
-        hstring ToString()
-        {
-            return {};
-        }
-    };
-
     template<typename D>
-    struct FreeInitializeT : implements<D, IStringable>
+    struct InitializeT : implements<D, IStringable>
     {
         bool& m_initialize_called;
 
-        FreeInitializeT(bool& initialize_called) : m_initialize_called(initialize_called)
+        InitializeT(bool& initialize_called) : m_initialize_called(initialize_called)
         {
         }
 
-        ~FreeInitializeT()
+        ~InitializeT()
         {
         }
 
@@ -63,24 +39,24 @@ namespace
         }
     };
 
-    struct FreeInitialize : FreeInitializeT<FreeInitialize>
+    struct Initialize : InitializeT<Initialize>
     {
-        FreeInitialize(bool& initialize_called) : FreeInitializeT(initialize_called)
+        Initialize(bool& initialize_called) : InitializeT(initialize_called)
         {
         }
     };
 
-    struct ThrowingDerived : FreeInitializeT<ThrowingDerived>
+    struct ThrowingDerived : InitializeT<ThrowingDerived>
     {
-        ThrowingDerived(bool& initialize_called) : FreeInitializeT(initialize_called)
+        ThrowingDerived(bool& initialize_called) : InitializeT(initialize_called)
         {
             throw some_exception();
         }
     };
 
-    struct OverriddenInitialize : FreeInitializeT<OverriddenInitialize>
+    struct OverriddenInitialize : InitializeT<OverriddenInitialize>
     {
-        OverriddenInitialize(bool& initialize_called) : FreeInitializeT(initialize_called)
+        OverriddenInitialize(bool& initialize_called) : InitializeT(initialize_called)
         {
         }
 
@@ -99,23 +75,7 @@ TEST_CASE("initialize")
         bool exception_caught{};
         try
         {
-            make<MemberInitialize>(initialize_called);
-        }
-        catch (some_exception const&)
-        {
-            exception_caught = true;
-        }
-        REQUIRE(initialize_called);
-        REQUIRE(exception_caught);
-    }
-
-    // Same as above, but with free initialization function (Xaml scenario)
-    {
-        bool initialize_called{};
-        bool exception_caught{};
-        try
-        {
-            make<FreeInitialize>(initialize_called);
+            make<Initialize>(initialize_called);
         }
         catch (some_exception const&)
         {

--- a/test/test/initialize_instance.cpp
+++ b/test/test/initialize_instance.cpp
@@ -1,0 +1,165 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    class some_exception : public std::exception
+    {
+    public:
+        some_exception() noexcept
+            : exception("some_exception", 1)
+        {
+        }
+    };
+
+    struct MemberInitialize : implements<MemberInitialize, IStringable>
+    {
+        bool& m_initialize_called;
+
+        MemberInitialize(bool& initialize_called) : m_initialize_called(initialize_called)
+        {
+        }
+
+        ~MemberInitialize()
+        {
+        }
+
+        void initialize_instance()
+        {
+            m_initialize_called = true;
+            throw some_exception();
+        }
+
+        hstring ToString()
+        {
+            return {};
+        }
+    };
+
+    template<typename D>
+    struct FreeInitializeT : implements<D, IStringable>
+    {
+        bool& m_initialize_called;
+
+        FreeInitializeT(bool& initialize_called) : m_initialize_called(initialize_called)
+        {
+        }
+
+        ~FreeInitializeT()
+        {
+        }
+
+        void InitializeComponent()
+        {
+            m_initialize_called = true;
+            throw some_exception();
+        }
+
+        hstring ToString()
+        {
+            return {};
+        }
+    };
+
+    struct FreeInitialize : FreeInitializeT<FreeInitialize>
+    {
+        FreeInitialize(bool& initialize_called) : FreeInitializeT(initialize_called)
+        {
+        }
+    };
+
+    template <typename D>
+    auto initialize_instance(FreeInitializeT<D>& instance)
+    {
+        static_cast<D&>(instance).InitializeComponent();
+    }
+
+    struct ThrowingDerived : FreeInitializeT<ThrowingDerived>
+    {
+        ThrowingDerived(bool& initialize_called) : FreeInitializeT(initialize_called)
+        {
+            throw some_exception();
+        }
+    };
+
+    struct OverriddenInitialize : FreeInitializeT<OverriddenInitialize>
+    {
+        OverriddenInitialize(bool& initialize_called) : FreeInitializeT(initialize_called)
+        {
+        }
+
+        void InitializeComponent()
+        {
+            m_initialize_called = true;
+        }
+    };
+}
+
+TEST_CASE("initialize_instance")
+{
+    // Ensure that failure to initialize is failure to instantiate, with no side effects
+    {
+        bool initialize_called{};
+        bool exception_caught{};
+        try
+        {
+            make<MemberInitialize>(initialize_called);
+        }
+        catch (some_exception const&)
+        {
+            exception_caught = true;
+        }
+        REQUIRE(initialize_called);
+        REQUIRE(exception_caught);
+    }
+
+    // Same as above, but with free initialization function (Xaml scenario)
+    {
+        bool initialize_called{};
+        bool exception_caught{};
+        try
+        {
+            make<FreeInitialize>(initialize_called);
+        }
+        catch (some_exception const&)
+        {
+            exception_caught = true;
+        }
+        REQUIRE(initialize_called);
+        REQUIRE(exception_caught);
+    }
+
+    // Ensure that base is never initialized if exception thrown from derived/base constructor
+    {
+        bool initialize_called{};
+        bool exception_caught{};
+        try
+        {
+            make<ThrowingDerived>(initialize_called);
+        }
+        catch (some_exception const&)
+        {
+            exception_caught = true;
+        }
+        REQUIRE(!initialize_called);
+        REQUIRE(exception_caught);
+    }
+
+    // Support for overriding initialization for post-processing (e.g., accessing Xaml properties)
+    {
+        bool initialize_called{};
+        bool exception_caught{};
+        try
+        {
+            make<OverriddenInitialize>(initialize_called);
+        }
+        catch (some_exception const&)
+        {
+            exception_caught = true;
+        }
+        REQUIRE(initialize_called);
+        REQUIRE(!exception_caught);
+    }
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -369,7 +369,7 @@
     </ClCompile>
     <ClCompile Include="hstring_empty.cpp" />
     <ClCompile Include="iid_ppv_args.cpp" />
-    <ClCompile Include="initialize_instance.cpp" />
+    <ClCompile Include="initialize.cpp" />
     <ClCompile Include="inspectable_interop.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -369,6 +369,7 @@
     </ClCompile>
     <ClCompile Include="hstring_empty.cpp" />
     <ClCompile Include="iid_ppv_args.cpp" />
+    <ClCompile Include="initialize_instance.cpp" />
     <ClCompile Include="inspectable_interop.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/vsix/ItemTemplates/BlankPage/BlankPage.cpp
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.cpp
@@ -9,16 +9,6 @@ using namespace Windows::UI::Xaml;
 
 namespace winrt::$rootnamespace$::implementation
 {
-    $safeitemname$::$safeitemname$()
-    {
-        // Xaml properties should be accessed after InitializeComponent
-    }
-
-    void $safeitemname$::InitializeComponent()
-    {
-        $safeitemname$T::InitializeComponent();
-    }
-
     int32_t $safeitemname$::MyProperty()
     {
         throw hresult_not_implemented();

--- a/vsix/ItemTemplates/BlankPage/BlankPage.cpp
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.cpp
@@ -11,7 +11,12 @@ namespace winrt::$rootnamespace$::implementation
 {
     $safeitemname$::$safeitemname$()
     {
-        InitializeComponent();
+        // Xaml properties should be accessed after InitializeComponent
+    }
+
+    void $safeitemname$::InitializeComponent()
+    {
+        $safeitemname$T::InitializeComponent();
     }
 
     int32_t $safeitemname$::MyProperty()

--- a/vsix/ItemTemplates/BlankPage/BlankPage.h
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.h
@@ -7,6 +7,7 @@ namespace winrt::$rootnamespace$::implementation
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
         $safeitemname$();
+        void InitializeComponent();
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ItemTemplates/BlankPage/BlankPage.h
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.h
@@ -6,8 +6,7 @@ namespace winrt::$rootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
-        $safeitemname$();
-        void InitializeComponent();
+        $safeitemname$() {}
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ItemTemplates/BlankPage/BlankPage.h
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.h
@@ -6,7 +6,11 @@ namespace winrt::$rootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
-        $safeitemname$() {}
+        $safeitemname$() 
+        {
+            // Xaml objects should not call InitializeComponent during construction.
+            // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
+        }
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
@@ -9,16 +9,6 @@ using namespace Windows::UI::Xaml;
 
 namespace winrt::$rootnamespace$::implementation
 {
-    $safeitemname$::$safeitemname$()
-    {
-        // Xaml properties should be accessed after InitializeComponent
-    }
-
-    void $safeitemname$::InitializeComponent()
-    {
-        $safeitemname$T::InitializeComponent();
-    }
-
     int32_t $safeitemname$::MyProperty()
     {
         throw hresult_not_implemented();

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.cpp
@@ -11,7 +11,12 @@ namespace winrt::$rootnamespace$::implementation
 {
     $safeitemname$::$safeitemname$()
     {
-        InitializeComponent();
+        // Xaml properties should be accessed after InitializeComponent
+    }
+
+    void $safeitemname$::InitializeComponent()
+    {
+        $safeitemname$T::InitializeComponent();
     }
 
     int32_t $safeitemname$::MyProperty()

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
@@ -10,7 +10,11 @@ namespace winrt::$rootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
-        $safeitemname$() {}
+        $safeitemname$() 
+        {
+            // Xaml objects should not call InitializeComponent during construction.
+            // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
+        }
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
@@ -11,6 +11,7 @@ namespace winrt::$rootnamespace$::implementation
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
         $safeitemname$();
+        void InitializeComponent();
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
@@ -10,8 +10,7 @@ namespace winrt::$rootnamespace$::implementation
 {
     struct $safeitemname$ : $safeitemname$T<$safeitemname$>
     {
-        $safeitemname$();
-        void InitializeComponent();
+        $safeitemname$() {}
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.cpp
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.cpp
@@ -14,12 +14,12 @@ using namespace $safeprojectname$;
 using namespace $safeprojectname$::implementation;
 
 /// <summary>
-/// Initializes the singleton application object.  This is the first line of authored code
+/// Creates the singleton application object.  This is the first line of authored code
 /// executed, and as such is the logical equivalent of main() or WinMain().
+/// Xaml properties should be accessed after InitializeComponent.
 /// </summary>
 App::App()
 {
-    InitializeComponent();
     Suspending({ this, &App::OnSuspending });
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
@@ -32,6 +32,14 @@ App::App()
         }
     });
 #endif
+}
+
+/// <summary>
+/// Initializes the singleton application object, registering it with the Xaml runtime.
+/// </summary>
+void App::InitializeComponent()
+{
+    AppT::InitializeComponent();
 }
 
 /// <summary>

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.cpp
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.cpp
@@ -16,7 +16,6 @@ using namespace $safeprojectname$::implementation;
 /// <summary>
 /// Creates the singleton application object.  This is the first line of authored code
 /// executed, and as such is the logical equivalent of main() or WinMain().
-/// Xaml properties should be accessed after InitializeComponent.
 /// </summary>
 App::App()
 {
@@ -32,14 +31,6 @@ App::App()
         }
     });
 #endif
-}
-
-/// <summary>
-/// Initializes the singleton application object, registering it with the Xaml runtime.
-/// </summary>
-void App::InitializeComponent()
-{
-    AppT::InitializeComponent();
 }
 
 /// <summary>

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.h
@@ -6,8 +6,6 @@ namespace winrt::$safeprojectname$::implementation
     struct App : AppT<App>
     {
         App();
-        void InitializeComponent();
-        void initialize_instance(){ InitializeComponent(); }
         void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const&);
         void OnSuspending(IInspectable const&, Windows::ApplicationModel::SuspendingEventArgs const&);
         void OnNavigationFailed(IInspectable const&, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs const&);

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/App.h
@@ -6,7 +6,8 @@ namespace winrt::$safeprojectname$::implementation
     struct App : AppT<App>
     {
         App();
-
+        void InitializeComponent();
+        void initialize_instance(){ InitializeComponent(); }
         void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const&);
         void OnSuspending(IInspectable const&, Windows::ApplicationModel::SuspendingEventArgs const&);
         void OnNavigationFailed(IInspectable const&, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs const&);

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.cpp
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.cpp
@@ -9,7 +9,12 @@ namespace winrt::$safeprojectname$::implementation
 {
     MainPage::MainPage()
     {
-        InitializeComponent();
+        // Xaml properties should be accessed after InitializeComponent
+    }
+
+    void MainPage::InitializeComponent()
+    {
+        MainPageT::InitializeComponent();
     }
 
     int32_t MainPage::MyProperty()

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.cpp
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.cpp
@@ -7,16 +7,6 @@ using namespace Windows::UI::Xaml;
 
 namespace winrt::$safeprojectname$::implementation
 {
-    MainPage::MainPage()
-    {
-        // Xaml properties should be accessed after InitializeComponent
-    }
-
-    void MainPage::InitializeComponent()
-    {
-        MainPageT::InitializeComponent();
-    }
-
     int32_t MainPage::MyProperty()
     {
         throw hresult_not_implemented();

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
@@ -6,7 +6,11 @@ namespace winrt::$safeprojectname$::implementation
 {
     struct MainPage : MainPageT<MainPage>
     {
-        MainPage(){}
+        MainPage()
+        {
+            // Xaml objects should not call InitializeComponent during construction.
+            // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
+        }
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
@@ -6,8 +6,7 @@ namespace winrt::$safeprojectname$::implementation
 {
     struct MainPage : MainPageT<MainPage>
     {
-        MainPage();
-        void InitializeComponent();
+        MainPage(){}
 
         int32_t MyProperty();
         void MyProperty(int32_t value);

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
@@ -7,6 +7,7 @@ namespace winrt::$safeprojectname$::implementation
     struct MainPage : MainPageT<MainPage>
     {
         MainPage();
+        void InitializeComponent();
 
         int32_t MyProperty();
         void MyProperty(int32_t value);


### PR DESCRIPTION
Initialization routines for components are now called after construction, rather than during.  This prevents 'this' pointers from being handed out and retained during construction, leading to multiple destructor calls.  If a component has an initialize_instance function (hopefully ugly enough named to prevent need for opting out), member or free (so that the Xaml compiler doesn't require a coordinated fix), then this function is called after the implementation is completely constructed.  If the initializer throws, the instance is destructed and the exception propagates as before.  Existing code can now remove InitializeComponent calls from class constructors, or override in order to access Xaml properties after initialization.  The support is general - non-Xaml code can also define initialize_instance.