### PR TITLE
Fix gcc build (and anyone else who doesn't support __uuidof)

### DIFF
--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -130,9 +130,12 @@ namespace winrt::impl
 
     template <typename T>
     inline constexpr guid guid_v = classic_com_guid<T>::value;
-#else
+#elif defined(_MSC_VER) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
     template <typename T>
     inline constexpr guid guid_v{ __uuidof(T) };
+#else
+    template <typename T>
+    inline constexpr guid guid_v{};
 #endif
 
     template <typename T>


### PR DESCRIPTION
Say `__uuidof` only if the compiler supports it as an intrinsic. Otherwise you get "undefined symbol" errors, even if the template is never invoked.

In theory we could add a `static_assert` to warn the user if they try to use `guid_v<T>` on a classic COM interface, but that would reintroduce the MSVC regression with complex templates. So we return to old behavior where `guid_v<T>` without classic COM support just produces the zero GUID.