### PR TITLE
C++20 consumers should have std::source_location support when logging error information

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!--<CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">210122.210122.210122.210122</CppWinRTBuildVersion>-->
     <CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">2.3.4.5</CppWinRTBuildVersion>
     <CppWinRTPlatform>$(Platform)</CppWinRTPlatform>
     <CppWinRTPlatform Condition="'$(Platform)'=='Win32'">x86</CppWinRTPlatform>
@@ -46,6 +47,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard Condition="'$(CppWinRTLanguageStandard)'==''">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(CppWinRTLanguageStandard)'=='stdcpp20'">stdcpp20</LanguageStandard>
       <LanguageStandard Condition="'$(CppWinRTLanguageStandard)'=='latest'">stdcpplatest</LanguageStandard>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -32,7 +32,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--<CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">210122.210122.210122.210122</CppWinRTBuildVersion>-->
     <CppWinRTBuildVersion Condition="'$(CppWinRTBuildVersion)'==''">2.3.4.5</CppWinRTBuildVersion>
     <CppWinRTPlatform>$(Platform)</CppWinRTPlatform>
     <CppWinRTPlatform Condition="'$(Platform)'=='Win32'">x86</CppWinRTPlatform>

--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -511,36 +511,24 @@ WINRT_EXPORT namespace winrt
         return impl::com_array_proxy<T>(__valueSize, value);
     }
 
