### PR TITLE
Enable more tests on llvm-mingw and some fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Build tests
         run: |
           cd build
-          cmake --build . --target test-vanilla test_win7
+          cmake --build . --target test-vanilla test_cpp20 test_win7
 
       - name: Upload test binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ../ -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug
+          cmake ../ -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DDOWNLOAD_WINDOWSNUMERICS=TRUE
           cmake --build . -j2 --target cppwinrt
 
       - name: Upload cppwinrt.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
           mkdir build
           cd build
           cmake ../ -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug
-          cmake --build . --target cppwinrt
+          cmake --build . -j2 --target cppwinrt
 
       - name: Upload cppwinrt.exe
         uses: actions/upload-artifact@v3
@@ -307,7 +307,7 @@ jobs:
       - name: Build tests
         run: |
           cd build
-          cmake --build . --target test-vanilla test_cpp20 test_win7
+          cmake --build . -j2 --target test-vanilla test_cpp20 test_win7 test_old
 
       - name: Upload test binaries
         uses: actions/upload-artifact@v3

--- a/cppwinrt/cmd_reader.h
+++ b/cppwinrt/cmd_reader.h
@@ -12,9 +12,9 @@
 #include <filesystem>
 #include <fstream>
 #include <regex>
-#include <Windows.h>
+#include <windows.h>
 #include <shlwapi.h>
