### PR TITLE
Fix invoke call on Clang (possibly a compiler bug)

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -414,7 +414,7 @@ namespace winrt::impl
 
             if (handler)
             {
-                invoke(handler, *this, status);
+                winrt::impl::invoke(handler, *this, status);
             }
         }
 
@@ -539,7 +539,7 @@ namespace winrt::impl
 
             if (handler)
             {
-                invoke(handler, *this, status);
+                winrt::impl::invoke(handler, *this, status);
             }
         }
 

--- a/test/test/disconnected.cpp
+++ b/test/test/disconnected.cpp
@@ -78,12 +78,7 @@ TEST_CASE("disconnected,handler,1")
     source(nullptr, 123);
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to fail with unhandled exception when built with Clang.
-TEST_CASE("disconnected,handler,2", "[!shouldfail]")
-#else
 TEST_CASE("disconnected,handler,2")
-#endif
 {
     auto async = Action();
 
@@ -112,12 +107,7 @@ TEST_CASE("disconnected,handler,3")
     WaitForSingleObject(signal.get(), INFINITE);
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to fail with unhandled exception when built with Clang.
-TEST_CASE("disconnected,handler,4", "[!shouldfail]")
-#else
 TEST_CASE("disconnected,handler,4")
-#endif
 {
     auto async = Operation();
 

--- a/test/test/disconnected.cpp
+++ b/test/test/disconnected.cpp
@@ -93,12 +93,7 @@ TEST_CASE("disconnected,handler,2")
         });
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to abort when built with Clang. (Seems to be from unhandled exception thrown on a worker thread.)
-TEST_CASE("disconnected,handler,3", "[.clang-crash]")
-#else
 TEST_CASE("disconnected,handler,3")
-#endif
 {
     auto async = ActionProgress();
     handle signal{ CreateEventW(nullptr, true, false, nullptr) };
@@ -132,12 +127,7 @@ TEST_CASE("disconnected,handler,4")
         });
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to abort when built with Clang. (Seems to be from unhandled exception thrown on a worker thread.)
-TEST_CASE("disconnected,handler,5", "[.clang-crash]")
-#else
 TEST_CASE("disconnected,handler,5")
-#endif
 {
     auto async = OperationProgress();
     handle signal{ CreateEventW(nullptr, true, false, nullptr) };

--- a/test/test_win7/disconnected.cpp
+++ b/test/test_win7/disconnected.cpp
@@ -82,12 +82,7 @@ TEST_CASE("disconnected,2")
         });
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to abort when built with Clang. (Seems to be from unhandled exception thrown on a worker thread.)
-TEST_CASE("disconnected,3", "[.clang-crash]")
-#else
 TEST_CASE("disconnected,3")
-#endif
 {
     auto async = ActionProgress();
     handle signal{ CreateEventW(nullptr, true, false, nullptr) };
@@ -121,12 +116,7 @@ TEST_CASE("disconnected,4")
         });
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to abort when built with Clang. (Seems to be from unhandled exception thrown on a worker thread.)
-TEST_CASE("disconnected,5", "[.clang-crash]")
-#else
 TEST_CASE("disconnected,5")
