### PR TITLE
Update C++/WinRT to consider the full contract version history for fast ABI

### DIFF
--- a/test/test_component_fast/Nomadic.cpp
+++ b/test/test_component_fast/Nomadic.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+#include "Nomadic.h"
+#include "Nomadic.g.cpp"
+
+namespace winrt::test_component_fast::implementation
+{
+    hstring Nomadic::FirstMethod()
+    {
+        return L"FirstMethod";
+    }
+    hstring Nomadic::SecondMethod()
+    {
+        return L"SecondMethod";
+    }
+    hstring Nomadic::ThirdMethod()
+    {
+        return L"ThirdMethod";
+    }
+    hstring Nomadic::FourthMethod()
+    {
+        return L"FourthMethod";
+    }
+}

--- a/test/test_component_fast/Nomadic.cpp
+++ b/test/test_component_fast/Nomadic.cpp
@@ -20,4 +20,16 @@ namespace winrt::test_component_fast::implementation
     {
         return L"FourthMethod";
     }
+    hstring Nomadic::FifthMethod()
+    {
+        return L"FifthMethod";
+    }
+    hstring Nomadic::SixthMethod()
+    {
+        return L"SixthMethod";
+    }
+    hstring Nomadic::SeventhMethod()
+    {
+        return L"SeventhMethod";
+    }
 }

--- a/test/test_component_fast/Nomadic.h
+++ b/test/test_component_fast/Nomadic.h
@@ -11,6 +11,9 @@ namespace winrt::test_component_fast::implementation
         hstring SecondMethod();
         hstring ThirdMethod();
         hstring FourthMethod();
+        hstring FifthMethod();
+        hstring SixthMethod();
+        hstring SeventhMethod();
     };
 }
 namespace winrt::test_component_fast::factory_implementation

--- a/test/test_component_fast/Nomadic.h
+++ b/test/test_component_fast/Nomadic.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Nomadic.g.h"
+
+namespace winrt::test_component_fast::implementation
+{
+    struct Nomadic : NomadicT<Nomadic>
+    {
+        Nomadic() = default;
+
+        hstring FirstMethod();
+        hstring SecondMethod();
+        hstring ThirdMethod();
+        hstring FourthMethod();
+    };
+}
+namespace winrt::test_component_fast::factory_implementation
+{
+    struct Nomadic : NomadicT<Nomadic, implementation::Nomadic>
+    {
+    };
+}

--- a/test/test_component_fast/test_component_fast.idl
+++ b/test/test_component_fast/test_component_fast.idl
@@ -42,6 +42,52 @@ namespace test_component_fast
         }
     }
 
+    [contractversion(5)]
+    apicontract FirstContract{};
+
+    [contractversion(5)]
+    apicontract SecondContract{};
+
+    [contractversion(5)]
+    apicontract ThirdContract{};
+
+    [contractversion(5)]
+    apicontract FourthContract{};
+
+    [fastabi2(ThirdContract, 3)]
+    [from_contract(FirstContract, range(1, 5), SecondContract)]
+    [from_contract(SecondContract, range(1, 5), ThirdContract)]
+    [from_contract(ThirdContract, range(1, 5))]
+    [contract(FourthContract, 1)]
+    runtimeclass Nomadic
+    {
+        Nomadic();
+
+        [interface_name("INomadicFourth")]
+        [contract(FourthContract, 1)]
+        {
+            String FourthMethod();
+        }
+
+        [interface_name("INomadicThird")]
+        [contract(ThirdContract, 2)]
+        {
+            String ThirdMethod();
+        }
+
+        [interface_name("INomadicSecond")]
+        [contract(SecondContract, 3)]
+        {
+            String SecondMethod();
+        }
+
+        [interface_name("INomadicFirst")]
+        [contract(FirstContract, 4)]
+        {
+            String FirstMethod();
+        }
+    }
+
     namespace Composition
     {
         [contractversion(4)]

--- a/test/test_component_fast/test_component_fast.idl
+++ b/test/test_component_fast/test_component_fast.idl
@@ -42,47 +42,75 @@ namespace test_component_fast
         }
     }
 
-    [contractversion(5)]
+    [contractversion(10)]
     apicontract FirstContract{};
 
-    [contractversion(5)]
+    [contractversion(10)]
     apicontract SecondContract{};
 
-    [contractversion(5)]
+    [contractversion(10)]
     apicontract ThirdContract{};
 
-    [contractversion(5)]
+    [contractversion(10)]
     apicontract FourthContract{};
 
     [fastabi2(ThirdContract, 3)]