-#include <XmlLite.h>
+#include <xmllite.h>
 
 namespace cppwinrt
 {

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#if __has_include(<WindowsNumerics.impl.h>)
+#if __has_include(<windowsnumerics.impl.h>)
 #define WINRT_IMPL_NUMERICS
 #include <directxmath.h>
 #endif

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -33,7 +33,7 @@
 #define _WINDOWS_NUMERICS_NAMESPACE_ winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ WINRT_EXPORT namespace winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_END_NAMESPACE_
-#include <WindowsNumerics.impl.h>
+#include <windowsnumerics.impl.h>
 #undef _WINDOWS_NUMERICS_NAMESPACE_
 #undef _WINDOWS_NUMERICS_BEGIN_NAMESPACE_
 #undef _WINDOWS_NUMERICS_END_NAMESPACE_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,4 +37,5 @@ add_custom_target(build-cppwinrt-projection
 
 
 add_subdirectory(test)
+add_subdirectory(test_cpp20)
 add_subdirectory(test_win7)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,3 +39,4 @@ add_custom_target(build-cppwinrt-projection
 add_subdirectory(test)
 add_subdirectory(test_cpp20)
 add_subdirectory(test_win7)
+add_subdirectory(old_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,35 @@ if(TARGET_IS_X64)
 endif()
 
 
+# Some tests requires windowsnumerics.impl.h, but mingw-w64 didn't have this
+# header until very recently. In case it is not present, download a copy if
+# DOWNLOAD_WINDOWSNUMERICS is true, otherwise skip the tests which depend on
+# this header.
+function(TestHasWindowsnumerics OUTPUT_VARNAME)
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("
+#define _WINDOWS_NUMERICS_NAMESPACE_ winrt::Windows::Foundation::Numerics
+#define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ WINRT_EXPORT namespace winrt::Windows::Foundation::Numerics
+#define _WINDOWS_NUMERICS_END_NAMESPACE_
+#include <windowsnumerics.impl.h>
+int main() {}
+    " ${OUTPUT_VARNAME})
+endfunction()
+TestHasWindowsnumerics(HAS_WINDOWSNUMERICS)
+set(DOWNLOAD_WINDOWSNUMERICS FALSE CACHE BOOL "Whether to download a copy of mingw-w64's windowsnumerics.impl.h if not available.")
+if(NOT HAS_WINDOWSNUMERICS AND DOWNLOAD_WINDOWSNUMERICS)
+    file(
+        DOWNLOAD https://github.com/mingw-w64/mingw-w64/raw/2b6272b31132e156dd1fc3722c1aa96b705a90dd/mingw-w64-headers/include/windowsnumerics.impl.h
+        "${CMAKE_CURRENT_BINARY_DIR}/windowsnumerics/windowsnumerics.impl.h"
+        EXPECTED_HASH SHA256=aff42491e57583c8ad8ca8e71d417a553bd1215ee9a71378679400ecded4b1ab
+        SHOW_PROGRESS
+    )
+    include_directories("${CMAKE_CURRENT_BINARY_DIR}/windowsnumerics")
+    set(HAS_WINDOWSNUMERICS TRUE)
+    message(STATUS "Using windowsnumerics.impl.h downloaded from mingw-w64")
+endif()
+
+
 add_custom_command(
     OUTPUT
         "${CMAKE_CURRENT_BINARY_DIR}/cppwinrt/winrt/base.h"
@@ -39,4 +68,7 @@ add_custom_target(build-cppwinrt-projection
 add_subdirectory(test)
 add_subdirectory(test_cpp20)
 add_subdirectory(test_win7)
-add_subdirectory(old_tests)
+
+if(HAS_WINDOWSNUMERICS)
+    add_subdirectory(old_tests)
+endif()

--- a/test/old_tests/CMakeLists.txt
+++ b/test/old_tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(UnitTests)

--- a/test/old_tests/UnitTests/CMakeLists.txt
+++ b/test/old_tests/UnitTests/CMakeLists.txt
@@ -1,0 +1,61 @@
+file(GLOB TEST_SRCS
+    LIST_DIRECTORIES false
+    CONFIGURE_DEPENDS
+    *.cpp
+)
+list(FILTER TEST_SRCS EXCLUDE REGEX "/(Main|pch)\\.cpp")
+
+
+# We can't build custom Component for mingw-w64 because it doesn't have an
+# alternative to midl that can produce winmd files.
+list(APPEND BROKEN_TESTS
+    Boxing2
+    Composable
+    Errors
+    Events
+    FastInput
+    Parameters
+    StructCodeGen
+    Structures
+    delegate_weak_strong
+    factory_cache
+    get_activation_factory
+    smart_pointers
+)
+
+list(APPEND BROKEN_TESTS
+    # Missing `Windows.Applicationmodel.Activation.h`
+    constexpr
+
+    # Missing `Windows.ApplicationModel.Appointments.h`
+    enum_flags
+
+    # Missing component `Reflect`.
+    # Test is also not included in the VS project.
+    reflect
+
+    # Segfault in winrt::impl::natvis::abi_val.
+    # Test is also not included in the VS project.
+    natvis
+)
+
+# Exclude broken tests
+foreach(TEST_SRCS_EXCLUDE_ITEM IN LISTS BROKEN_TESTS)
+    list(FILTER TEST_SRCS EXCLUDE REGEX "/${TEST_SRCS_EXCLUDE_ITEM}\\.cpp")
+endforeach()
+
+add_executable(test_old Main.cpp ${TEST_SRCS})
+target_link_libraries(test_old runtimeobject synchronization)
+
+target_precompile_headers(test_old PRIVATE pch.h)
+set_source_files_properties(
+    conditional_implements_pure.cpp
+    PROPERTIES SKIP_PRECOMPILE_HEADERS true
+)
+
+add_dependencies(test_old build-cppwinrt-projection)
+
+add_test(
+    NAME test_old
+    COMMAND "$<TARGET_FILE:test_old>"
+)

--- a/test/old_tests/UnitTests/Main.cpp
+++ b/test/old_tests/UnitTests/Main.cpp
@@ -18,6 +18,7 @@ int main(int argc, char * argv[])
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    SetThreadUILanguage(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US));
     int const result = Catch::Session().run(argc, argv);
 
     // Completely unnecessary in an app, but useful for testing clear_factory_cache behavior.

--- a/test/old_tests/UnitTests/Main.cpp
+++ b/test/old_tests/UnitTests/Main.cpp
@@ -2,6 +2,10 @@
 #include "pch.h"
 
 #define CATCH_CONFIG_RUNNER
+
+// Force reportFatal to be available on mingw-w64
+#define CATCH_CONFIG_WINDOWS_SEH
+
 #include "catch.hpp"
 
 int main(int argc, char * argv[])

--- a/test/old_tests/UnitTests/VariadicDelegate.cpp
+++ b/test/old_tests/UnitTests/VariadicDelegate.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Variadic delegate - event")
 
 TEST_CASE("Variadic delegate - exception")
 {
-    delegate<> d = [] { throw std::exception("what"); };
+    delegate<> d = [] { throw std::runtime_error("what"); };
     REQUIRE_THROWS_AS(d(), std::exception);
 }
 

--- a/test/old_tests/UnitTests/agile_ref.cpp
+++ b/test/old_tests/UnitTests/agile_ref.cpp
@@ -36,8 +36,8 @@ IAsyncAction test_agile_ref()
     });
 }
 
-#if defined(__clang__) && (defined(_M_IX86) || defined(__i386__))
-// FIXME: Test is known to crash with exit code 0x80000003 (breakpoint?) on x86 when built with Clang.
+#if defined(__clang__) && defined(_MSC_VER) && (defined(_M_IX86) || defined(__i386__))
+// FIXME: Test is known to crash from calling invalid address on x86 when built with Clang.
 TEST_CASE("agile_ref", "[.clang-crash]")
 #else
 TEST_CASE("agile_ref")

--- a/test/old_tests/UnitTests/apartment_context.cpp
+++ b/test/old_tests/UnitTests/apartment_context.cpp
@@ -46,6 +46,11 @@ namespace
         co_await context;
     }
 
+// Not yet buildable on mingw-w64. The lambda needs to have __stdcall
+// specified on it but there is a Clang crash bug blocking this:
+// https://github.com/llvm/llvm-project/issues/58366
+#if !defined(__MINGW32__)
+
     template<typename TLambda>
     void InvokeInContext(IContextCallback* context, TLambda&& lambda)
     {
@@ -69,6 +74,8 @@ namespace
         return context;
     }
 
+#endif
+
     bool is_nta_on_mta()
     {
         APTTYPE type;
@@ -90,6 +97,10 @@ namespace
         return (hr == RPC_E_SERVER_DIED_DNE) || (hr == RPC_E_DISCONNECTED);
     }
 
+// Not yet buildable on mingw-w64.
+// Missing __uuidof(IContextCallback).
+#if !defined(__MINGW32__)
+
     IAsyncAction TestNeutralApartmentContext()
     {
         auto controller = DispatcherQueueController::CreateOnDedicatedThread();
@@ -101,6 +112,8 @@ namespace
 
         REQUIRE(is_nta_on_mta());
     }
+
+#endif
 
     IAsyncAction TestStaToStaApartmentContext()
     {
@@ -245,10 +258,16 @@ TEST_CASE("apartment_context coverage")
     Async().get();
 }
 
+// Not yet buildable on mingw-w64.
+// Missing __uuidof(IContextCallback).
+#if !defined(__MINGW32__)
+
 TEST_CASE("apartment_context nta")
 {
     TestNeutralApartmentContext().get();
 }
+
+#endif
 
 TEST_CASE("apartment_context sta")
 {

--- a/test/old_tests/UnitTests/apartment_context.cpp
+++ b/test/old_tests/UnitTests/apartment_context.cpp
@@ -274,7 +274,7 @@ TEST_CASE("apartment_context sta")
     TestStaToStaApartmentContext().get();
 }
 
-#if defined(__clang__) && (defined(_M_IX86) || defined(__i386__))
+#if defined(__clang__) && defined(_MSC_VER) && (defined(_M_IX86) || defined(__i386__))
 // FIXME: Test is known to segfault on x86 when built with Clang.
 TEST_CASE("apartment_context disconnected", "[.clang-crash]")
 #else

--- a/test/old_tests/UnitTests/array.cpp
+++ b/test/old_tests/UnitTests/array.cpp
@@ -941,13 +941,20 @@ TEST_CASE("array_view,cv array_view")
         array_view<volatile int> a2 = a;
         REQUIRE(a2.data() == a.data());
         REQUIRE(a2.size() == 3);
+        // For libc++ as of LLVM 15, std::equal is unable to compare between
+        // volatile and non-volatile elements of ranges.
+        // https://github.com/llvm/llvm-project/issues/59021
+#if !defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 160000
         REQUIRE(a2 == a);
+#endif
     }
     {
         array_view<const volatile int> a2 = a;
         REQUIRE(a2.data() == a.data());
         REQUIRE(a2.size() == 3);
+#if !defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 160000
         REQUIRE(a2 == a);
+#endif
     }
 }
 

