### PR TITLE
Add support for composed implementations of IComponentConnector

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -3270,6 +3270,14 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         {
             w.write(strings::base_xaml_typename);
         }
+        else if (namespace_name == "Windows.UI.Xaml.Markup")
+        {
+            w.write(strings::base_xaml_component_connector, "Windows");
+        }
+        else if (namespace_name == "Microsoft.UI.Xaml.Markup")
+        {
+            w.write(strings::base_xaml_component_connector, "Microsoft");
+        }
     }
 
     static void write_namespace_special_1(writer& w, std::string_view const& namespace_name)

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -797,6 +797,7 @@ catch (...) { return winrt::to_hresult(); }
                 }
                 else
                 {
+                    composable_base_name = w.write_temp("using composable_base = B;");
                     base_type_parameter = ", typename B";
                     base_type_argument = ", B";
                     no_module_lock = "no_module_lock, ";
@@ -868,7 +869,7 @@ catch (...) { return winrt::to_hresult(); }
 namespace winrt::@::implementation
 {
     template <typename D, typename... I>
-    using %T = %_base<D, I...>;
+    using %T = %_base<D, impl::marker, I...>;
 }
 
 #endif

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -869,7 +869,7 @@ catch (...) { return winrt::to_hresult(); }
 namespace winrt::@::implementation
 {
     template <typename D, typename... I>
-    using %T = %_base<D, impl::marker, I...>;
+    using %T = %_base<D, I...>;
 }
 
 #endif

--- a/cppwinrt/cppwinrt.vcxproj
+++ b/cppwinrt/cppwinrt.vcxproj
@@ -54,9 +54,9 @@
     <ClInclude Include="..\strings\base_com_ptr.h" />
     <ClInclude Include="..\strings\base_coroutine_foundation.h" />
     <ClInclude Include="..\strings\base_coroutine_system.h" />
+    <ClInclude Include="..\strings\base_coroutine_system_winui.h" />
     <ClInclude Include="..\strings\base_coroutine_threadpool.h" />
     <ClInclude Include="..\strings\base_coroutine_ui_core.h" />
-    <ClInclude Include="..\strings\base_coroutine_system_winui.h" />
     <ClInclude Include="..\strings\base_deferral.h" />
     <ClInclude Include="..\strings\base_delegate.h" />
     <ClInclude Include="..\strings\base_error.h" />
@@ -88,6 +88,7 @@
     <ClInclude Include="..\strings\base_version_odr.h" />
     <ClInclude Include="..\strings\base_weak_ref.h" />
     <ClInclude Include="..\strings\base_windows.h" />
+    <ClInclude Include="..\strings\base_xaml_component_connector.h" />
     <ClInclude Include="..\strings\base_xaml_typename.h" />
     <ClInclude Include="cmd_reader.h" />
     <ClInclude Include="code_writers.h" />

--- a/cppwinrt/cppwinrt.vcxproj.filters
+++ b/cppwinrt/cppwinrt.vcxproj.filters
@@ -64,9 +64,6 @@
     <ClInclude Include="..\strings\base_coroutine_foundation.h">
       <Filter>strings</Filter>
     </ClInclude>
-    <ClInclude Include="..\strings\base_coroutine_system.h">
-      <Filter>strings</Filter>
-    </ClInclude>
     <ClInclude Include="..\strings\base_coroutine_threadpool.h">
       <Filter>strings</Filter>
     </ClInclude>
@@ -163,9 +160,6 @@
     <ClInclude Include="..\strings\base_includes.h">
       <Filter>strings</Filter>
     </ClInclude>
-    <ClInclude Include="..\strings\base_coroutine_system_winui.h">
-      <Filter>strings</Filter>
-    </ClInclude>
     <ClInclude Include="..\strings\base_iterator.h">
       <Filter>strings</Filter>
     </ClInclude>
@@ -173,6 +167,15 @@
       <Filter>strings</Filter>
     </ClInclude>
     <ClInclude Include="..\strings\base_stringable_format.h">
+      <Filter>strings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\strings\base_xaml_component_connector.h">
+      <Filter>strings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\strings\base_coroutine_system.h">
+      <Filter>strings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\strings\base_coroutine_system_winui.h">
       <Filter>strings</Filter>
     </ClInclude>
   </ItemGroup>

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -112,6 +112,14 @@ void MyComponent::InitializeComponent()
 }
 ```
 
+***[Windows|Microsoft]::UI::Xaml::Markup::ComponentConnectorT***
+
+A consequence of calling InitializeComponent outside construction is that Xaml runtime callbacks to IComponentConnector::Connect and IComponentConnector2::GetBindingConnector are now dispatched to the most derived implementations. Previously, these calls were dispatched directly to the class under construction, as the vtable had yet to be initialized. For objects with markup that derive from composable base classes with markup, this is a breaking change. Derived classes must now implement IComponentConnector::Connect and IComponentConnector2::GetBindingConnector by explicitly calling into the base class. The ComponentConnectorT template provides a correct implemenation for these interfaces:
+
+```cpp
+    struct DerivedPage : winrt::Windows::UI::Xaml::Markup::ComponentConnectorT<DerivedPageT<DerivedPage>>
+```
+
 ## Troubleshooting
 
 The msbuild verbosity level maps to msbuild message importance as follows:

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -254,7 +254,7 @@ namespace winrt::impl
     struct interface_list<>
     {
         template <typename Traits>
-        static constexpr auto find(const Traits& traits) noexcept
+        static constexpr auto find(Traits const& traits) noexcept
         {
             return traits.not_found();
         }
@@ -264,7 +264,7 @@ namespace winrt::impl
     struct interface_list<First, Rest...>
     {
         template <typename Traits>
-        static constexpr auto find(const Traits& traits) noexcept
+        static constexpr auto find(Traits const& traits) noexcept
         {
             if (traits.template test<First>())
             {

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -365,7 +365,7 @@ namespace winrt::impl
     template<typename T>
     struct find_iid_traits
     {
-        const T* _obj;
+        const T* m_object;
         const guid& m_guid;
 
         template <typename I>
@@ -377,7 +377,7 @@ namespace winrt::impl
         template <typename I>
         constexpr void* found() const noexcept
         {
-            return to_abi<I>(_obj);
+            return to_abi<I>(m_object);
         }
 
         static constexpr void* not_found() noexcept
@@ -422,7 +422,7 @@ namespace winrt::impl
     template<typename T>
     struct find_inspectable_traits
     {
-        const T* _obj;
+        const T* m_object;
 
         template <typename I>
         static constexpr bool test() noexcept
@@ -433,7 +433,7 @@ namespace winrt::impl
         template <typename I>
         constexpr void* found() const noexcept
         {
-            return to_abi<I>(_obj);
+            return to_abi<I>(m_object);
         }
 
         static constexpr void* not_found() noexcept

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -365,8 +365,8 @@ namespace winrt::impl
     template<typename T>
     struct find_iid_traits
     {
-        const T* m_object;
-        const guid& m_guid;
+        T const* m_object;
+        guid const& m_guid;
 
         template <typename I>
         constexpr bool test() const noexcept
@@ -387,7 +387,7 @@ namespace winrt::impl
     };
 
     template <typename T>
-    auto find_iid(const T* obj, const guid& iid) noexcept
+    auto find_iid(T const* obj, guid const& iid) noexcept
     {
         return static_cast<unknown_abi*>(implemented_interfaces<T>::find(find_iid_traits<T>{ obj, iid }));
     }
@@ -422,7 +422,7 @@ namespace winrt::impl
     template<typename T>
     struct find_inspectable_traits
     {
-        const T* m_object;
+        T const* m_object;
 
         template <typename I>
         static constexpr bool test() noexcept
@@ -443,7 +443,7 @@ namespace winrt::impl
     };
 
     template <typename T>
-    inspectable_abi* find_inspectable(const T* obj) noexcept
+    inspectable_abi* find_inspectable(T const* obj) noexcept
     {
         using default_interface = typename implements_default_interface<T>::type;
 
@@ -556,7 +556,7 @@ namespace winrt::impl
     template <typename D>
     struct produce<D, INonDelegatingInspectable> : produce_base<D, INonDelegatingInspectable>
     {
-        int32_t __stdcall QueryInterface(const guid& id, void** object) noexcept final
+        int32_t __stdcall QueryInterface(guid const& id, void** object) noexcept final
         {
             return this->shim().NonDelegatingQueryInterface(id, object);
         }
@@ -964,7 +964,7 @@ namespace winrt::impl
             return target;
         }
 
-        int32_t __stdcall NonDelegatingQueryInterface(const guid& id, void** object) noexcept
+        int32_t __stdcall NonDelegatingQueryInterface(guid const& id, void** object) noexcept
         {
             if (is_guid_of<Windows::Foundation::IInspectable>(id) || is_guid_of<Windows::Foundation::IUnknown>(id))
             {
@@ -986,13 +986,13 @@ namespace winrt::impl
 
         int32_t __stdcall NonDelegatingGetIids(uint32_t* count, guid** array) noexcept
         {
-            const auto& local_iids = static_cast<D*>(this)->get_local_iids();
-            const uint32_t& local_count = local_iids.first;
+            auto const& local_iids = static_cast<D*>(this)->get_local_iids();
+            uint32_t const& local_count = local_iids.first;
             if constexpr (root_implements_type::is_composing)
             {
                 if (local_count > 0)
                 {
-                    const com_array<guid>& inner_iids = get_interfaces(root_implements_type::m_inner);
+                    com_array<guid> const& inner_iids = get_interfaces(root_implements_type::m_inner);
                     *count = local_count + inner_iids.size();
                     *array = static_cast<guid*>(WINRT_IMPL_CoTaskMemAlloc(sizeof(guid)*(*count)));
                     if (*array == nullptr)
@@ -1243,7 +1243,7 @@ namespace winrt::impl
         }
 
         virtual unknown_abi* get_unknown() const noexcept = 0;
-        virtual std::pair<uint32_t, const guid*> get_local_iids() const noexcept = 0;
+        virtual std::pair<uint32_t, guid const*> get_local_iids() const noexcept = 0;
         virtual hstring GetRuntimeClassName() const = 0;
         virtual void* find_interface(guid const&) const noexcept = 0;
         virtual inspectable_abi* find_inspectable() const noexcept = 0;
@@ -1504,7 +1504,7 @@ WINRT_EXPORT namespace winrt
             return impl::find_inspectable(static_cast<const D*>(this));
         }
 
-        std::pair<uint32_t, const guid*> get_local_iids() const noexcept override
+        std::pair<uint32_t, guid const*> get_local_iids() const noexcept override
         {
             using interfaces = impl::uncloaked_interfaces<D>;
             using local_iids = impl::uncloaked_iids<interfaces>;

--- a/strings/base_xaml_component_connector.h
+++ b/strings/base_xaml_component_connector.h
@@ -1,0 +1,53 @@
+
+WINRT_EXPORT namespace winrt::%::UI::Xaml::Markup
+{
+    template <typename D>
+    struct ComponentConnectorT : D
+    {
+        using composable_base = typename D::composable_base;
+
+        void InitializeComponent()
+        {
+            if constexpr (has_connectable_base)
+            {
+                _dispatch_base = true;
+                composable_base::InitializeComponent();
+                _dispatch_base = false;
+            }
+            D::InitializeComponent();
+        }
+
+        void Connect(int32_t connectionId, Windows::Foundation::IInspectable const& target)
+        {
+            if constexpr (has_connectable_base)
+            {
+                if (_dispatch_base)
+                {
+                    composable_base::Connect(connectionId, target);
+                    return;
+                }
+            }
+            D::Connect(connectionId, target);
+        }
+
+        auto GetBindingConnector(int32_t connectionId, Windows::Foundation::IInspectable const& target)
+        {
+            if constexpr (has_connectable_base)
+            {
+                if (_dispatch_base)
+                {
+                    return composable_base::GetBindingConnector(connectionId, target);
+                }
+            }
+            return D::GetBindingConnector(connectionId, target);
+        }
+
+    private:
+        static constexpr bool has_connectable_base{
+            impl::has_initializer<composable_base>::value &&
+            impl::has_interface<D, IComponentConnector>() &&
+            impl::has_interface<D, IComponentConnector2>() };
+
+        bool _dispatch_base{};
+    };
+}

--- a/strings/base_xaml_component_connector.h
+++ b/strings/base_xaml_component_connector.h
@@ -8,20 +8,20 @@ WINRT_EXPORT namespace winrt::%::UI::Xaml::Markup
 
         void InitializeComponent()
         {
-            if constexpr (has_connectable_base)
+            if constexpr (m_has_connectable_base)
             {
-                _dispatch_base = true;
+                m_dispatch_base = true;
                 composable_base::InitializeComponent();
-                _dispatch_base = false;
+                m_dispatch_base = false;
             }
             D::InitializeComponent();
         }
 
         void Connect(int32_t connectionId, Windows::Foundation::IInspectable const& target)
         {
-            if constexpr (has_connectable_base)
+            if constexpr (m_has_connectable_base)
             {
-                if (_dispatch_base)
+                if (m_dispatch_base)
                 {
                     composable_base::Connect(connectionId, target);
                     return;
@@ -32,9 +32,9 @@ WINRT_EXPORT namespace winrt::%::UI::Xaml::Markup
 
         auto GetBindingConnector(int32_t connectionId, Windows::Foundation::IInspectable const& target)
         {
-            if constexpr (has_connectable_base)
+            if constexpr (m_has_connectable_base)
             {
-                if (_dispatch_base)
+                if (m_dispatch_base)
                 {
                     return composable_base::GetBindingConnector(connectionId, target);
                 }
@@ -43,11 +43,11 @@ WINRT_EXPORT namespace winrt::%::UI::Xaml::Markup
         }
 
     private:
-        static constexpr bool has_connectable_base{
+        static constexpr bool m_has_connectable_base{
             impl::has_initializer<composable_base>::value &&
             impl::has_interface<D, IComponentConnector>() &&
             impl::has_interface<D, IComponentConnector2>() };
 
-        bool _dispatch_base{};
+        bool m_dispatch_base{};
     };
 }


### PR DESCRIPTION
fixes #1140

This change adds a helper, ComponentConnectorT, to resolve the breaking change introduced with #1140.  Note that this is manual opt-in for the developer, and not an automatic fix, as that would require coordinated work with the Xaml Compiler.  I don't think it's worth the effort to do that, for several reasons:

When deriving from a base class with markup, IComponentConnector::Connect has never been reliable outside construction, such as when called back from FindName.  If a base class has a property with both the same type (e.g., TextBlock) and connectionId as a derived class,  then Connect would erroneously call the derived property setter.   The same risk applies to DisconnectUnloadedObject.  This was the opposite of the non-virtual dispatch that InitializeComponent was previously relying on.  At steady state (outside construction), virtual dispatch would be functional and the derived Connect would always be called.  However, unlike with calls from within InitializeComponent, where _dispatch_base can be used to correctly dispatch callbacks, there is no way to know how to do this with Xaml runtime calls for FindName (x:Load and template apply scenarios).  The risk exists in both directions - a base property can erroneously override a derived property and vice versa.

For that reason, the Xaml team does not recommend bases with markup, although there is nothing to prevent that or inform the developer of the risks (see [related discussion](https://github.com/microsoft/microsoft-ui-xaml/issues/5597)).  To preserve the existing (risky) behavior outside construction, _dispatch_base defaults to false to dispatch to the derived class.

