### PR TITLE
Use `auto` trick to catch missing header files for auto_revoke

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1001,14 +1001,13 @@ namespace cppwinrt
         if (is_add_overload(method))
         {
             auto format = R"(        using %_revoker = impl::event_revoker<%, &impl::abi_t<%>::remove_%>;
-        [[nodiscard]] WINRT_IMPL_AUTO(%_revoker) %(auto_revoke_t, %) const;
+        [[nodiscard]] auto %(auto_revoke_t, %) const;
 )";
 
             w.write(format,
                 method_name,
                 type,
                 type,
-                method_name,
                 method_name,
                 method_name,
                 bind<write_consume_params>(signature));
@@ -1170,7 +1169,7 @@ namespace cppwinrt
 
         if (is_add_overload(method))
         {
-            format = R"(    template <typename D%> WINRT_IMPL_AUTO(typename consume_%<D%>::%_revoker) consume_%<D%>::%(auto_revoke_t, %) const
+            format = R"(    template <typename D%> auto consume_%<D%>::%(auto_revoke_t, %) const
     {
         return impl::make_event_revoker<D, %_revoker>(this, %(%));
     }
@@ -1178,9 +1177,6 @@ namespace cppwinrt
 
             w.write(format,
                 bind<write_comma_generic_typenames>(generics),
-                type_impl_name,
-                bind<write_comma_generic_types>(generics),
-                method_name,
                 type_impl_name,
                 bind<write_comma_generic_types>(generics),
                 method_name,
@@ -1214,15 +1210,13 @@ namespace cppwinrt
 
         if (is_add_overload(method))
         {
-            format = R"(    inline WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %) const
+            format = R"(    inline auto %::%(auto_revoke_t, %) const
     {
         return impl::make_event_revoker<D, %_revoker>(this, %(%));
     }
 )";
 
             w.write(format,
-                class_type.TypeName(),
-                method_name,
                 class_type.TypeName(),
                 method_name,
                 bind<write_consume_params>(signature),
@@ -3017,14 +3011,13 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             if (is_add_overload(method))
             {
                 auto format = R"(        using %_revoker = impl::factory_event_revoker<%, &impl::abi_t<%>::remove_%>;
-        [[nodiscard]] static WINRT_IMPL_AUTO(%_revoker) %(auto_revoke_t, %);
+        [[nodiscard]] static auto %(auto_revoke_t, %);
 )";
 
                 w.write(format,
                     method_name,
                     factory.second.type,
                     factory.second.type,
-                    method_name,
                     method_name,
                     method_name,
                     bind<write_consume_params>(signature));
@@ -3056,7 +3049,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 
         if (is_add_overload(method))
         {
-            auto format = R"(    inline WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %)
+            auto format = R"(    inline auto %::%(auto_revoke_t, %)
     {
         auto f = get_activation_factory<%, %>();
         return %::%_revoker{ f, f.%(%) };
@@ -3064,8 +3057,6 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 )";
 
             w.write(format,
-                type_name,
-                method_name,
                 type_name,
                 method_name,
                 bind<write_consume_params>(signature),

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1001,7 +1001,7 @@ namespace cppwinrt
         if (is_add_overload(method))
         {
             auto format = R"(        using %_revoker = impl::event_revoker<%, &impl::abi_t<%>::remove_%>;
-        [[nodiscard]] %_revoker %(auto_revoke_t, %) const;
+        [[nodiscard]] WINRT_IMPL_AUTO(%_revoker) %(auto_revoke_t, %) const;
 )";
 
             w.write(format,
@@ -1170,7 +1170,7 @@ namespace cppwinrt
 
         if (is_add_overload(method))
         {
-            format = R"(    template <typename D%> typename consume_%<D%>::%_revoker consume_%<D%>::%(auto_revoke_t, %) const
+            format = R"(    template <typename D%> WINRT_IMPL_AUTO(typename consume_%<D%>::%_revoker) consume_%<D%>::%(auto_revoke_t, %) const
     {
         return impl::make_event_revoker<D, %_revoker>(this, %(%));
     }
@@ -1214,7 +1214,7 @@ namespace cppwinrt
 
         if (is_add_overload(method))
         {
-            format = R"(    inline %::%_revoker %::%(auto_revoke_t, %) const
+            format = R"(    inline WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %) const
     {
         return impl::make_event_revoker<D, %_revoker>(this, %(%));
     }
@@ -3017,7 +3017,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             if (is_add_overload(method))
             {
                 auto format = R"(        using %_revoker = impl::factory_event_revoker<%, &impl::abi_t<%>::remove_%>;
-        [[nodiscard]] static %_revoker %(auto_revoke_t, %);
+        [[nodiscard]] static WINRT_IMPL_AUTO(%_revoker) %(auto_revoke_t, %);
 )";
 
                 w.write(format,
@@ -3056,10 +3056,10 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 
         if (is_add_overload(method))
         {
-            auto format = R"(    inline %::%_revoker %::%(auto_revoke_t, %)
+            auto format = R"(    inline WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %)
     {
         auto f = get_activation_factory<%, %>();
-        return { f, f.%(%) };
+        return %::%_revoker{ f, f.%(%) };
     }
 )";
 
@@ -3071,6 +3071,8 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
                 bind<write_consume_params>(signature),
                 type_name,
                 factory,
+                type_name,
+                method_name,
                 method_name,
                 bind<write_consume_args>(signature));
         }

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -518,10 +518,10 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method))
                     {
-                        auto format = R"(    %::%_revoker %::%(auto_revoke_t, %)
+                        auto format = R"(    WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
-        return { f, f.%(%) };
+        return %::%_revoker{ f, f.%(%) };
     }
 )";
 
@@ -534,6 +534,8 @@ catch (...) { return winrt::to_hresult(); }
                             type_namespace,
                             type_name,
                             factory_name,
+                            type_name,
+                            method_name,
                             method_name,
                             bind<write_consume_args>(signature));
                     }

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -518,7 +518,7 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method))
                     {
-                        auto format = R"(    WINRT_IMPL_AUTO(%::%_revoker) %::%(auto_revoke_t, %)
+                        auto format = R"(    auto %::%(auto_revoke_t, %)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
         return %::%_revoker{ f, f.%(%) };
@@ -526,8 +526,6 @@ catch (...) { return winrt::to_hresult(); }
 )";
 
                         w.write(format,
-                            type_name,
-                            method_name,
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),


### PR DESCRIPTION
We forgot to apply the `auto` trick to `auto_revoke` methods to catch missing header files at compile time. As a result, people who used `auto_revoke` didn't learn about missing header files until link time.

Apply the same technique to auto-revoke event handler registration.

(Story time: A customer was running into linker errors due to a missing header file when they used `auto_revoke`. One thing they tried was switching to non-`auto_revoke` events, and then they got the compile-time error. But their conclusion wasn't "Oh, that's my problem" but rather "Oh no, that made it worse, go back!")