### PR TITLE
Fix formatting primitive types such as integers

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -555,12 +555,12 @@ namespace winrt::impl
     template <typename... Args>
     inline hstring base_format(Args&&... args)
     {
-        auto const size = std::formatted_size(args...);
+        auto const size = std::formatted_size(std::forward<Args>(args)...);
         WINRT_ASSERT(size < UINT_MAX);
         auto const size32 = static_cast<uint32_t>(size);
 
         hstring_builder builder(size32);
-        WINRT_VERIFY_(size32, std::format_to_n(builder.data(), size32, args...).size);
+        WINRT_VERIFY_(size32, std::format_to_n(builder.data(), size32, std::forward<Args>(args)...).size);
         return builder.to_hstring();
     }
 #endif
@@ -572,13 +572,13 @@ WINRT_EXPORT namespace winrt
     template <typename... Args>
     inline hstring format(std::wformat_string<Args...> const fmt, Args&&... args)
     {
-        return impl::base_format(fmt, args...);
+        return impl::base_format(fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     inline hstring format(std::locale const& loc, std::wformat_string<Args...> const fmt, Args&&... args)
     {
-        return impl::base_format(loc, fmt, args...);
+        return impl::base_format(loc, fmt, std::forward<Args>(args)...);
     }
 #endif
 

--- a/test/test_cpp20/format.cpp
+++ b/test/test_cpp20/format.cpp
@@ -31,5 +31,9 @@ TEST_CASE("format")
         std::wstring str = L"World";
         REQUIRE(winrt::format(L"Hello {}", str) == L"Hello World");
     }
+
+    {
+        REQUIRE(winrt::format(L"C++/WinRT #{:d}", 1) == L"C++/WinRT #1");
+    }
 #endif
 }


### PR DESCRIPTION
With std::format reference semantics are only used for user defined types so without std::forward you somehow can't format integers. Forwarding twice is safe because objects are not copied/moved from during formatting.

Would like a quick release of this fix because it's breaking my scenario.