### PR TITLE
Don't use __uuidof without GUID

### DIFF
--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -119,12 +119,12 @@ namespace winrt::impl
 
     template <typename T>
 #if defined(__clang__)
-#if __has_declspec_attribute(uuid)
+#if __has_declspec_attribute(uuid) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
     inline const guid guid_v{ __uuidof(T) };
 #else
     inline constexpr guid guid_v{};
 #endif
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
     inline constexpr guid guid_v{ __uuidof(T) };
 #else
     inline constexpr guid guid_v{};


### PR DESCRIPTION
If GUID is not defined, then don't breathe the name of the `__uuidof` intrinsic, because that would instantiate an undefined structure. clang is stricter about this than msvc, but fix both just in case.

Fixes #1179
