### PR TITLE
Static events should not use the auto trick

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -518,7 +518,7 @@ catch (...) { return winrt::to_hresult(); }
 
                     if (is_add_overload(method))
                     {
-                        auto format = R"(    auto %::%(auto_revoke_t, %)
+                        auto format = R"(    %::%_revoker %::%(auto_revoke_t, %)
     {
         auto f = make<winrt::@::factory_implementation::%>().as<%>();
         return %::%_revoker{ f, f.%(%) };
@@ -526,6 +526,8 @@ catch (...) { return winrt::to_hresult(); }
 )";
 
                         w.write(format,
+                            type_name,
+                            method_name,
                             type_name,
                             method_name,
                             bind<write_consume_params>(signature),

--- a/test/test_component/Class.cpp
+++ b/test/test_component/Class.cpp
@@ -516,3 +516,10 @@ namespace winrt::test_component::implementation
         return pass;
     }
 }
+
+namespace
+{
+    void ValidateStaticEventAutoRevoke() {
+        auto x = winrt::test_component::Simple::StaticEvent(winrt::auto_revoke, [](auto&&, auto&&) {});
+    }
+}


### PR DESCRIPTION
The same way we don't use the auto trick for static properties and static methods.

Fixes issue introduced by #1136 