### PR TITLE
Copy and swap assignment

### DIFF
--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -176,7 +176,9 @@ WINRT_EXPORT namespace winrt
         void copy_from(type* other) noexcept
         {
             if (other)
+			{
                 const_cast<std::remove_const_t<type>*>(other)->AddRef();
+			}
             com_ptr cpy(other, take_ownership_from_abi);
             swap(*this, cpy);
         }

--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -176,9 +176,9 @@ WINRT_EXPORT namespace winrt
         void copy_from(type* other) noexcept
         {
             if (other)
-			{
+            {
                 const_cast<std::remove_const_t<type>*>(other)->AddRef();
-			}
+            }
             com_ptr cpy(other, take_ownership_from_abi);
             swap(*this, cpy);
         }

--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -66,8 +66,11 @@ WINRT_EXPORT namespace winrt
 
         com_ptr& operator=(com_ptr&& other) noexcept
         {
-            com_ptr cpy(std::move(other));
-            swap(*this, cpy);
+            if (this != &other)
+            {
+                com_ptr cpy(std::move(other));
+                swap(*this, cpy);
+            }
             return*this;
         }
 

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -168,8 +168,11 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
 
         IUnknown& operator=(IUnknown&& other) noexcept
         {
-            IUnknown cpy(std::move(other));
-            swap(*this, cpy);
+            if (this != &other)
+            {
+                IUnknown cpy(std::move(other));
+                swap(*this, cpy);
+            }
             return*this;
         }
 

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -161,9 +161,9 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
 
         IUnknown& operator=(IUnknown const& other) noexcept
         {
-			IUnknown cpy(other);
-			swap(*this, cpy);
-			return*this;
+            IUnknown cpy(other);
+            swap(*this, cpy);
+            return*this;
         }
 
         IUnknown& operator=(IUnknown&& other) noexcept

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -161,24 +161,15 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
 
         IUnknown& operator=(IUnknown const& other) noexcept
         {
-            if (this != &other)
-            {
-                release_ref();
-                m_ptr = other.m_ptr;
-                add_ref();
-            }
-
-            return*this;
+			IUnknown cpy(other);
+			swap(*this, cpy);
+			return*this;
         }
 
         IUnknown& operator=(IUnknown&& other) noexcept
         {
-            if (this != &other)
-            {
-                release_ref();
-                m_ptr = std::exchange(other.m_ptr, {});
-            }
-
+            IUnknown cpy(std::move(other));
+            swap(*this, cpy);
             return*this;
         }
 


### PR DESCRIPTION
Use the copy and swap idiom for com_ptr and IUnknown assignment operators provides several benefits
* no temporary nullptr during assignment
* prevents the erroneous destruction of recursive data structures (better explained here https://youtu.be/7Qgd9B1KuMQ?t=850)
* better exception safety guaranty (when exception was thrown then no changes were made), probably not so important here