### PR TITLE
Partial GCC compatibility improvements

### DIFF
--- a/cppwinrt/pch.h
+++ b/cppwinrt/pch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include "cmd_reader.h"
 #include <winmd_reader.h>
 #include "task_group.h"

--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace cppwinrt
 {

--- a/strings/base_chrono.h
+++ b/strings/base_chrono.h
@@ -47,7 +47,7 @@ WINRT_EXPORT namespace winrt
 
         static time_point from_time_t(time_t time) noexcept
         {
-            return from_sys(std::chrono::system_clock::from_time_t(time));
+            return std::chrono::time_point_cast<duration>(from_sys(std::chrono::system_clock::from_time_t(time)));
         }
 
         static file_time to_file_time(time_point const& time) noexcept

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -21,6 +21,10 @@
 #include <utility>
 #include <vector>
 
+#if __has_include(<version>)
+#include <version>
+#endif
+
 #if __has_include(<windowsnumerics.impl.h>)
 #define WINRT_IMPL_NUMERICS
 #include <directxmath.h>
@@ -51,7 +55,7 @@ namespace winrt::impl
     using suspend_never = std::suspend_never;
 }
 
-#else
+#elif __has_include(<experimental/coroutine>)
 
 #include <experimental/coroutine>
 
@@ -64,4 +68,6 @@ namespace winrt::impl
     using suspend_never = std::experimental::suspend_never;
 }
 
+#else
+#error C++/WinRT requires coroutine support, which is currently missing. Try enabling C++20 in your compiler.
 #endif

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -6,6 +6,7 @@
 #include <charconv>
 #include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <map>
 #include <memory>

--- a/strings/base_string_operators.h
+++ b/strings/base_string_operators.h
@@ -55,9 +55,9 @@ WINRT_EXPORT namespace winrt
         return left < std::wstring_view(right);
     }
 
-    bool operator<(hstring const& left, nullptr_t) = delete;
+    bool operator<(hstring const& left, std::nullptr_t) = delete;
 
-    bool operator<(nullptr_t, hstring const& right) = delete;
+    bool operator<(std::nullptr_t, hstring const& right) = delete;
     inline bool operator!=(hstring const& left, hstring const& right) noexcept { return !(left == right); }
     inline bool operator>(hstring const& left, hstring const& right) noexcept { return right < left; }
     inline bool operator<=(hstring const& left, hstring const& right) noexcept { return !(right < left); }


### PR DESCRIPTION
**Generated headers do not actually work on GCC.**

This implements some changes intended to improve compatibility with GCC 12. However, there is an [8-year-old upstream defect](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61663) which stops `winrt::impl::bind_in` from compiling:

<details>
<summary>GCC 12 Compile Error</summary>