--- a/test/old_tests/UnitTests/async.cpp
+++ b/test/old_tests/UnitTests/async.cpp
@@ -397,7 +397,7 @@ namespace
 #endif
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncAction", "[.clang-crash]")
 #else
@@ -442,7 +442,7 @@ TEST_CASE("async, Throw_IAsyncAction")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncAction, 2", "[.clang-crash]")
 #else
@@ -488,7 +488,7 @@ TEST_CASE("async, Throw_IAsyncAction, 2")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncActionWithProgress", "[.clang-crash]")
 #else
@@ -533,7 +533,7 @@ TEST_CASE("async, Throw_IAsyncActionWithProgress")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncActionWithProgress, 2", "[.clang-crash]")
 #else
@@ -579,7 +579,7 @@ TEST_CASE("async, Throw_IAsyncActionWithProgress, 2")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncOperation", "[.clang-crash]")
 #else
@@ -624,7 +624,7 @@ TEST_CASE("async, Throw_IAsyncOperation")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncOperation, 2", "[.clang-crash]")
 #else
@@ -670,7 +670,7 @@ TEST_CASE("async, Throw_IAsyncOperation, 2")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncOperationWithProgress", "[.clang-crash]")
 #else
@@ -715,7 +715,7 @@ TEST_CASE("async, Throw_IAsyncOperationWithProgress")
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Throw_IAsyncOperationWithProgress, 2", "[.clang-crash]")
 #else
