### PR TITLE
Default initialize `winrt::guid` members

### DIFF
--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -133,10 +133,10 @@ WINRT_EXPORT namespace winrt
 
     public:
 
-        uint32_t Data1;
-        uint16_t Data2;
-        uint16_t Data3;
-        uint8_t  Data4[8];
+        uint32_t Data1{};
+        uint16_t Data2{};
+        uint16_t Data3{};
+        uint8_t  Data4[8]{};
 
         guid() noexcept = default;
 


### PR DESCRIPTION
winrt::guid members are not default initialized which may lead to undefined behavior in the usage code if not explicitly initialized.
As per C++ core guidelines: Prevents “use before set” errors
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html#Rc-initialize