```
In file included from C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.Collections.h:9,
                 from D:/cppwinrt/test/test/pch.h:9,
                 from C:/msys64/home/Alvin/cppwinrt/test/test/CMakeFiles/test-vanilla.dir/cmake_pch.hxx:5,
                 from <command-line>:
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreateGuid(const winrt::guid&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2193:130:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:472:108: error: cannot convert 'winrt::impl::bind_in<winrt::guid>' to 'winrt::guid'
  472 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreateGuid(impl::bind_in(value), &propertyValue));
      |                                                                                                            ^~~~~~~~~~~~~~
      |                                                                                                            |
      |                                                                                                            winrt::impl::bind_in<winrt::guid>
In file included from C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.1.h:7,
                 from C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.2.h:7,
                 from C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:10:
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:418:50: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreateGuid(winrt::guid, void**)'
  418 |             virtual int32_t __stdcall CreateGuid(winrt::guid, void**) noexcept = 0;
      |                                                  ^~~~~~~~~~~
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreateDateTime(const winrt::Windows::Foundation::DateTime&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics; winrt::Windows::Foundation::DateTime = std::chrono::time_point<winrt::clock, std::chrono::duration<long long int, std::ratio<1, 10000000> > >]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2197:134:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:478:112: error: cannot convert 'winrt::impl::bind_in<std::chrono::time_point<winrt::clock, std::chrono::duration<long long int, std::ratio<1, 10000000> > > >'
 to 'int64_t' {aka 'long long int'}
  478 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreateDateTime(impl::bind_in(value), &propertyValue));
      |                                                                                                                ^~~~~~~~~~~~~~
      |                                                                                                                |
      |                                                                                                                winrt::impl::bind_in<std::chrono::time_point<winrt::clock, std::chrono::duration<long long int, std::ratio<1,
10000000> > > >
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:419:54: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreateDateTime(int64_t, void**)'
  419 |             virtual int32_t __stdcall CreateDateTime(int64_t, void**) noexcept = 0;
      |                                                      ^~~~~~~
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreateTimeSpan(const winrt::Windows::Foundation::TimeSpan&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics; winrt::Windows::Foundation::TimeSpan = std::chrono::duration<long long int, std::ratio<1, 10000000> >]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2201:134:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:484:112: error: cannot convert 'winrt::impl::bind_in<std::chrono::duration<long long int, std::ratio<1, 10000000> > >' to 'int64_t' {aka 'long long int'}
  484 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreateTimeSpan(impl::bind_in(value), &propertyValue));
      |                                                                                                                ^~~~~~~~~~~~~~
      |                                                                                                                |
      |                                                                                                                winrt::impl::bind_in<std::chrono::duration<long long int, std::ratio<1, 10000000> > >
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:420:54: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreateTimeSpan(int64_t, void**)'
  420 |             virtual int32_t __stdcall CreateTimeSpan(int64_t, void**) noexcept = 0;
      |                                                      ^~~~~~~
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreatePoint(const winrt::Windows::Foundation::Point&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2205:131:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:490:109: error: cannot convert 'winrt::impl::bind_in<winrt::Windows::Foundation::Point>' to 'winrt::Windows::Foundation::Point'
  490 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreatePoint(impl::bind_in(value), &propertyValue));
      |                                                                                                             ^~~~~~~~~~~~~~
      |                                                                                                             |
      |                                                                                                             winrt::impl::bind_in<winrt::Windows::Foundation::Point>
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:421:51: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreatePoint(winr
t::Windows::Foundation::Point, void**)'
  421 |             virtual int32_t __stdcall CreatePoint(winrt::Windows::Foundation::Point, void**) noexcept = 0;
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreateSize(const winrt::Windows::Foundation::Size&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2209:130:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:496:108: error: cannot convert 'winrt::impl::bind_in<winrt::Windows::Foundation::Size>' to 'winrt::Windows::Foundation::Size'
  496 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreateSize(impl::bind_in(value), &propertyValue));
      |                                                                                                            ^~~~~~~~~~~~~~
      |                                                                                                            |
      |                                                                                                            winrt::impl::bind_in<winrt::Windows::Foundation::Size>
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:422:50: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreateSize(winrt::Windows::Foundation::Size, void**)'
  422 |             virtual int32_t __stdcall CreateSize(winrt::Windows::Foundation::Size, void**) noexcept = 0;
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h: In instantiation of 'auto winrt::impl::consume_Windows_Foundation_IPropertyValueStatics<D>::CreateRect(const winrt::Windows::Foundation::Rect&) const [with D = winrt::Windows::Foundation::IPropertyValueStatics]':
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:2213:130:   required from here
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/Windows.Foundation.h:502:108: error: cannot convert 'winrt::impl::bind_in<winrt::Windows::Foundation::Rect>' to 'winrt::Windows::Foundation::Rect'
  502 |         check_hresult(WINRT_IMPL_SHIM(winrt::Windows::Foundation::IPropertyValueStatics)->CreateRect(impl::bind_in(value), &propertyValue));
      |                                                                                                            ^~~~~~~~~~~~~~
      |                                                                                                            |
      |                                                                                                            winrt::impl::bind_in<winrt::Windows::Foundation::Rect>
C:/msys64/home/Alvin/cppwinrt/test/cppwinrt/winrt/impl/Windows.Foundation.0.h:423:50: note:   initializing argument 1 of 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IPropertyValueStatics>::type::CreateRect(winrt::Windows::Foundation::Rect, void**)'
  423 |             virtual int32_t __stdcall CreateRect(winrt::Windows::Foundation::Rect, void**) noexcept = 0;
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

Unless the issue can be worked around by changing the implementation of `winrt::impl::bind_in`, I don't see cppwinrt being usable with GCC any time soon. (CC @Biswa96)