@@ -813,7 +813,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncAction", "[.clang-crash]")
 #else
@@ -848,7 +848,7 @@ TEST_CASE("async, Cancel_IAsyncAction")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncAction, 2", "[.clang-crash]")
 #else
@@ -883,7 +883,7 @@ TEST_CASE("async, Cancel_IAsyncAction, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncActionWithProgress", "[.clang-crash]")
 #else
@@ -919,7 +919,7 @@ TEST_CASE("async, Cancel_IAsyncActionWithProgress")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncActionWithProgress, 2", "[.clang-crash]")
 #else
@@ -955,7 +955,7 @@ TEST_CASE("async, Cancel_IAsyncActionWithProgress, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncOperation", "[.clang-crash]")
 #else
@@ -990,7 +990,7 @@ TEST_CASE("async, Cancel_IAsyncOperation")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncOperation, 2", "[.clang-crash]")
 #else
@@ -1025,7 +1025,7 @@ TEST_CASE("async, Cancel_IAsyncOperation, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncOperationWithProgress", "[.clang-crash]")
 #else
@@ -1061,7 +1061,7 @@ TEST_CASE("async, Cancel_IAsyncOperationWithProgress")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, Cancel_IAsyncOperationWithProgress, 2", "[.clang-crash]")
 #else
@@ -1149,7 +1149,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncAction", "[.clang-crash]")
 #else
@@ -1182,7 +1182,7 @@ TEST_CASE("async, AutoCancel_IAsyncAction")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncAction, 2", "[.clang-crash]")
 #else