-    inline hstring get_class_name(Windows::Foundation::IInspectable const& object)
+    inline hstring get_class_name(Windows::Foundation::IInspectable const& object WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         void* value{};
-#ifdef __cpp_lib_source_location
-        check_hresult((*(impl::inspectable_abi**)&object)->GetRuntimeClassName(&value), std::source_location::current());
-#else
-        check_hresult((*(impl::inspectable_abi**)&object)->GetRuntimeClassName(&value));
-#endif
+        check_hresult((*(impl::inspectable_abi**)&object)->GetRuntimeClassName(&value) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         return { value, take_ownership_from_abi };
     }
 
-    inline com_array<guid> get_interfaces(Windows::Foundation::IInspectable const& object)
+    inline com_array<guid> get_interfaces(Windows::Foundation::IInspectable const& object WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         com_array<guid> value;
-#ifdef __cpp_lib_source_location
-        check_hresult((*(impl::inspectable_abi**)&object)->GetIids(impl::put_size_abi(value), put_abi(value)), std::source_location::current());
-#else
-        check_hresult((*(impl::inspectable_abi**)&object)->GetIids(impl::put_size_abi(value), put_abi(value)));
-#endif
+        check_hresult((*(impl::inspectable_abi**)&object)->GetIids(impl::put_size_abi(value), put_abi(value)) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         return value;
     }
 
-    inline Windows::Foundation::TrustLevel get_trust_level(Windows::Foundation::IInspectable const& object)
+    inline Windows::Foundation::TrustLevel get_trust_level(Windows::Foundation::IInspectable const& object WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         Windows::Foundation::TrustLevel value{};
-#ifdef __cpp_lib_source_location
-        check_hresult((*(impl::inspectable_abi**)&object)->GetTrustLevel(&value), std::source_location::current());
-#else
-        check_hresult((*(impl::inspectable_abi**)&object)->GetTrustLevel(&value));
-#endif
+        check_hresult((*(impl::inspectable_abi**)&object)->GetTrustLevel(&value) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         return value;
     }
 }

--- a/strings/base_array.h
+++ b/strings/base_array.h
@@ -514,21 +514,33 @@ WINRT_EXPORT namespace winrt
     inline hstring get_class_name(Windows::Foundation::IInspectable const& object)
     {
         void* value{};
+#ifdef __cpp_lib_source_location
+        check_hresult((*(impl::inspectable_abi**)&object)->GetRuntimeClassName(&value), std::source_location::current());
+#else
         check_hresult((*(impl::inspectable_abi**)&object)->GetRuntimeClassName(&value));
+#endif
         return { value, take_ownership_from_abi };
     }
 
     inline com_array<guid> get_interfaces(Windows::Foundation::IInspectable const& object)
     {
         com_array<guid> value;
+#ifdef __cpp_lib_source_location
+        check_hresult((*(impl::inspectable_abi**)&object)->GetIids(impl::put_size_abi(value), put_abi(value)), std::source_location::current());
+#else
         check_hresult((*(impl::inspectable_abi**)&object)->GetIids(impl::put_size_abi(value), put_abi(value)));
+#endif
         return value;
     }
 
     inline Windows::Foundation::TrustLevel get_trust_level(Windows::Foundation::IInspectable const& object)
     {
         Windows::Foundation::TrustLevel value{};
+#ifdef __cpp_lib_source_location
+        check_hresult((*(impl::inspectable_abi**)&object)->GetTrustLevel(&value), std::source_location::current());
+#else
         check_hresult((*(impl::inspectable_abi**)&object)->GetTrustLevel(&value));
+#endif
         return value;
     }
 }

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -315,6 +315,16 @@ WINRT_EXPORT namespace winrt
             impl::load_runtime_function(L"combase.dll", "RoOriginateLanguageException", handler, fallback_RoOriginateLanguageException);
             WINRT_VERIFY(handler(code, message, nullptr));
 
+            if (winrt_throw_hresult_handler)
+            {
+#ifdef __cpp_lib_source_location
+                std::source_location sourceInformation = std::source_location::current();
+                winrt_throw_hresult_handler(sourceInformation.line(), sourceInformation.file_name(), sourceInformation.function_name(), WINRT_IMPL_RETURNADDRESS(), code);
+#else
+                winrt_throw_hresult_handler(0, nullptr, nullptr, WINRT_IMPL_RETURNADDRESS(), code);
+#endif
+            }
+
             com_ptr<impl::IErrorInfo> info;
             WINRT_VERIFY_(0, WINRT_IMPL_GetErrorInfo(0, info.put_void()));
             WINRT_VERIFY(info.try_as(m_info));
@@ -442,7 +452,6 @@ WINRT_EXPORT namespace winrt
         if (winrt_throw_hresult_handler)
         {
 #ifdef __cpp_lib_source_location
-            // line, filename, func
             winrt_throw_hresult_handler(sourceInformation.line(), sourceInformation.file_name(), sourceInformation.function_name(), WINRT_IMPL_RETURNADDRESS(), result);
 #else
             winrt_throw_hresult_handler(0, nullptr, nullptr, WINRT_IMPL_RETURNADDRESS(), result);

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -207,17 +207,17 @@ WINRT_EXPORT namespace winrt
             return *this;
         }
 
-        explicit hresult_error(hresult const code) noexcept : m_code(verify_error(code))
+        explicit hresult_error(hresult const code WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
-            originate(code, nullptr);
+            originate(code, nullptr WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
-        hresult_error(hresult const code, param::hstring const& message) noexcept : m_code(verify_error(code))
+        hresult_error(hresult const code, param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
-            originate(code, get_abi(message));
+            originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
-        hresult_error(hresult const code, take_ownership_from_abi_t) noexcept : m_code(verify_error(code))
+        hresult_error(hresult const code, take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
             com_ptr<impl::IErrorInfo> info;
             WINRT_IMPL_GetErrorInfo(0, info.put_void());
@@ -247,7 +247,7 @@ WINRT_EXPORT namespace winrt
                     message = impl::trim_hresult_message(legacy.get(), WINRT_IMPL_SysStringLen(legacy.get()));
                 }
 
-                originate(code, get_abi(message));
+                originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
             }
         }
 
@@ -309,7 +309,7 @@ WINRT_EXPORT namespace winrt
             return 1;
         }
 
-        void originate(hresult const code, void* message) noexcept
+        void originate(hresult const code, void* message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept
         {
             static int32_t(__stdcall* handler)(int32_t error, void* message, void* exception) noexcept;
             impl::load_runtime_function(L"combase.dll", "RoOriginateLanguageException", handler, fallback_RoOriginateLanguageException);
@@ -318,7 +318,6 @@ WINRT_EXPORT namespace winrt
             if (winrt_throw_hresult_handler)
             {
 #ifdef __cpp_lib_source_location
-                std::source_location sourceInformation = std::source_location::current();
                 winrt_throw_hresult_handler(sourceInformation.line(), sourceInformation.file_name(), sourceInformation.function_name(), WINRT_IMPL_RETURNADDRESS(), code);
 #else
                 winrt_throw_hresult_handler(0, nullptr, nullptr, WINRT_IMPL_RETURNADDRESS(), code);
@@ -354,101 +353,98 @@ WINRT_EXPORT namespace winrt
 
     struct hresult_access_denied : hresult_error
     {
-        hresult_access_denied() noexcept : hresult_error(impl::error_access_denied) {}
-        hresult_access_denied(param::hstring const& message) noexcept : hresult_error(impl::error_access_denied, message) {}
-        hresult_access_denied(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi) {}
+        hresult_access_denied(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_access_denied WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_access_denied(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_access_denied(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_wrong_thread : hresult_error
     {
-        hresult_wrong_thread() noexcept : hresult_error(impl::error_wrong_thread) {}
-        hresult_wrong_thread(param::hstring const& message) noexcept : hresult_error(impl::error_wrong_thread, message) {}
-        hresult_wrong_thread(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_wrong_thread, take_ownership_from_abi) {}
+        hresult_wrong_thread(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_wrong_thread WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_wrong_thread(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_wrong_thread, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_wrong_thread(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_wrong_thread, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_not_implemented : hresult_error
     {
-        hresult_not_implemented() noexcept : hresult_error(impl::error_not_implemented) {}
-        hresult_not_implemented(param::hstring const& message) noexcept : hresult_error(impl::error_not_implemented, message) {}
-        hresult_not_implemented(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_not_implemented, take_ownership_from_abi) {}
+        hresult_not_implemented(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_not_implemented WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_not_implemented(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_not_implemented, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_not_implemented(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_not_implemented, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_invalid_argument : hresult_error
     {
-        hresult_invalid_argument() noexcept : hresult_error(impl::error_invalid_argument) {}
-        hresult_invalid_argument(param::hstring const& message) noexcept : hresult_error(impl::error_invalid_argument, message) {}
-        hresult_invalid_argument(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_invalid_argument, take_ownership_from_abi) {}
+        hresult_invalid_argument(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_invalid_argument WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_invalid_argument(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_invalid_argument, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_invalid_argument(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_invalid_argument, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_out_of_bounds : hresult_error
     {
-        hresult_out_of_bounds() noexcept : hresult_error(impl::error_out_of_bounds) {}
-        hresult_out_of_bounds(param::hstring const& message) noexcept : hresult_error(impl::error_out_of_bounds, message) {}
-        hresult_out_of_bounds(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_out_of_bounds, take_ownership_from_abi) {}
+        hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_out_of_bounds WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_out_of_bounds, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_out_of_bounds(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_out_of_bounds, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_no_interface : hresult_error
     {
-        hresult_no_interface() noexcept : hresult_error(impl::error_no_interface) {}
-        hresult_no_interface(param::hstring const& message) noexcept : hresult_error(impl::error_no_interface, message) {}
-        hresult_no_interface(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_no_interface, take_ownership_from_abi) {}
+        hresult_no_interface(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_no_interface WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_no_interface(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_no_interface, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_no_interface(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_no_interface, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_class_not_available : hresult_error
     {
-        hresult_class_not_available() noexcept : hresult_error(impl::error_class_not_available) {}
-        hresult_class_not_available(param::hstring const& message) noexcept : hresult_error(impl::error_class_not_available, message) {}
-        hresult_class_not_available(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_available, take_ownership_from_abi) {}
+        hresult_class_not_available(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_class_not_available WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_class_not_available(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_class_not_available, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_class_not_available(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_class_not_available, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_class_not_registered : hresult_error
     {
-        hresult_class_not_registered() noexcept : hresult_error(impl::error_class_not_registered) {}
-        hresult_class_not_registered(param::hstring const& message) noexcept : hresult_error(impl::error_class_not_registered, message) {}
-        hresult_class_not_registered(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_class_not_registered, take_ownership_from_abi) {}
+        hresult_class_not_registered(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_class_not_registered WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_class_not_registered(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_class_not_registered, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_class_not_registered(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_class_not_registered, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_changed_state : hresult_error
     {
-        hresult_changed_state() noexcept : hresult_error(impl::error_changed_state) {}
-        hresult_changed_state(param::hstring const& message) noexcept : hresult_error(impl::error_changed_state, message) {}
-        hresult_changed_state(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_changed_state, take_ownership_from_abi) {}
+        hresult_changed_state(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_changed_state WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_changed_state(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_changed_state, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_changed_state(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_changed_state, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_illegal_method_call : hresult_error
     {
-        hresult_illegal_method_call() noexcept : hresult_error(impl::error_illegal_method_call) {}
-        hresult_illegal_method_call(param::hstring const& message) noexcept : hresult_error(impl::error_illegal_method_call, message) {}
-        hresult_illegal_method_call(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_illegal_method_call, take_ownership_from_abi) {}
+        hresult_illegal_method_call(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_illegal_method_call WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_method_call(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_method_call, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_method_call(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_method_call, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_illegal_state_change : hresult_error
     {
-        hresult_illegal_state_change() noexcept : hresult_error(impl::error_illegal_state_change) {}
-        hresult_illegal_state_change(param::hstring const& message) noexcept : hresult_error(impl::error_illegal_state_change, message) {}
-        hresult_illegal_state_change(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_illegal_state_change, take_ownership_from_abi) {}
+        hresult_illegal_state_change(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_illegal_state_change WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_state_change(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_state_change, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_state_change(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_state_change, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_illegal_delegate_assignment : hresult_error
     {
-        hresult_illegal_delegate_assignment() noexcept : hresult_error(impl::error_illegal_delegate_assignment) {}
-        hresult_illegal_delegate_assignment(param::hstring const& message) noexcept : hresult_error(impl::error_illegal_delegate_assignment, message) {}
-        hresult_illegal_delegate_assignment(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_illegal_delegate_assignment, take_ownership_from_abi) {}
+        hresult_illegal_delegate_assignment(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_illegal_delegate_assignment WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_delegate_assignment(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_delegate_assignment, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_illegal_delegate_assignment(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_illegal_delegate_assignment, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_canceled : hresult_error
     {
-        hresult_canceled() noexcept : hresult_error(impl::error_canceled) {}
-        hresult_canceled(param::hstring const& message) noexcept : hresult_error(impl::error_canceled, message) {}
-        hresult_canceled(take_ownership_from_abi_t) noexcept : hresult_error(impl::error_canceled, take_ownership_from_abi) {}
+        hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_canceled WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        hresult_canceled(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
-#ifdef __cpp_lib_source_location
-    [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result, std::source_location sourceInformation = std::source_location::current())
-#else
-    [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result)
-#endif
+    [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
+        // TODO - pragma detect mismatch on this
         if (winrt_throw_hresult_handler)
         {
 #ifdef __cpp_lib_source_location
@@ -589,87 +585,53 @@ WINRT_EXPORT namespace winrt
         }
     }
 
-#ifdef __cpp_lib_source_location
-    [[noreturn]] inline void throw_last_error(std::source_location sourceInformation = std::source_location::current())
+    [[noreturn]] inline void throw_last_error(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM)
     {
-        throw_hresult(impl::hresult_from_win32(WINRT_IMPL_GetLastError()), sourceInformation);
+        throw_hresult(impl::hresult_from_win32(WINRT_IMPL_GetLastError()) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
     }
 
-    inline hresult check_hresult(hresult const result, std::source_location sourceInformation = std::source_location::current())
+    inline hresult check_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (result < 0)
         {
-            throw_hresult(result, sourceInformation);
+            throw_hresult(result WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
         return result;
     }
 
     template<typename T>
-    void check_nt(T result, std::source_location sourceInformation = std::source_location::current())
+    void check_nt(T result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (result != 0)
         {
-            throw_hresult(impl::hresult_from_nt(result), sourceInformation);
+            throw_hresult(impl::hresult_from_nt(result) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
     }
 
     template<typename T>
-    void check_win32(T result, std::source_location sourceInformation = std::source_location::current())
+    void check_win32(T result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (result != 0)
         {
-            throw_hresult(impl::hresult_from_win32(result), sourceInformation);
-        }
-    }
-#else
-    [[noreturn]] inline void throw_last_error()
-    {
-        throw_hresult(impl::hresult_from_win32(WINRT_IMPL_GetLastError()));
-    }
-
-    inline hresult check_hresult(hresult const result)
-    {
-        if (result < 0)
-        {
-            throw_hresult(result);
-        }
-        return result;
-    }
-
-    template<typename T>
-    void check_nt(T result)
-    {
-        if (result != 0)
-        {
-            throw_hresult(impl::hresult_from_nt(result));
+            throw_hresult(impl::hresult_from_win32(result) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
     }
 
     template<typename T>
-    void check_win32(T result)
-    {
-        if (result != 0)
-        {
-            throw_hresult(impl::hresult_from_win32(result));
-        }
-    }
-#endif
-
-    template<typename T>
-    void check_bool(T result)
+    void check_bool(T result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (!result)
         {
-            winrt::throw_last_error();
+            winrt::throw_last_error(WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM);
         }
     }
 
     template<typename T>
-    T* check_pointer(T* pointer)
+    T* check_pointer(T* pointer WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (!pointer)
         {
-            throw_last_error();
+            throw_last_error(WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM);
         }
 
         return pointer;
@@ -686,11 +648,11 @@ WINRT_EXPORT namespace winrt
 
 namespace winrt::impl
 {
-    inline hresult check_hresult_allow_bounds(hresult const result)
+    inline hresult check_hresult_allow_bounds(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
         if (result != impl::error_out_of_bounds && result != impl::error_fail && result != impl::error_file_not_found)
         {
-            check_hresult(result);
+            check_hresult(result WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
         return result;
     }

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -315,6 +315,9 @@ WINRT_EXPORT namespace winrt
             impl::load_runtime_function(L"combase.dll", "RoOriginateLanguageException", handler, fallback_RoOriginateLanguageException);
             WINRT_VERIFY(handler(code, message, nullptr));
 
+            // This is an extension point that can be filled in by other libraries (such as WIL) to get call outs when errors are
+            // originated.  This is intended for logging purposes.  When possible include the std::source_information so that accurate
+            // information is available on the caller who generated the error.
             if (winrt_throw_hresult_handler)
             {
 #ifdef __cpp_lib_source_location
@@ -444,7 +447,6 @@ WINRT_EXPORT namespace winrt
 
     [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)
     {
-        // TODO - pragma detect mismatch on this
         if (winrt_throw_hresult_handler)
         {
 #ifdef __cpp_lib_source_location

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -463,70 +463,70 @@ WINRT_EXPORT namespace winrt
 
         if (result == impl::error_access_denied)
         {
-            throw hresult_access_denied(take_ownership_from_abi);
+            throw hresult_access_denied(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_wrong_thread)
         {
-            throw hresult_wrong_thread(take_ownership_from_abi);
+            throw hresult_wrong_thread(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_not_implemented)
         {
-            throw hresult_not_implemented(take_ownership_from_abi);
+            throw hresult_not_implemented(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_invalid_argument)
         {
-            throw hresult_invalid_argument(take_ownership_from_abi);
+            throw hresult_invalid_argument(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_out_of_bounds)
         {
-            throw hresult_out_of_bounds(take_ownership_from_abi);
+            throw hresult_out_of_bounds(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_no_interface)
         {
-            throw hresult_no_interface(take_ownership_from_abi);
+            throw hresult_no_interface(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_class_not_available)
         {
-            throw hresult_class_not_available(take_ownership_from_abi);
+            throw hresult_class_not_available(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_class_not_registered)
         {
-            throw hresult_class_not_registered(take_ownership_from_abi);
+            throw hresult_class_not_registered(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_changed_state)
         {
-            throw hresult_changed_state(take_ownership_from_abi);
+            throw hresult_changed_state(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_illegal_method_call)
         {
-            throw hresult_illegal_method_call(take_ownership_from_abi);
+            throw hresult_illegal_method_call(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_illegal_state_change)
         {
-            throw hresult_illegal_state_change(take_ownership_from_abi);
+            throw hresult_illegal_state_change(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_illegal_delegate_assignment)
         {
-            throw hresult_illegal_delegate_assignment(take_ownership_from_abi);
+            throw hresult_illegal_delegate_assignment(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
         if (result == impl::error_canceled)
         {
-            throw hresult_canceled(take_ownership_from_abi);
+            throw hresult_canceled(take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
-        throw hresult_error(result, take_ownership_from_abi);
+        throw hresult_error(result, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD);
     }
 
     inline WINRT_IMPL_NOINLINE hresult to_hresult() noexcept

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -28,6 +28,10 @@
 #include <format>
 #endif
 
+#ifdef __cpp_lib_source_location
+#include <source_location>
+#endif
+
 #ifdef __cpp_lib_coroutine
 
 #include <coroutine>

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -60,6 +60,7 @@ typedef struct _GUID GUID;
 // result any public-facing method that can result in an error needs a default-constructed source_location argument.  Because
 // this type does not exist in C++17 we need to use a macro to optionally add parameters and forwarding wherever appropriate.
 #ifdef __cpp_lib_source_location
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT , std::source_location sourceInformation
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS , std::source_location sourceInformation = std::source_location::current()
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM std::source_location sourceInformation = std::source_location::current()
 
@@ -68,6 +69,7 @@ typedef struct _GUID GUID;
 
 #pragma detect_mismatch("WINRT_SOURCE_LOCATION", "true")
 #else
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM
 

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -54,3 +54,25 @@
 struct IUnknown;
 typedef struct _GUID GUID;
 #endif
+
+// std::source_location is a C++20 feature, which is above the C++17 feature floor for cppwinrt.  The source location needs
+// to be the calling code, not cppwinrt itself, so that it is useful to developers building on top of this library.  As a
+// result any public-facing method that can result in an error needs a default-constructed source_location argument.  Because
+// this type does not exist in C++17 we need to use a macro to optionally add parameters and forwarding wherever appropriate.
+#ifdef __cpp_lib_source_location
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS , std::source_location sourceInformation = std::source_location::current()
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM std::source_location sourceInformation = std::source_location::current()
+
+#define WINRT_IMPL_SOURCE_LOCATION_FORWARD , sourceInformation
+#define WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM sourceInformation
+
+#pragma detect_mismatch("WINRT_SOURCE_LOCATION", "true")
+#else
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM
+
+#define WINRT_IMPL_SOURCE_LOCATION_FORWARD
+#define WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM
+
+#pragma detect_mismatch("WINRT_SOURCE_LOCATION", "false")
+#endif

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -1,11 +1,7 @@
 
 WINRT_EXPORT namespace winrt
 {
-#ifdef __cpp_lib_source_location
-    hresult check_hresult(hresult const result, std::source_location sourceInformation);
-#else
-    hresult check_hresult(hresult const result);
-#endif
+    hresult check_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT);
     hresult to_hresult() noexcept;
 
     template <typename D, typename I>

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -1,7 +1,11 @@
 
 WINRT_EXPORT namespace winrt
 {
+#ifdef __cpp_lib_source_location
+    hresult check_hresult(hresult const result, std::source_location sourceInformation);
+#else
     hresult check_hresult(hresult const result);
+#endif
     hresult to_hresult() noexcept;
 
     template <typename D, typename I>

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -59,7 +59,11 @@ namespace
 
     void __stdcall logger(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept
     {
-        lineNumber; fileName; functionName;
+        // In C++17 these fields cannot be filled in so they are expected to be empty.
+        REQUIRE(lineNumber == 0);
+        REQUIRE(fileName == nullptr);
+        REQUIRE(functionName == nullptr);
+
         REQUIRE(returnAddress);
         REQUIRE(result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
         s_loggerCalled = true;

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -1,0 +1,33 @@
+#include "pch.h"
+
+using namespace winrt;
+using namespace Windows::Foundation;
+
+namespace
+{
+    static bool s_loggerCalled = false;
+
+    void __stdcall logger(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept
+    {
+        lineNumber; fileName; functionName;
+        REQUIRE(returnAddress);
+        REQUIRE(result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
+        s_loggerCalled = true;
+    }
+}
+
+TEST_CASE("custom_error_logger")
+{
+    // Set up global handler
+    REQUIRE(!s_loggerCalled);
+    REQUIRE(!winrt_throw_hresult_handler);
+    winrt_throw_hresult_handler = logger;
+
+    // Validate that handler translated exception
+    REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
+    REQUIRE(s_loggerCalled);
+
+    // Remove global handler
+    winrt_throw_hresult_handler = nullptr;
+    s_loggerCalled = false;
+}

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -7,8 +7,25 @@ namespace
 {
     static bool s_loggerCalled = false;
 
+    // Note that we are checking that the source line number matches expectations.  If lines above this are changed
+    // then this value needs to change as well.
+    void FailOnLine15()
+    {
+        // Validate that handler translated exception
+        REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
+    }
+
     void __stdcall logger(uint32_t lineNumber, char const* fileName, char const* functionName, void* returnAddress, winrt::hresult const result) noexcept
     {
+        // In C++20 these fields should be filled in by std::source_location
+        REQUIRE(lineNumber == 15);
+        const auto fileNameSv = std::string_view(fileName);
+        REQUIRE(!fileNameSv.empty());
+        REQUIRE(fileNameSv.find("custom_error.cpp") != std::string::npos);
+        const auto functionNameSv = std::string_view(functionName);
+        REQUIRE(!functionNameSv.empty());
+        REQUIRE(functionNameSv == "FailOnLine15");
+
         lineNumber; fileName; functionName;
         REQUIRE(returnAddress);
         REQUIRE(result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
@@ -23,8 +40,7 @@ TEST_CASE("custom_error_logger")
     REQUIRE(!winrt_throw_hresult_handler);
     winrt_throw_hresult_handler = logger;
 
-    // Validate that handler translated exception
-    REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
+    FailOnLine15();
     REQUIRE(s_loggerCalled);
 
     // Remove global handler

--- a/test/test_cpp20/pch.h
+++ b/test/test_cpp20/pch.h
@@ -11,4 +11,6 @@
 #include <winstring.h>
 #include "catch.hpp"
 
+#include <string_view>
+
 using namespace std::literals;

--- a/test/test_cpp20/test_cpp20.vcxproj
+++ b/test/test_cpp20/test_cpp20.vcxproj
@@ -42,6 +42,9 @@
     <CppWinRTLanguageStandard>stdcpp20</CppWinRTLanguageStandard>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/test/test_cpp20/test_cpp20.vcxproj
+++ b/test/test_cpp20/test_cpp20.vcxproj
@@ -116,6 +116,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,6 +138,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,6 +158,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -175,6 +178,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -194,6 +198,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -215,6 +220,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -238,6 +244,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -261,6 +268,7 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -281,6 +289,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="await_completed.cpp" />
+    <ClCompile Include="custom_error.cpp" />
     <ClCompile Include="format.cpp" />
     <ClCompile Include="hstring.cpp" />
     <ClCompile Include="main.cpp">

--- a/test/test_cpp20/test_cpp20.vcxproj
+++ b/test/test_cpp20/test_cpp20.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{5FF6CD6C-515A-4D55-97B6-62AD9BCB77EA}</ProjectGuid>
     <RootNamespace>unittests</RootNamespace>
     <ProjectName>test_cpp20</ProjectName>
-    <CppWinRTLanguageStandard>latest</CppWinRTLanguageStandard>
+    <CppWinRTLanguageStandard>stdcpp20</CppWinRTLanguageStandard>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -116,7 +116,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -138,7 +137,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,7 +156,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -178,7 +175,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -198,7 +194,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -220,7 +215,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -244,7 +238,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -268,7 +261,6 @@
       <AdditionalIncludeDirectories>$(OutputPath);Generated Files;..\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Closes #1184

## Why is this change being made?
This change is being made to (greatly!) improve the error logging for exceptions that originate in cppwinrt.  This is especially directed at the cases where cppwinrt and WIL are interoperating.  The extension point between them has the ability to forward the file name, line number, and function name across to be logged.  They always pass null.

With C++20 and `std::source_location` specifically that can change.  It is possible to capture that information in a standards-compliant way and forward it along to be logged.  The result is __vastly__ improved WIL logging output.

## Briefly summarize what changed
Unfortunately this change is a bit ugly and requires macros.  The reason for that is because `std::source_location` is new in C++20 and because it must be constructed by the code that is calling into cppwinrt headers.  The support floor for cppwinrt is C++17 so this type needs to be behind an `#ifdef`.  That is what leads to the macros (which evaluate to nothing for C++17).

The second bit of ugliness is that the calling code must be what constructs the `std::source_location`.  Otherwise it will get the source information for cppwinrt itself which is not helpful.  This is achieved with a default parameter for every method that can originate an error.  The caller silently constructs it before the call so it has accurate source information.  For cases where errors hop a few times this must be forwarded so it is not lost.

Other miscellaneous changes include:
* The test_cpp20 project was updated to the VS2022 toolset.  The VS2019 toolset has an Internal Compiler Error (ICE) when building C++20 code.  The crash is gone in newer versions.
* The test_cpp20 project now requests C++20 (not C++/latest).
* `hresult_error::originate` will now call `winrt_throw_hesult_handler` if it is provided.  Previously `throw winrt::hresult_error(E_WHATEVER)` would not log to WIL.  Now it does.
* `#pragma detect mismatch` for whether `std::source_location` is being used, or not.

## How was this change tested?
A new test file was added to the C++20 test binary.  This test ensures that the source information is accurate (and in fact caught a subtle bug when the test was being written!).