### PR TITLE
Test whether SDKManifest.xml exists before attempting to read it.

### DIFF
--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -474,7 +474,11 @@ namespace cppwinrt
                         xml_path = item.path() / sdk_version;
                         xml_path /= L"SDKManifest.xml";
 
-                        add_files_from_xml(files, sdk_version, xml_path, sdk_path);
+                        // Not all Extension SDKs include an SDKManifest.xml file; ignore those which do not (e.g. WindowsIoT).
+                        if (std::filesystem::is_regular_file(xml_path))
+                        {
+                            add_files_from_xml(files, sdk_version, xml_path, sdk_path);
+                        }
                     }
 
                     continue;


### PR DESCRIPTION
This change fixes #1145 by testing whether an `SDKManifest.xml` exists within an Extension SDK's folder before attempting to read it, and ignores Extension SDKs which lack this file.