### PR TITLE
Make guid constexpr on clang, improve error reporting

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -26,6 +26,10 @@
 
   <PropertyGroup Condition="'$(Clang)'=='1'">
     <PlatformToolset>ClangCL</PlatformToolset>
+    <!-- The experimental coroutines aren't supported under Clang -->
+    <CppWinRTLanguageStandard>20</CppWinRTLanguageStandard>
+    <!-- Disable vcpkg autolink because it's not compatible with lld-link -->
+    <VcpkgAutoLink>false</VcpkgAutoLink>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -50,7 +54,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/bigobj</AdditionalOptions>
       <AdditionalOptions Condition="'$(CppWinRTLanguageStandard)'==''">/await %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Clang)'=='1'">-Wno-unused-command-line-argument -fno-delayed-template-parsing -Xclang -fcoroutines-ts -mcx16</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Clang)'=='1'">-Wno-unused-command-line-argument -fno-delayed-template-parsing -mcx16</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>onecore.lib</AdditionalDependencies>

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -25,8 +25,7 @@
   -->
 
   <PropertyGroup Condition="'$(Clang)'=='1'">
-    <CLToolExe>clang-cl.exe</CLToolExe>
-    <CLToolPath>C:\Program Files\LLVM\bin</CLToolPath>
+    <PlatformToolset>ClangCL</PlatformToolset>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/natvis/cppwinrtvisualizer.vcxproj
+++ b/natvis/cppwinrtvisualizer.vcxproj
@@ -105,10 +105,9 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;WIN32;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalOptions>/await</AdditionalOptions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ResourceCompile>
@@ -131,11 +130,10 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/await</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -156,11 +154,10 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/await</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -183,11 +180,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;WIN32;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/await</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -213,11 +209,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/await</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -243,11 +238,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/await</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -458,12 +458,8 @@ namespace winrt::impl
     };
 
     template <typename T>
-#ifdef __clang__
-    inline static const auto name_v
-#else
 #pragma warning(suppress: 4307)
     inline constexpr auto name_v
-#endif
     {
         combine
         (

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -118,17 +118,23 @@ namespace winrt::impl
     };
 
     template <typename T>
+    struct classic_com_guid
+    {
 #if defined(__clang__)
 #if __has_declspec_attribute(uuid) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
-    inline const guid guid_v{ __uuidof(T) };
+        static constexpr guid value{ __uuidof(T) };
 #else
-    inline constexpr guid guid_v{};
+        static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must #include <unknwn.h> before including C++/WinRT headers.");
 #endif
-#elif defined(_MSC_VER) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
-    inline constexpr guid guid_v{ __uuidof(T) };
+#elif defined(_MSC_VER)
+        static constexpr guid value{ __uuidof(T) }; 
 #else
-    inline constexpr guid guid_v{};
+        static_assert(std::is_void_v<T> /* dependent_false */, "Classic COM interfaces are not supported on this compiler");
 #endif
+    };
+
+    template <typename T>
+    inline constexpr guid guid_v = classic_com_guid<T>::value;
 
     template <typename T>
     constexpr auto to_underlying_type(T const value) noexcept

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -117,24 +117,23 @@ namespace winrt::impl
         static constexpr auto data{ category_signature<category_t<T>, T>::data };
     };
 
+#if defined(__clang__)
     template <typename T>
     struct classic_com_guid
     {
-#if defined(__clang__)
 #if __has_declspec_attribute(uuid) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
         static constexpr guid value{ __uuidof(T) };
 #else
         static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must compile with -fms-extensions and include <unknwn.h> before including C++/WinRT headers.");
 #endif
-#elif defined(_MSC_VER)
-        static constexpr guid value{ __uuidof(T) };
-#else
-        static_assert(std::is_void_v<T> /* dependent_false */, "Classic COM interfaces are not supported on this compiler");
-#endif
     };
 
     template <typename T>
     inline constexpr guid guid_v = classic_com_guid<T>::value;
+#else
+    template <typename T>
+    inline constexpr guid guid_v{ __uuidof(T) };
+#endif
 
     template <typename T>
     constexpr auto to_underlying_type(T const value) noexcept

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -127,7 +127,7 @@ namespace winrt::impl
         static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must #include <unknwn.h> before including C++/WinRT headers.");
 #endif
 #elif defined(_MSC_VER)
-        static constexpr guid value{ __uuidof(T) }; 
+        static constexpr guid value{ __uuidof(T) };
 #else
         static_assert(std::is_void_v<T> /* dependent_false */, "Classic COM interfaces are not supported on this compiler");
 #endif

--- a/test/test/generic_types.cpp
+++ b/test/test/generic_types.cpp
@@ -8,9 +8,5 @@ TEST_CASE("generic_types")
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.Uri", Uri);
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.PropertyType", PropertyType);
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.Point", Point);
-
-    // Clang 9 doesn't think this is a constant expression.
-#ifndef __clang__
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.IStringable", IStringable);
-#endif
 }

--- a/test/test_win7/generic_types.cpp
+++ b/test/test_win7/generic_types.cpp
@@ -8,9 +8,5 @@ TEST_CASE("generic_types")
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.Uri", Uri);
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.PropertyType", PropertyType);
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.Point", Point);
-
-    // Clang 9 doesn't think this is a constant expression.
-#ifndef __clang__
     REQUIRE_EQUAL_NAME(L"Windows.Foundation.IStringable", IStringable);
-#endif
 }


### PR DESCRIPTION
This makes `guid_v` (and by extension `name_v`) constexpr on Clang, improves the error reporting when `unknwn.h` is not included before `winrt/base.h` (gives a compile-time error instead of an empty GUID and potential ODR violations), and finally brings back the ability to use classic COM without including `unknwn.h` before `winrt/base.h` on MSVC.
 
Fixes #1186 