-#endif
 {
     auto async = OperationProgress();
     handle signal{ CreateEventW(nullptr, true, false, nullptr) };

--- a/test/test_win7/disconnected.cpp
+++ b/test/test_win7/disconnected.cpp
@@ -67,12 +67,7 @@ TEST_CASE("disconnected,1")
     source(nullptr, 123);
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to fail with unhandled exception when built with Clang.
-TEST_CASE("disconnected,2", "[!shouldfail]")
-#else
 TEST_CASE("disconnected,2")
-#endif
 {
     auto async = Action();
 
@@ -101,12 +96,7 @@ TEST_CASE("disconnected,3")
     WaitForSingleObject(signal.get(), INFINITE);
 }
 
-#if defined(__clang__)
-// FIXME: Test is known to fail with unhandled exception when built with Clang.
-TEST_CASE("disconnected,4", "[!shouldfail]")
-#else
 TEST_CASE("disconnected,4")
-#endif
 {
     auto async = Operation();
 


### PR DESCRIPTION
For unknown reasons, Clang resolves the `invoke` call (in `winrt::impl::promise_base::Completed` and `winrt::impl::promise_base::set_completed`) to `std::invoke` instead of `winrt::impl::invoke`, which breaks exception handling and causes some disconnected.cpp tests to crash. After changing the call to specify the namespace, 4 more tests in `disconnected.cpp` now passes on Clang.

---

To demonstrate the issue, I modified the generated `winrt/Windows::Foundation.h` and duplicated line 3765 (`winrt::impl::promise_base::set_completed`), and changed it so that one call specifies the namespace and the other doesn't. The disassembly shows how the name resolution of the two calls differ (this is with clang+mingw but the same happens with clang+msvc):

```
** 3763             if (handler)
   3764             {

    0x1ea95c <+156>: leal   -0x8(%ebp), %ecx
    0x1ea95f <+159>: calll  0x155e70                  ; winrt::Windows::Foundation::IUnknown::operator bool at base.h:2139
    0x1ea964 <+164>: testb  $0x1, %al
    0x1ea966 <+166>: jne    0x1ea971                  ; <+177> at Windows.Foundation.h
    0x1ea96c <+172>: jmp    0x1ea9a7                  ; <+231> at Windows.Foundation.h:3768:9

   1    // WARNING: Please don't edit this file. It was generated by C++/WinRT v2.3.4.5

    0x1ea971 <+177>: movl   -0x14(%ebp), %ecx

-> 3765                 invoke(handler, *this, status);

->  0x1ea974 <+180>: movl   %esp, %eax
    0x1ea976 <+182>: leal   -0xc(%ebp), %edx
    0x1ea979 <+185>: movl   %edx, 0x8(%eax)
    0x1ea97c <+188>: movl   %ecx, 0x4(%eax)
    0x1ea97f <+191>: leal   -0x8(%ebp), %ecx
    0x1ea982 <+194>: movl   %ecx, (%eax)
    0x1ea984 <+196>: calll  0x1ea9c0                  ; std::__1::invoke<winrt::Windows::Foundation::AsyncActionWithProgressCompletedHandler<int>&, winrt::impl::promise_base<std::__1::coroutine_traits<winrt::Windows::Foundation::IAsyncActionWithProgress<int>>::promise_type, winrt::Windows::Foundation::IAsyncActionWithProgress<int>, int>&, winrt::Windows::Foundation::AsyncStatus&> at invoke.h:530
    0x1ea989 <+201>: jmp    0x1ea98e                  ; <+206> at Windows.Foundation.h

   1    // WARNING: Please don't edit this file. It was generated by C++/WinRT v2.3.4.5

    0x1ea98e <+206>: movl   -0x14(%ebp), %ecx

** 3766                 ::winrt::impl::invoke(handler, *this, status);
   3767             }

    0x1ea991 <+209>: leal   -0x8(%ebp), %edx
    0x1ea994 <+212>: leal   -0xc(%ebp), %eax
    0x1ea997 <+215>: movl   %edx, (%esp)
    0x1ea99a <+218>: movl   %ecx, 0x4(%esp)
    0x1ea99e <+222>: movl   %eax, 0x8(%esp)
    0x1ea9a2 <+226>: calll  0x1ea9f0                  ; winrt::impl::invoke<winrt::Windows::Foundation::AsyncActionWithProgressCompletedHandler<int>, winrt::impl::promise_base<std::__1::coroutine_traits<winrt::Windows::Foundation::IAsyncActionWithProgress<int>>::promise_type, winrt::Windows::Foundation::IAsyncActionWithProgress<int>, int>, winrt::Windows::Foundation::AsyncStatus> at base.h:5859

** 3768         }
```