### PR TITLE
Fix llvm-mingw tests with LLVM trunk

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ function(TestHasWindowsnumerics OUTPUT_VARNAME)
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("
 #define _WINDOWS_NUMERICS_NAMESPACE_ winrt::Windows::Foundation::Numerics
-#define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ WINRT_EXPORT namespace winrt::Windows::Foundation::Numerics
+#define _WINDOWS_NUMERICS_BEGIN_NAMESPACE_ namespace winrt::Windows::Foundation::Numerics
 #define _WINDOWS_NUMERICS_END_NAMESPACE_
 #include <windowsnumerics.impl.h>
 int main() {}

--- a/test/test_cpp20/format.cpp
+++ b/test/test_cpp20/format.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+
+#ifdef __cpp_lib_format
 #include <format>
 
 struct stringable : winrt::implements<stringable, winrt::Windows::Foundation::IStringable>
@@ -37,3 +39,4 @@ TEST_CASE("format")
     }
 #endif
 }
+#endif

--- a/test/test_cpp20/ranges.cpp
+++ b/test/test_cpp20/ranges.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+
+#ifdef __cpp_lib_ranges
 #include <algorithm>
 #include <ranges>
 
@@ -46,3 +48,4 @@ TEST_CASE("ranges")
         REQUIRE((result == std::vector{ 2, 4, 6 }));
     }
 }
+#endif


### PR DESCRIPTION
Tested locally with llvm-mingw nightly build (LLVM 169f0556530412ed1589ba5f3edeb8665bf16a91, mingw-w64 af82412710326734249c374cd3e182ffc6dce09a). This also fixes build error of test_cpp20/format.cpp with libc++ >=15.0.1