### PR TITLE
Projects with a nested Windows namespace (e.g., Microsoft::Windows) fail to compile

### DIFF
--- a/strings/base_xaml_component_connector.h
+++ b/strings/base_xaml_component_connector.h
@@ -17,7 +17,7 @@ WINRT_EXPORT namespace winrt::Windows::UI::Xaml::Markup
             D::InitializeComponent();
         }
 
-        void Connect(int32_t connectionId, Windows::Foundation::IInspectable const& target)
+        void Connect(int32_t connectionId, winrt::Windows::Foundation::IInspectable const& target)
         {
             if constexpr (m_has_connectable_base)
             {
@@ -30,7 +30,7 @@ WINRT_EXPORT namespace winrt::Windows::UI::Xaml::Markup
             D::Connect(connectionId, target);
         }
 
-        auto GetBindingConnector(int32_t connectionId, Windows::Foundation::IInspectable const& target)
+        auto GetBindingConnector(int32_t connectionId, winrt::Windows::Foundation::IInspectable const& target)
         {
             if constexpr (m_has_connectable_base)
             {


### PR DESCRIPTION
Discovered with WinUI-PR pipeline run: update versions for CppWinRT, wil, BuildTools, .NET runtime
