### PR TITLE
Fix classic COM errors on non-supported compilers

### DIFF
--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -123,34 +123,28 @@ namespace winrt::impl
 #ifdef __clang__
 #if !__has_declspec_attribute(uuid)
         static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must compile with -fms-extensions.");
-#endif 
 #endif
 
-#if defined(_MSC_VER) || defined(__clang__)
 #ifndef WINRT_IMPL_IUNKNOWN_DEFINED
         static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must include <unknwn.h> before including C++/WinRT headers.");
 #endif
-#else
+#else // MSVC won't hit this struct, so we can safely assume everything that isn't Clang isn't supported
         static_assert(std::is_void_v<T> /* dependent_false */, "Classic COM interfaces are not supported with this compiler.");
 #endif
     };
 
     template <typename T>
-#ifdef WINRT_IMPL_IUNKNOWN_DEFINED
 #ifdef __clang__
-#if __has_declspec_attribute(uuid)
+#if __has_declspec_attribute(uuid) && defined(WINRT_IMPL_IUNKNOWN_DEFINED)
     inline constexpr guid guid_v{ __uuidof(T) };
 #else
     inline constexpr guid guid_v = classic_com_guid_error<T>::value;
-#endif // __has_declspec_attribute(uuid)
+#endif
 #elif defined(_MSC_VER)
     inline constexpr guid guid_v{ __uuidof(T) };
 #else
     inline constexpr guid guid_v = classic_com_guid_error<T>::value;
-#endif // __clang__
-#else
-    inline constexpr guid guid_v = classic_com_guid_error<T>::value;
-#endif // WINRT_IMPL_IUNKNOWN_DEFINED
+#endif
 
     template <typename T>
     constexpr auto to_underlying_type(T const value) noexcept


### PR DESCRIPTION
Also, enable fast path for Clang and give friendlier errors to MSVC.

Testing the `__has_declspec_attribute` path revealed to be a bit tricky, because a bunch of CRT headers rely on MS extensions. I ended up passing `-fno-declspec` to disable `__declspec` specifically and then adding `#define __declspec(x)` to no-op all the `__declspec` in the CRT headers and cppwinrt. This finally gave the desired error:
```
_build\x64\Debug\winrt/base.h(688,9): error: static_assert failed due to requirement 'std::is_void_v<IClassFactory>' "To use classic COM interfaces, you must compile with -fms-extensions."
        static_assert(std::is_void_v<T> /* dependent_false */, "To use classic COM interfaces, you must compile with -fms-extensions.");
        ^             ~~~~~~~~~~~~~~~~~
```