### PR TITLE
Better support for mingw-w64 and GCC-compatible compilers

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -166,7 +166,7 @@ namespace winrt::impl
         return result;
 #elif defined _M_ARM64
 #if defined(__GNUC__)
-        int32_t const result = *target;
+        int64_t const result = *target;
 #else
         int64_t const result = __iso_volatile_load64(target);
 #endif

--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -128,7 +128,9 @@ WINRT_EXPORT namespace winrt
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if defined _M_ARM
+#if defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__))
+#define WINRT_IMPL_INTERLOCKED_READ_MEMORY_BARRIER __asm__ __volatile__ ("dmb ish");
+#elif defined _M_ARM
 #define WINRT_IMPL_INTERLOCKED_READ_MEMORY_BARRIER (__dmb(_ARM_BARRIER_ISH));
 #elif defined _M_ARM64
 #define WINRT_IMPL_INTERLOCKED_READ_MEMORY_BARRIER (__dmb(_ARM64_BARRIER_ISH));

--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -145,7 +145,11 @@ namespace winrt::impl
         _ReadWriteBarrier();
         return result;
 #elif defined _M_ARM || defined _M_ARM64
+#if defined(__GNUC__)
+        int32_t const result = *target;
+#else
         int32_t const result = __iso_volatile_load32(reinterpret_cast<int32_t const volatile*>(target));
+#endif
         WINRT_IMPL_INTERLOCKED_READ_MEMORY_BARRIER
         return result;
 #else
@@ -161,7 +165,11 @@ namespace winrt::impl
         _ReadWriteBarrier();
         return result;
 #elif defined _M_ARM64
+#if defined(__GNUC__)
+        int32_t const result = *target;
+#else
         int64_t const result = __iso_volatile_load64(target);
+#endif
         WINRT_IMPL_INTERLOCKED_READ_MEMORY_BARRIER
         return result;
 #else

--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -281,7 +281,12 @@ namespace winrt::impl
             object_and_count current_value{ pointer_value, 0 };
 
 #if defined _WIN64
-            if (1 == _InterlockedCompareExchange128((int64_t*)this, 0, 0, (int64_t*)&current_value))
+#if defined(__GNUC__)
+            bool exchanged = __sync_bool_compare_and_swap((__int128*)this, *(__int128*)&current_value, (__int128)0);
+#else
+            bool exchanged = 1 == _InterlockedCompareExchange128((int64_t*)this, 0, 0, (int64_t*)&current_value);
+#endif
+            if (exchanged)
             {
                 pointer_value->Release();
             }


### PR DESCRIPTION
There are still some intrinsics and defines missing in mingw-w64 (see https://github.com/mstorsjo/llvm-mingw/issues/307) which can all be replaced with other compatible constructions. Verified by compiling a sample program locally for i686, x86_64 and aarch64 (aarch64 build is untested because I don't have a compatible system).

(CI checks for mingw-w64 will be coming soon™)

CC: @mstorsjo @cristianadam