@@ -1215,7 +1215,7 @@ TEST_CASE("async, AutoCancel_IAsyncAction, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("", "[.clang-crash]")
 #else
@@ -1248,7 +1248,7 @@ TEST_CASE("async, AutoCancel_IAsyncActionWithProgress")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncActionWithProgress, 2", "[.clang-crash]")
 #else
@@ -1281,7 +1281,7 @@ TEST_CASE("async, AutoCancel_IAsyncActionWithProgress, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncOperation", "[.clang-crash]")
 #else
@@ -1314,7 +1314,7 @@ TEST_CASE("async, AutoCancel_IAsyncOperation")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncOperation, 2", "[.clang-crash]")
 #else
@@ -1347,7 +1347,7 @@ TEST_CASE("async, AutoCancel_IAsyncOperation, 2")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncOperationWithProgress", "[.clang-crash]")
 #else
@@ -1380,7 +1380,7 @@ TEST_CASE("async, AutoCancel_IAsyncOperationWithProgress")
     REQUIRE(statusMatches);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, AutoCancel_IAsyncOperationWithProgress, 2", "[.clang-crash]")
 #else
@@ -1443,7 +1443,7 @@ TEST_CASE("async, get, suspend with success")
     REQUIRE(456 == d.get());
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async, get, failure", "[.clang-crash]")
 #else

--- a/test/old_tests/UnitTests/async_cancel.cpp
+++ b/test/old_tests/UnitTests/async_cancel.cpp
@@ -122,7 +122,7 @@ TEST_CASE("async_cancel_no_async")
     REQUIRE(a.Status() == AsyncStatus::Completed);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_cancel_before_callback", "[.clang-crash]")
 #else
@@ -144,7 +144,7 @@ TEST_CASE("async_cancel_before_callback")
     REQUIRE(async.Status() == AsyncStatus::Canceled);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to randomly crash when built with Clang.
 TEST_CASE("async_cancel_after_callback", "[.clang-crash]")
 #else
@@ -164,7 +164,7 @@ TEST_CASE("async_cancel_after_callback")
     REQUIRE(async.Status() == AsyncStatus::Canceled);
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_cancel_use_status", "[.clang-crash]")
 #else

--- a/test/old_tests/UnitTests/capture.cpp
+++ b/test/old_tests/UnitTests/capture.cpp
@@ -4,11 +4,15 @@
 using namespace winrt;
 using namespace Windows::Foundation;
 
-struct __declspec(uuid("5fb96f8d-409c-42a9-99a7-8a95c1459dbd")) ICapture : ::IUnknown
+struct DECLSPEC_UUID("5fb96f8d-409c-42a9-99a7-8a95c1459dbd") ICapture : ::IUnknown
 {
     virtual int32_t __stdcall GetValue() noexcept = 0;
     virtual int32_t __stdcall CreateMemberCapture(int32_t value, GUID const& iid, void** object) noexcept = 0;
 };
+
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(ICapture, 0x5fb96f8d, 0x409c, 0x42a9, 0x99, 0xa7, 0x8a, 0x95, 0xc1, 0x45, 0x9d, 0xbd)
+#endif
 
 struct Capture : implements<Capture, ICapture>
 {

--- a/test/old_tests/UnitTests/com_ref.cpp
+++ b/test/old_tests/UnitTests/com_ref.cpp
@@ -3,7 +3,7 @@
 
 namespace
 {
-    struct __declspec(uuid("52bb7805-e46e-46f9-8508-86606d2f6bc1")) IClassic : ::IUnknown
+    struct DECLSPEC_UUID("52bb7805-e46e-46f9-8508-86606d2f6bc1") IClassic : ::IUnknown
     {
     };
 
@@ -11,6 +11,10 @@ namespace
     {
     };
 }
+
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IClassic, 0x52bb7805, 0xe46e, 0x46f9, 0x85, 0x08, 0x86, 0x60, 0x6d, 0x2f, 0x6b, 0xc1);
+#endif
 
 TEST_CASE("com_ref agile_ref")
 {

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -1,6 +1,11 @@
 #include "pch.h"
 #include "catch.hpp"
 
+// Missing in mingw-w64
+#ifndef E_BOUNDS
+#define E_BOUNDS (0x8000000B)
+#endif
+
 extern "C" BOOL __stdcall RoOriginateLanguageException(HRESULT error, void* message, void* languageException);
 
 using namespace winrt;
@@ -497,7 +502,7 @@ TEST_CASE("hresult, std abi support")
     {
         EventHandler<int> handler = [](auto&& ...)
         {
-            throw std::exception("std__exception");
+            throw std::runtime_error("std__exception");
         };
 
         handler(nullptr, 0);

--- a/test/old_tests/UnitTests/make_self.cpp
+++ b/test/old_tests/UnitTests/make_self.cpp
@@ -1,6 +1,12 @@
 #include "pch.h"
 #include "catch.hpp"
 
+#if defined(_MSC_VER)
+#define WDECLSPECL_NOVTABLE __declspec(novtable)
+#else
+#define WDECLSPECL_NOVTABLE
+#endif
+
 //
 // These tests ensure that the make_self function works as expected to provide direct acccess
 // to an implementation.
@@ -11,10 +17,14 @@
 
 using namespace winrt;
 
-struct __declspec(uuid("eebb3a22-13a6-43b9-9d53-b7deb5a20ae5")) __declspec(novtable) IMakeSelf : IUnknown
+struct DECLSPEC_UUID("eebb3a22-13a6-43b9-9d53-b7deb5a20ae5") WDECLSPECL_NOVTABLE IMakeSelf : IUnknown
 {
     virtual HRESULT __stdcall Call() = 0;
 };
+
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IMakeSelf, 0xeebb3a22, 0x13a6, 0x43b9, 0x9d, 0x53, 0xb7, 0xde, 0xb5, 0xa2, 0x0a, 0xe5);
+#endif
 
 struct MakeSelfStringable : implements<MakeSelfStringable, Windows::Foundation::IStringable>
 {

--- a/test/old_tests/UnitTests/param_iterable.cpp
+++ b/test/old_tests/UnitTests/param_iterable.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "catch.hpp"
+#include <list>
 
 using namespace winrt;
 using namespace Windows::Foundation::Collections;

--- a/test/old_tests/UnitTests/pch.h
+++ b/test/old_tests/UnitTests/pch.h
@@ -4,6 +4,8 @@
 #define WINRT_NATVIS
 #define _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
 
+#include "mingw_com_support.h"
+
 // Light up ::IUnknown interop by including this first
 #include <unknwn.h>
 #undef GetCurrentTime

--- a/test/test/coro_system.cpp
+++ b/test/test/coro_system.cpp
@@ -13,10 +13,7 @@ namespace
     {
         co_await resume_foreground(queue);
 
-// FIXME: Fail to compile with Clang due to co_await overload resolution
-#if !defined(__clang__)
         co_await queue;
-#endif
     }
 }
 

--- a/test/test/coro_ui_core.cpp
+++ b/test/test/coro_ui_core.cpp
@@ -18,10 +18,7 @@ namespace
 
         co_await resume_foreground(queue);
 
-// FIXME: Fail to compile with Clang due to co_await overload resolution
-#if !defined(__clang__)
         co_await queue;
-#endif
     }
 }
 

