### PR TITLE
Improve compatibility with mingw-w64 in generated headers

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -765,7 +765,7 @@ namespace cppwinrt
         {
             auto format = R"(    template <> struct abi<%>
     {
-        struct __declspec(novtable) type : inspectable_abi
+        struct WINRT_IMPL_NOVTABLE type : inspectable_abi
         {
 )";
 
@@ -775,7 +775,7 @@ namespace cppwinrt
         {
             auto format = R"(    template <%> struct abi<%>
     {
-        struct __declspec(novtable) type : inspectable_abi
+        struct WINRT_IMPL_NOVTABLE type : inspectable_abi
         {
 )";
 
@@ -816,7 +816,7 @@ namespace cppwinrt
     {
         auto format = R"(    template <%> struct abi<%>
     {
-        struct __declspec(novtable) type : unknown_abi
+        struct WINRT_IMPL_NOVTABLE type : unknown_abi
         {
             virtual int32_t __stdcall Invoke(%) noexcept = 0;
         };

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -348,7 +348,7 @@ namespace cppwinrt
             return;
         }
 
-        auto format = R"(    template <%> struct __declspec(empty_bases) %;
+        auto format = R"(    template <%> struct WINRT_IMPL_EMPTY_BASES %;
 )";
 
         w.write(format,
@@ -1962,7 +1962,7 @@ namespace cppwinrt
     static void write_dispatch_overridable(writer& w, TypeDef const& class_type)
     {
         auto format = R"(template <typename T, typename D>
-struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
+struct WINRT_IMPL_EMPTY_BASES produce_dispatch_to_overridable<T, D, %>
     : produce_dispatch_to_overridable_base<T, D, %>
 {
 %};
@@ -2378,7 +2378,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
 
         if (empty(generics))
         {
-            auto format = R"(    struct __declspec(empty_bases) % :
+            auto format = R"(    struct WINRT_IMPL_EMPTY_BASES % :
         winrt::Windows::Foundation::IInspectable,
         impl::consume_t<%>%
     {
@@ -2401,7 +2401,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
             type_name = remove_tick(type_name);
 
             auto format = R"(    template <%>
-    struct __declspec(empty_bases) % :
+    struct WINRT_IMPL_EMPTY_BASES % :
         winrt::Windows::Foundation::IInspectable,
         impl::consume_t<%>%
     {%
@@ -3147,7 +3147,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         auto type_name = type.TypeName();
         auto factories = get_factories(w, type);
 
-        auto format = R"(    struct __declspec(empty_bases) % : %%%
+        auto format = R"(    struct WINRT_IMPL_EMPTY_BASES % : %%%
     {
         %(std::nullptr_t) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : %(ptr, take_ownership_from_abi) {}
@@ -3172,7 +3172,7 @@ struct __declspec(empty_bases) produce_dispatch_to_overridable<T, D, %>
         auto type_name = type.TypeName();
         auto factories = get_factories(w, type);
 
-        auto format = R"(    struct __declspec(empty_bases) % : %%
+        auto format = R"(    struct WINRT_IMPL_EMPTY_BASES % : %%
     {
         %(std::nullptr_t) noexcept {}
         %(void* ptr, take_ownership_from_abi_t) noexcept : %(ptr, take_ownership_from_abi) {}

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -743,7 +743,7 @@ catch (...) { return winrt::to_hresult(); }
             auto format = R"(namespace winrt::@::implementation
 {
     template <typename D%, typename... I>
-    struct __declspec(empty_bases) %_base : implements<D, @::%%%, %I...>%%%
+    struct WINRT_IMPL_EMPTY_BASES %_base : implements<D, @::%%%, %I...>%%%
     {
         using base_type = %_base;
         using class_type = @::%;
@@ -836,7 +836,7 @@ catch (...) { return winrt::to_hresult(); }
             auto format = R"(namespace winrt::@::factory_implementation
 {
     template <typename D, typename T, typename... I>
-    struct __declspec(empty_bases) %T : implements<D, winrt::Windows::Foundation::IActivationFactory%, I...>
+    struct WINRT_IMPL_EMPTY_BASES %T : implements<D, winrt::Windows::Foundation::IActivationFactory%, I...>
     {
         using instance_type = @::%;
 

--- a/strings/base_abi.h
+++ b/strings/base_abi.h
@@ -3,7 +3,7 @@ namespace winrt::impl
 {
     template <> struct abi<Windows::Foundation::IUnknown>
     {
-        struct __declspec(novtable) type
+        struct WINRT_IMPL_NOVTABLE type
         {
             virtual int32_t __stdcall QueryInterface(guid const& id, void** object) noexcept = 0;
             virtual uint32_t __stdcall AddRef() noexcept = 0;
@@ -15,7 +15,7 @@ namespace winrt::impl
 
     template <> struct abi<Windows::Foundation::IInspectable>
     {
-        struct __declspec(novtable) type : unknown_abi
+        struct WINRT_IMPL_NOVTABLE type : unknown_abi
         {
             virtual int32_t __stdcall GetIids(uint32_t* count, guid** ids) noexcept = 0;
             virtual int32_t __stdcall GetRuntimeClassName(void** name) noexcept = 0;
@@ -27,20 +27,20 @@ namespace winrt::impl
 
     template <> struct abi<Windows::Foundation::IActivationFactory>
     {
-        struct __declspec(novtable) type : inspectable_abi
+        struct WINRT_IMPL_NOVTABLE type : inspectable_abi
         {
             virtual int32_t __stdcall ActivateInstance(void** instance) noexcept = 0;
         };
     };
 
-    struct __declspec(novtable) IAgileObject : unknown_abi {};
+    struct WINRT_IMPL_NOVTABLE IAgileObject : unknown_abi {};
 
-    struct __declspec(novtable) IAgileReference : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IAgileReference : unknown_abi
     {
         virtual int32_t __stdcall Resolve(guid const& id, void** object) noexcept = 0;
     };
 
-    struct __declspec(novtable) IMarshal : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IMarshal : unknown_abi
     {
         virtual int32_t __stdcall GetUnmarshalClass(guid const& riid, void* pv, uint32_t dwDestContext, void* pvDestContext, uint32_t mshlflags, guid* pCid) noexcept = 0;
         virtual int32_t __stdcall GetMarshalSizeMax(guid const& riid, void* pv, uint32_t dwDestContext, void* pvDestContext, uint32_t mshlflags, uint32_t* pSize) noexcept = 0;
@@ -50,20 +50,20 @@ namespace winrt::impl
         virtual int32_t __stdcall DisconnectObject(uint32_t dwReserved) noexcept = 0;
     };
 
-    struct __declspec(novtable) IGlobalInterfaceTable : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IGlobalInterfaceTable : unknown_abi
     {
         virtual int32_t __stdcall RegisterInterfaceInGlobal(void* object, guid const& iid, uint32_t* cookie) noexcept = 0;
         virtual int32_t __stdcall RevokeInterfaceFromGlobal(uint32_t cookie) noexcept = 0;
         virtual int32_t __stdcall GetInterfaceFromGlobal(uint32_t cookie, guid const& iid, void** object) noexcept = 0;
     };
 
-    struct __declspec(novtable) IStaticLifetime : inspectable_abi
+    struct WINRT_IMPL_NOVTABLE IStaticLifetime : inspectable_abi
     {
         virtual int32_t __stdcall unused() noexcept = 0;
         virtual int32_t __stdcall GetCollection(void** value) noexcept = 0;
     };
 
-    struct __declspec(novtable) IStaticLifetimeCollection : inspectable_abi
+    struct WINRT_IMPL_NOVTABLE IStaticLifetimeCollection : inspectable_abi
     {
         virtual int32_t __stdcall Lookup(void*, void**) noexcept = 0;
         virtual int32_t __stdcall unused() noexcept = 0;
@@ -74,23 +74,23 @@ namespace winrt::impl
         virtual int32_t __stdcall unused4() noexcept = 0;
     };
 
-    struct __declspec(novtable) IWeakReference : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IWeakReference : unknown_abi
     {
         virtual int32_t __stdcall Resolve(guid const& iid, void** objectReference) noexcept = 0;
     };
 
-    struct __declspec(novtable) IWeakReferenceSource : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IWeakReferenceSource : unknown_abi
     {
         virtual int32_t __stdcall GetWeakReference(IWeakReference** weakReference) noexcept = 0;
     };
 
-    struct __declspec(novtable) IRestrictedErrorInfo : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IRestrictedErrorInfo : unknown_abi
     {
         virtual int32_t __stdcall GetErrorDetails(bstr* description, int32_t* error, bstr* restrictedDescription, bstr* capabilitySid) noexcept = 0;
         virtual int32_t __stdcall GetReference(bstr* reference) noexcept = 0;
     };
 
-    struct __declspec(novtable) IErrorInfo : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IErrorInfo : unknown_abi
     {
         virtual int32_t __stdcall GetGUID(guid* value) noexcept = 0;
         virtual int32_t __stdcall GetSource(bstr* value) noexcept = 0;
@@ -99,7 +99,7 @@ namespace winrt::impl
         virtual int32_t __stdcall GetHelpContext(uint32_t* value) noexcept = 0;
     };
 
-    struct __declspec(novtable) ILanguageExceptionErrorInfo2 : unknown_abi
+    struct WINRT_IMPL_NOVTABLE ILanguageExceptionErrorInfo2 : unknown_abi
     {
         virtual int32_t __stdcall GetLanguageException(void** exception) noexcept = 0;
         virtual int32_t __stdcall GetPreviousLanguageExceptionErrorInfo(ILanguageExceptionErrorInfo2** previous) noexcept = 0;
@@ -109,12 +109,12 @@ namespace winrt::impl
 
     struct ICallbackWithNoReentrancyToApplicationSTA;
 
-    struct __declspec(novtable) IContextCallback : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IContextCallback : unknown_abi
     {
         virtual int32_t __stdcall ContextCallback(int32_t(__stdcall* callback)(com_callback_args*), com_callback_args* args, guid const& iid, int method, void* reserved) noexcept = 0;
     };
 
-    struct __declspec(novtable) IServerSecurity : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IServerSecurity : unknown_abi
     {
         virtual int32_t __stdcall QueryBlanket(uint32_t*, uint32_t*, wchar_t**, uint32_t*, uint32_t*, void**, uint32_t*) noexcept = 0;
         virtual int32_t __stdcall ImpersonateClient() noexcept = 0;
@@ -122,12 +122,12 @@ namespace winrt::impl
         virtual int32_t __stdcall IsImpersonating() noexcept = 0;
     };
 
-    struct __declspec(novtable) IBufferByteAccess : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IBufferByteAccess : unknown_abi
     {
         virtual int32_t __stdcall Buffer(uint8_t** value) noexcept = 0;
     };
 
-    struct __declspec(novtable) IMemoryBufferByteAccess : unknown_abi
+    struct WINRT_IMPL_NOVTABLE IMemoryBufferByteAccess : unknown_abi
     {
         virtual int32_t __stdcall GetBuffer(uint8_t** value, uint32_t* capacity) noexcept = 0;
     };

--- a/strings/base_composable.h
+++ b/strings/base_composable.h
@@ -27,7 +27,7 @@ namespace winrt::impl
     };
 
     template <typename T, typename D, typename I>
-    class __declspec(empty_bases) produce_dispatch_to_overridable_base
+    class WINRT_IMPL_EMPTY_BASES produce_dispatch_to_overridable_base
     {
     protected:
         D& shim() noexcept

--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -151,7 +151,7 @@ namespace winrt::impl
     };
 
     template <typename R, typename... Args>
-    struct __declspec(empty_bases) delegate_base : Windows::Foundation::IUnknown
+    struct WINRT_IMPL_EMPTY_BASES delegate_base : Windows::Foundation::IUnknown
     {
         delegate_base(std::nullptr_t = nullptr) noexcept {}
         delegate_base(void* ptr, take_ownership_from_abi_t) noexcept : IUnknown(ptr, take_ownership_from_abi) {}
@@ -201,13 +201,13 @@ namespace winrt::impl
 WINRT_EXPORT namespace winrt
 {
     template <typename... Args>
-    struct __declspec(empty_bases) delegate : impl::delegate_base<void, Args...>
+    struct WINRT_IMPL_EMPTY_BASES delegate : impl::delegate_base<void, Args...>
     {
         using impl::delegate_base<void, Args...>::delegate_base;
     };
 
     template <typename R, typename... Args>
-    struct __declspec(empty_bases) delegate<R(Args...)> : impl::delegate_base<R, Args...>
+    struct WINRT_IMPL_EMPTY_BASES delegate<R(Args...)> : impl::delegate_base<R, Args...>
     {
         using impl::delegate_base<R, Args...>::delegate_base;
     };

--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -91,7 +91,7 @@ namespace winrt::impl
     }
 
     template <typename R, typename... Args>
-    struct __declspec(novtable) variadic_delegate_abi : unknown_abi
+    struct WINRT_IMPL_NOVTABLE variadic_delegate_abi : unknown_abi
     {
         virtual R invoke(Args const& ...) = 0;
     };

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -1,6 +1,5 @@
 
 #if defined(_MSC_VER)
-#include <intrin.h>
 #define WINRT_IMPL_RETURNADDRESS() _ReturnAddress()
 #elif defined(__GNUC__)
 #define WINRT_IMPL_RETURNADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -83,6 +83,7 @@ extern "C"
     int32_t __stdcall WINRT_GetActivationFactory(void* classId, void** factory) noexcept;
 }
 
+#if defined(_MSC_VER)
 #ifdef _M_HYBRID
 #define WINRT_IMPL_LINK(function, count) __pragma(comment(linker, "/alternatename:#WINRT_IMPL_" #function "@" #count "=#" #function "@" #count))
 #elif _M_ARM64EC
@@ -91,6 +92,13 @@ extern "C"
 #define WINRT_IMPL_LINK(function, count) __pragma(comment(linker, "/alternatename:_WINRT_IMPL_" #function "@" #count "=_" #function "@" #count))
 #else
 #define WINRT_IMPL_LINK(function, count) __pragma(comment(linker, "/alternatename:WINRT_IMPL_" #function "=" #function))
+#endif
+#elif defined(__GNUC__)
+#if defined(__i386__)
+#define WINRT_IMPL_LINK(function, count) __asm__(".weak _WINRT_IMPL_" #function "@" #count "\n.set _WINRT_IMPL_" #function "@" #count ", _" #function "@" #count);
+#else
+#define WINRT_IMPL_LINK(function, count) __asm__(".weak WINRT_IMPL_" #function "\n.set WINRT_IMPL_" #function ", " #function);
+#endif
 #endif
 
 WINRT_IMPL_LINK(LoadLibraryW, 4)

--- a/strings/base_fast_forward.h
+++ b/strings/base_fast_forward.h
@@ -4,6 +4,12 @@
 #define WINRT_IMPL_STRING_1(expression) #expression
 #define WINRT_IMPL_STRING(expression) WINRT_IMPL_STRING_1(expression)
 
+#if defined(_MSC_VER)
+#define WINRT_IMPL_FF_NOVTABLE __declspec(novtable)
+#else
+#define WINRT_IMPL_FF_NOVTABLE
+#endif
+
 #if !defined(WINRT_FAST_ABI_SIZE)
 #define WINRT_FAST_ABI_SIZE %
 #endif
@@ -30,7 +36,7 @@ namespace winrt::impl
             }
         };
 
-        struct __declspec(novtable) inspectable
+        struct WINRT_IMPL_FF_NOVTABLE inspectable
         {
             virtual int32_t __stdcall QueryInterface(guid const& id, void** object) noexcept = 0;
             virtual uint32_t __stdcall AddRef() noexcept = 0;
@@ -130,3 +136,4 @@ namespace winrt
 
 #undef WINRT_IMPL_STRING
 #undef WINRT_IMPL_STRING_1
+#undef WINRT_IMPL_FF_NOVTABLE

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -800,7 +800,7 @@ namespace winrt::impl
     };
 
     template <typename D, typename... I>
-    struct __declspec(novtable) root_implements
+    struct WINRT_IMPL_NOVTABLE root_implements
         : root_implements_composing_outer<std::disjunction_v<std::is_same<composing, I>...>>
         , root_implements_composable_inner<D, std::disjunction_v<std::is_same<composable, I>...>>
         , module_lock_updater<!std::disjunction_v<std::is_same<no_module_lock, I>...>>

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -749,7 +749,7 @@ namespace winrt::impl
     };
 
     template <bool>
-    struct __declspec(empty_bases) root_implements_composing_outer
+    struct WINRT_IMPL_EMPTY_BASES root_implements_composing_outer
     {
     protected:
         static constexpr bool is_composing = false;
@@ -757,7 +757,7 @@ namespace winrt::impl
     };
 
     template <>
-    struct __declspec(empty_bases) root_implements_composing_outer<true>
+    struct WINRT_IMPL_EMPTY_BASES root_implements_composing_outer<true>
     {
         template <typename Qi>
         auto try_as() const noexcept
@@ -775,7 +775,7 @@ namespace winrt::impl
     };
 
     template <typename D, bool>
-    struct __declspec(empty_bases) root_implements_composable_inner
+    struct WINRT_IMPL_EMPTY_BASES root_implements_composable_inner
     {
     protected:
         static constexpr inspectable_abi* outer() noexcept { return nullptr; }
@@ -785,7 +785,7 @@ namespace winrt::impl
     };
 
     template <typename D>
-    struct __declspec(empty_bases) root_implements_composable_inner<D, true> : producer<D, INonDelegatingInspectable>
+    struct WINRT_IMPL_EMPTY_BASES root_implements_composable_inner<D, true> : producer<D, INonDelegatingInspectable>
     {
     protected:
         inspectable_abi* outer() noexcept { return m_outer; }

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -1,4 +1,5 @@
 
+#include <intrin.h>
 #include <algorithm>
 #include <array>
 #include <atomic>

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -47,6 +47,12 @@
 #define WINRT_IMPL_NOINLINE
 #endif
 
+#if defined(_MSC_VER)
+#define WINRT_IMPL_EMPTY_BASES __declspec(empty_bases)
+#else
+#define WINRT_IMPL_EMPTY_BASES
+#endif
+
 #ifdef __IUnknown_INTERFACE_DEFINED__
 #define WINRT_IMPL_IUNKNOWN_DEFINED
 #else

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -53,6 +53,12 @@
 #define WINRT_IMPL_EMPTY_BASES
 #endif
 
+#if defined(_MSC_VER)
+#define WINRT_IMPL_NOVTABLE __declspec(novtable)
+#else
+#define WINRT_IMPL_NOVTABLE
+#endif
+
 #ifdef __IUnknown_INTERFACE_DEFINED__
 #define WINRT_IMPL_IUNKNOWN_DEFINED
 #else

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -171,7 +171,7 @@ namespace winrt::impl
     };
 
     template <typename D, typename... I>
-    struct __declspec(empty_bases) require : require_one<D, I>...
+    struct WINRT_IMPL_EMPTY_BASES require : require_one<D, I>...
     {};
 
     template <typename D, typename I>
@@ -184,7 +184,7 @@ namespace winrt::impl
     };
 
     template <typename D, typename... I>
-    struct __declspec(empty_bases) base : base_one<D, I>...
+    struct WINRT_IMPL_EMPTY_BASES base : base_one<D, I>...
     {};
 
     template <typename T>


### PR DESCRIPTION
This aims to make the generated headers usable by a Clang-based mingw-w64 toolchain. See https://github.com/mstorsjo/llvm-mingw/issues/307

Note that, even with these changes, the headers does not work with llvm-mingw 15 out of the box, because there are some functions and definitions missing in mingw-w64's version of `intrin.h`. We will consider fixing this upstream.