-    [from_contract(FirstContract, range(1, 5), SecondContract)]
-    [from_contract(SecondContract, range(1, 5), ThirdContract)]
-    [from_contract(ThirdContract, range(1, 5))]
+    [from_contract(FirstContract, range(1, 10), SecondContract)]
+    [from_contract(SecondContract, range(1, 10), ThirdContract)]
+    [from_contract(ThirdContract, range(1, 10))]
     [contract(FourthContract, 1)]
     runtimeclass Nomadic
     {
         Nomadic();
 
+        /* NOTE: There seems to be a bug in midlrt where 'INomadicSeventh' and 'INomadicEighth' are both versioned to
+                 1.0 (when the class was added to the contract) in metadata. The interface impl list has the correct
+                 contract versions, however this trips us up since we only look at the version of the interface
+        [interface_name("INomadicEighth")]
+        [contract(FourthContract, 2.1)]
+        {
+            String EighthMethod();
+        }
+        */
+
+        [interface_name("INomadicSeventh")]
+        [contract(FourthContract, 1.2)]
+        {
+            String SeventhMethod();
+        }
+
+        [interface_name("INomadicSixth")]
+        [contract(ThirdContract, 4.3)]
+        {
+            String SixthMethod();
+        }
+
+        [interface_name("INomadicFifth")]
+        [contract(ThirdContract, 3.4)]
+        {
+            String FifthMethod();
+        }
+
         [interface_name("INomadicFourth")]
-        [contract(FourthContract, 1)]
+        [contract(SecondContract, 6.5)]
         {
             String FourthMethod();
         }
 
         [interface_name("INomadicThird")]
-        [contract(ThirdContract, 2)]
+        [contract(SecondContract, 5.6)]
         {
             String ThirdMethod();
         }
 
         [interface_name("INomadicSecond")]
-        [contract(SecondContract, 3)]
+        [contract(FirstContract, 8.7)]
         {
             String SecondMethod();
         }
 
         [interface_name("INomadicFirst")]
-        [contract(FirstContract, 4)]
+        [contract(FirstContract, 7.8)]
         {
             String FirstMethod();
         }

--- a/test/test_component_fast/test_component_fast.vcxproj
+++ b/test/test_component_fast/test_component_fast.vcxproj
@@ -617,6 +617,7 @@
     <ClCompile Include="Composition.Compositor.cpp" />
     <ClCompile Include="Composition.SpriteVisual.cpp" />
     <ClCompile Include="Composition.Visual.cpp" />
+    <ClCompile Include="Nomadic.cpp" />
     <ClCompile Include="Simple.cpp" />
     <ClCompile Include="Generated Files\module.g.cpp" />
     <ClCompile Include="pch.cpp">
@@ -628,6 +629,7 @@
     <ClInclude Include="Composition.Compositor.h" />
     <ClInclude Include="Composition.SpriteVisual.h" />
     <ClInclude Include="Composition.Visual.h" />
+    <ClInclude Include="Nomadic.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Simple.h" />
   </ItemGroup>

--- a/test/test_fast/Nomadic.cpp
+++ b/test/test_fast/Nomadic.cpp
@@ -11,7 +11,7 @@ hstring invoke_by_interface_vtable_offset(Nomadic const& nomadic, ptrdiff_t offs
     //       that IInspectable has 6 functions in total (including those inherited from IUnknown)
     auto insp = static_cast<::IInspectable*>(get_abi(nomadic));
     auto vtable = *reinterpret_cast<void***>(insp);
-    auto fn_ptr = static_cast<HRESULT(*)(::IInspectable*, HSTRING*)>(vtable[6 + offset]);
+    auto fn_ptr = static_cast<HRESULT(__stdcall *)(::IInspectable*, HSTRING*)>(vtable[6 + offset]);
 
     HSTRING hstr;
     check_hresult(fn_ptr(insp, &hstr));
@@ -30,4 +30,7 @@ TEST_CASE("Nomadic")
     REQUIRE(invoke_by_interface_vtable_offset(n, 1) == L"SecondMethod");
     REQUIRE(invoke_by_interface_vtable_offset(n, 2) == L"ThirdMethod");
     REQUIRE(invoke_by_interface_vtable_offset(n, 3) == L"FourthMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 4) == L"FifthMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 5) == L"SixthMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 6) == L"SeventhMethod");
 }

--- a/test/test_fast/Nomadic.cpp
+++ b/test/test_fast/Nomadic.cpp
@@ -1,0 +1,33 @@
+#include "pch.h"
+#include "winrt/test_component_fast.h"
+#include <inspectable.h>
+
+using namespace winrt;
+using namespace test_component_fast;
+
+hstring invoke_by_interface_vtable_offset(Nomadic const& nomadic, ptrdiff_t offset)
+{
+    // NOTE: Behavior guaranteed by Windows ABI; see the "C style interface" for WinRT/COM types for more info. Note
+    //       that IInspectable has 6 functions in total (including those inherited from IUnknown)
+    auto insp = static_cast<::IInspectable*>(get_abi(nomadic));
+    auto vtable = *reinterpret_cast<void***>(insp);
+    auto fn_ptr = static_cast<HRESULT(*)(::IInspectable*, HSTRING*)>(vtable[6 + offset]);
+
+    HSTRING hstr;
+    check_hresult(fn_ptr(insp, &hstr));
+
+    hstring result;
+    attach_abi(result, hstr);
+    return result;
+}
+
+TEST_CASE("Nomadic")
+{
+    impl::get_diagnostics_info().detach();
+
+    Nomadic n;
+    REQUIRE(invoke_by_interface_vtable_offset(n, 0) == L"FirstMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 1) == L"SecondMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 2) == L"ThirdMethod");
+    REQUIRE(invoke_by_interface_vtable_offset(n, 3) == L"FourthMethod");
+}

--- a/test/test_fast/test_fast.vcxproj
+++ b/test/test_fast/test_fast.vcxproj
@@ -283,6 +283,7 @@
     <ClCompile Include="main.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Nomadic.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>


### PR DESCRIPTION
Currently interfaces are being sorted for fast ABI by their current contract version which is incorrect because (1) we actually want to consider their initial contract/version, not the current ones, and (2) we want to consider the contract each interface was introduced in relative to the contract history of the type they apply to. E.g. an interface introduced in contract 'A' version 2 should be sorted before an interface introduced in contract 'B' version 1 if the class was in contract 'A' before contract 'B'.

Note that the sorting algorithm is N^2, however this should be fine since moving contracts should be rare and the history should be small to the point that trying to create a graph/linked list would be wasteful and probably more inefficient.

Also note that this maintains some simplifying assumptions we've generally agreed in the past are okay.
* It ignores the "versioning scheme" of the attribute and instead assumes that if contracts are involved at all, everything is contract versioned
* It assumes that relevant interfaces are introduced and added to the type in the same contract/version. I.e. it ignores the versioning attributes on the class's interface impl list