### PR TITLE
Fix multi_threaded_map/_vector tests on Clang

### DIFF
--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -46,7 +46,7 @@ endforeach()
 
 add_executable(test-vanilla main.cpp ${TEST_SRCS})
 set_target_properties(test-vanilla PROPERTIES OUTPUT_NAME "test")
-target_link_libraries(test-vanilla runtimeobject)
+target_link_libraries(test-vanilla runtimeobject synchronization)
 
 target_precompile_headers(test-vanilla PRIVATE pch.h)
 set_source_files_properties(

--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -152,7 +152,6 @@ namespace concurrent_collections
         concurrency_checked_random_access_iterator(container const* c, iterator it) : owner(c), iterator(it) {}
 
         // Implicit conversion from non-const iterator to const iterator.
-        template<typename = std::enable_if_t<!std::is_same_v<ConvertibleFrom, void>>>
         concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator<container, ConvertibleFrom> other) : owner(other.owner), iterator(other.inner()) { }
 
         concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator const&) = default;

--- a/test/test/multi_threaded_map.cpp
+++ b/test/test/multi_threaded_map.cpp
@@ -5,9 +5,6 @@
 
 #include "multi_threaded_common.h"
 
-// FIXME: Fail to compile with Clang due to "error : no type named 'type' in 'std::enable_if<false>'"
-#if !defined(__clang__)
-
 using namespace winrt;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
@@ -338,4 +335,3 @@ TEST_CASE("multi_threaded_observable_map")
     test_map_concurrency<int, MapKind::IObservableMap>();
     test_map_concurrency<IInspectable, MapKind::IObservableMap>();
 }
-#endif

--- a/test/test/multi_threaded_vector.cpp
+++ b/test/test/multi_threaded_vector.cpp
@@ -2,9 +2,6 @@
 
 #include "multi_threaded_common.h"
 
-// FIXME: Fail to compile with Clang due to "error : no type named 'type' in 'std::enable_if<false>'"
-#if !defined(__clang__)
-
 using namespace winrt;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
@@ -84,7 +81,7 @@ namespace
             }
             else
             {
-                return vector.as<IObservableVector<IInspectable>>();
+                return vector.template as<IObservableVector<IInspectable>>();
             }
         }
     }
@@ -469,4 +466,3 @@ TEST_CASE("multi_threaded_observable_vector")
     test_vector_concurrency<IInspectable, VectorKind::IObservableVector>();
     test_vector_concurrency<IInspectable, VectorKind::IObservableVectorAsInspectable>();
 }
-#endif


### PR DESCRIPTION
Removed one bit of enable_if_t metaprogramming that doesn't build with Clang and seems to be unneeded. The error message is:

```
enable_if.h:26:78: error: no type named 'type' in 'std::enable_if<false>'; 'enable_if' cannot be used to disable this declaration
template <bool _Bp, class _Tp = void> using enable_if_t = typename enable_if<_Bp, _Tp>::type;
                                                                             ^~~
multi_threaded_common.h:155:34: note: in instantiation of template type alias 'enable_if_t' requested here
        template<typename = std::enable_if_t<!std::is_same_v<ConvertibleFrom, void>>>
                                 ^
[snip]
```