--- a/test/test/main.cpp
+++ b/test/test/main.cpp
@@ -17,6 +17,7 @@ int main(int const argc, char** argv)
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    SetThreadUILanguage(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US));
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_cpp20/CMakeLists.txt
+++ b/test/test_cpp20/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(CMAKE_CXX_STANDARD 20)
+# std::format, std::ranges::is_heap, std::views::reverse, std::ranges::max
+# are experimental in libc++ as of Clang 15.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
+
+file(GLOB TEST_SRCS
+    LIST_DIRECTORIES false
+    CONFIGURE_DEPENDS
+    *.cpp
+)
+list(FILTER TEST_SRCS EXCLUDE REGEX "/(main|pch)\\.cpp")
+
+
+list(APPEND BROKEN_TESTS
+    # No broken tests.
+)
+
+# Exclude broken tests
+foreach(TEST_SRCS_EXCLUDE_ITEM IN LISTS BROKEN_TESTS)
+    list(FILTER TEST_SRCS EXCLUDE REGEX "/${TEST_SRCS_EXCLUDE_ITEM}\\.cpp")
+endforeach()
+
+add_executable(test_cpp20 main.cpp ${TEST_SRCS})
+
+target_precompile_headers(test_cpp20 PRIVATE pch.h)
+set_source_files_properties(
+    main.cpp
+    PROPERTIES SKIP_PRECOMPILE_HEADERS true
+)
+
+add_dependencies(test_cpp20 build-cppwinrt-projection)
+
+add_test(
+    NAME test_cpp20
+    COMMAND "$<TARGET_FILE:test_cpp20>"
+)

--- a/test/test_cpp20/main.cpp
+++ b/test/test_cpp20/main.cpp
@@ -1,5 +1,9 @@
 #include <crtdbg.h>
 #define CATCH_CONFIG_RUNNER
+
+// Force reportFatal to be available on mingw-w64
+#define CATCH_CONFIG_WINDOWS_SEH
+
 #include "catch.hpp"
 #include "winrt/base.h"
 

--- a/test/test_win7/async_auto_cancel.cpp
+++ b/test/test_win7/async_auto_cancel.cpp
@@ -70,7 +70,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_auto_cancel", "[.clang-crash]")
 #else

--- a/test/test_win7/async_cancel_callback.cpp
+++ b/test/test_win7/async_cancel_callback.cpp
@@ -90,7 +90,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_cancel_callback", "[.clang-crash]")
 #else

--- a/test/test_win7/async_check_cancel.cpp
+++ b/test/test_win7/async_check_cancel.cpp
@@ -104,7 +104,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_check_cancel", "[.clang-crash]")
 #else

--- a/test/test_win7/async_throw.cpp
+++ b/test/test_win7/async_throw.cpp
@@ -77,7 +77,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_throw", "[.clang-crash]")
 #else

--- a/test/test_win7/async_wait_for.cpp
+++ b/test/test_win7/async_wait_for.cpp
@@ -96,7 +96,7 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_wait_for", "[.clang-crash]")
 #else


### PR DESCRIPTION
Changes include:

- Since a partial `windowsnumerics.impl.h` header has been added to mingw-w64 recently, we can enable the tests that depend on it. If it is not available in the current mingw-w64 toolchain, there is an option to download a copy of it from the mingw-w64 git repo to allow these tests to run.
- Enable some test cases of `test_cpp20` and `test_old` for llvm-mingw. `test_old` in particular depends on `windowsnumerics.impl.h`)
- Re-enable test code for Clang fixed by #1228.
- Enable some test cases for llvm-mingw that crashes only when built using Clang with MSVC ABI.
- Make some tests relying on error messages pass on non-English Windows systems.
- Use lowercase filename when including Windows headers, which is needed for cross-building from Linux with mingw-w64.
