### PR TITLE
CI: Refactor LLVM setup steps and use cache

### DIFF
--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -1,0 +1,46 @@
+name: 'Set up llvm-mingw toolchain'
+description: 'Set up llvm-mingw toolchain'
+inputs:
+  llvm-mingw-version:
+    description: 'llvm-mingw version'
+    required: true
+    default: '20220906'
+  host-arch:
+    description: 'llvm-mingw toolchain host architecture (e.g. i686, x86_64)'
+    required: true
+    default: 'x86_64'
+outputs:
+  llvm-path:
+    description: "The path in which llvm-mingw is installed to"
+    value: ${{ steps.setup-llvm.outputs.llvm-path }}
+runs:
+  using: "composite"
+  steps:
+    - name: Cache llvm-mingw
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: .llvm-mingw
+        key: llvm-mingw-${{ runner.os }}-${{ inputs.llvm-mingw-version }}-${{ inputs.host-arch }}
+
+    - name: Install llvm-mingw ${{ inputs.llvm-mingw-version }} (${{ inputs.host-arch }})
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $llvm_mingw_version = "${{ inputs.llvm-mingw-version }}"
+        $llvm_arch = "${{ inputs.host-arch }}"
+        Invoke-WebRequest "https://github.com/mstorsjo/llvm-mingw/releases/download/${llvm_mingw_version}/llvm-mingw-${llvm_mingw_version}-ucrt-${llvm_arch}.zip" -OutFile llvm-mingw.zip
+        7z x llvm-mingw.zip -o"$pwd\.llvm-mingw"
+        rm llvm-mingw.zip
+
+    - name: Set up llvm-mingw
+      id: setup-llvm
+      shell: pwsh
+      run: |
+        $llvm_mingw_version = "${{ inputs.llvm-mingw-version }}"
+        $llvm_arch = "${{ inputs.host-arch }}"
+        if (!(Test-Path "$pwd\.llvm-mingw\llvm-mingw-${llvm_mingw_version}-ucrt-${llvm_arch}\bin\clang++.exe")) { return 1 }
+        Add-Content $env:GITHUB_OUTPUT "llvm-path=$pwd\.llvm-mingw\llvm-mingw-${llvm_mingw_version}-ucrt-${llvm_arch}"
+        Add-Content $env:GITHUB_PATH "$pwd\.llvm-mingw\llvm-mingw-${llvm_mingw_version}-ucrt-${llvm_arch}\bin"
+        # for the ASAN runtime DLL:
+        Add-Content $env:GITHUB_PATH "$pwd\.llvm-mingw\llvm-mingw-${llvm_mingw_version}-ucrt-${llvm_arch}\${llvm_arch}-w64-mingw32\bin"

--- a/.github/actions/setup-llvm-msvc/action.yml
+++ b/.github/actions/setup-llvm-msvc/action.yml
@@ -8,25 +8,41 @@ inputs:
 outputs:
   llvm-path:
     description: "The path in which LLVM is installed to"
-    value: ${{ steps.install-llvm.outputs.llvm-path }}
+    value: ${{ steps.setup-llvm.outputs.llvm-path }}
 runs:
   using: "composite"
   steps:
-    - id: install-llvm
-      name: Install LLVM ${{ inputs.llvm-version }}
+    - name: Cache LLVM and tools
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: |
+          .LLVM
+          .llvm-utils
+        key: llvm-msvc-${{ runner.os }}-${{ inputs.llvm-version }}
+
+    - name: Install LLVM ${{ inputs.llvm-version }}
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
         Invoke-WebRequest "https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ inputs.llvm-version }}/LLVM-${{ inputs.llvm-version }}-win64.exe" -OutFile LLVM-installer.exe
         .\LLVM-installer.exe /S "/D=$pwd\.LLVM" | Out-Null
         rm LLVM-installer.exe
-        if (!(Test-Path "$pwd\.LLVM\bin\clang-cl.exe")) { exit 1 }
-        Add-Content $env:GITHUB_PATH "$pwd\.LLVM\bin"
-        Add-Content $env:GITHUB_OUTPUT "llvm-path=$pwd\.LLVM"
 
     # Not using the LLVM tools that comes with MSVC.
-    - name: Set up LLVM build tools for msbuild
+    - name: Download LLVM build tools for msbuild
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
         Invoke-WebRequest "https://github.com/zufuliu/llvm-utils/releases/download/v22.09/LLVM_VS2017.zip" -OutFile LLVM_VS2017.zip
         7z x -y "LLVM_VS2017.zip" -o"$pwd\.llvm-utils\"
+        rm LLVM_VS2017.zip
+
+    - name: Set up LLVM build tools for msbuild
+      id: setup-llvm
+      shell: pwsh
+      run: |
+        if (!(Test-Path "$pwd\.LLVM\bin\clang-cl.exe")) { exit 1 }
+        Add-Content $env:GITHUB_PATH "$pwd\.LLVM\bin"
+        Add-Content $env:GITHUB_OUTPUT "llvm-path=$pwd\.LLVM"
         cmd /c ".llvm-utils\LLVM_VS2017\install.bat" 1

--- a/.github/actions/setup-llvm-msvc/action.yml
+++ b/.github/actions/setup-llvm-msvc/action.yml
@@ -1,0 +1,32 @@
+name: 'Set up LLVM for MSVC'
+description: 'Set up upstream LLVM for targeting MSVC ABI'
+inputs:
+  llvm-version:
+    description: 'LLVM version'
+    required: true
+    default: '15.0.5'
+outputs:
+  llvm-path:
+    description: "The path in which LLVM is installed to"
+    value: ${{ steps.install-llvm.outputs.llvm-path }}
+runs:
+  using: "composite"
+  steps:
+    - id: install-llvm
+      name: Install LLVM ${{ inputs.llvm-version }}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest "https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ inputs.llvm-version }}/LLVM-${{ inputs.llvm-version }}-win64.exe" -OutFile LLVM-installer.exe
+        .\LLVM-installer.exe /S "/D=$pwd\.LLVM" | Out-Null
+        rm LLVM-installer.exe
+        if (!(Test-Path "$pwd\.LLVM\bin\clang-cl.exe")) { exit 1 }
+        Add-Content $env:GITHUB_PATH "$pwd\.LLVM\bin"
+        Add-Content $env:GITHUB_OUTPUT "llvm-path=$pwd\.LLVM"
+
+    # Not using the LLVM tools that comes with MSVC.
+    - name: Set up LLVM build tools for msbuild
+      shell: pwsh
+      run: |
+        Invoke-WebRequest "https://github.com/zufuliu/llvm-utils/releases/download/v22.09/LLVM_VS2017.zip" -OutFile LLVM_VS2017.zip
+        7z x -y "LLVM_VS2017.zip" -o"$pwd\.llvm-utils\"
+        cmd /c ".llvm-utils\LLVM_VS2017\install.bat" 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,16 +259,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install llvm-mingw toolchain
-        run: |
-          $llvm_mingw_version = "20220906"
-          Invoke-WebRequest "https://github.com/mstorsjo/llvm-mingw/releases/download/${llvm_mingw_version}/llvm-mingw-${llvm_mingw_version}-ucrt-${{ matrix.arch }}.zip" -OutFile llvm-mingw.zip
-          7z x llvm-mingw.zip
-          rm llvm-mingw.zip
-          if (!(Test-Path "$pwd\llvm-mingw-${llvm_mingw_version}-ucrt-${{ matrix.arch }}\bin\clang++.exe")) { return 1 }
-          Add-Content $env:GITHUB_PATH "$pwd\llvm-mingw-${llvm_mingw_version}-ucrt-${{ matrix.arch }}\bin"
-          # for the ASAN runtime DLL:
-          Add-Content $env:GITHUB_PATH "$pwd\llvm-mingw-${llvm_mingw_version}-ucrt-${{ matrix.arch }}\${{ matrix.arch }}-w64-mingw32\bin"
+      - id: setup-llvm
+        name: Set up llvm-mingw
+        uses: ./.github/actions/setup-llvm-mingw
 
       - name: Build cppwinrt
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install LLVM 15
+      - id: setup-llvm
+        name: Set up LLVM (MSVC)
+        uses: ./.github/actions/setup-llvm-msvc
         if: matrix.compiler == 'clang-cl'
-        run: |
-          Invoke-WebRequest "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.2/LLVM-15.0.2-win64.exe" -OutFile LLVM-installer.exe
-          .\LLVM-installer.exe /S "/D=$pwd\LLVM" | Out-Null
-          rm LLVM-installer.exe
-          if (!(Test-Path "$pwd\LLVM\bin\clang-cl.exe")) { exit 1 }
-          Add-Content $env:GITHUB_PATH "$pwd\LLVM\bin"
-
-      - name: Set up LLVM build tools for msbuild
-        if: matrix.compiler == 'clang-cl'
-        # Not using the LLVM tools that comes with MSVC.
-        run: |
-          Invoke-WebRequest "https://github.com/zufuliu/llvm-utils/releases/download/v22.09/LLVM_VS2017.zip" -OutFile LLVM_VS2017.zip
-          7z x -y "LLVM_VS2017.zip" | Out-Null
-          cmd /c "LLVM_VS2017\install.bat" 1
 
       - name: Download nuget
         run: |
@@ -60,7 +48,7 @@ jobs:
           $target_version = "1.2.3.4"
           $props = "Configuration=$target_configuration,Platform=$target_platform,CppWinRTBuildVersion=$target_version"
           if ("${{ matrix.compiler }}" -eq "clang-cl") {
-            $props += ",Clang=1,PlatformToolset=LLVM_v143,LLVMInstallDir=$pwd\LLVM"
+            $props += ",Clang=1,PlatformToolset=LLVM_v143,LLVMInstallDir=${{ steps.setup-llvm.outputs.llvm-path }}"
           }
           Add-Content $env:GITHUB_ENV "msbuild_config_props=/p:$props"
 
@@ -120,22 +108,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install LLVM 15
+      - id: setup-llvm
+        name: Set up LLVM (MSVC)
+        uses: ./.github/actions/setup-llvm-msvc
         if: matrix.compiler == 'clang-cl'
-        run: |
-          Invoke-WebRequest "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.2/LLVM-15.0.2-win64.exe" -OutFile LLVM-installer.exe
-          .\LLVM-installer.exe /S "/D=$pwd\LLVM" | Out-Null
-          rm LLVM-installer.exe
-          if (!(Test-Path "$pwd\LLVM\bin\clang-cl.exe")) { exit 1 }
-          Add-Content $env:GITHUB_PATH "$pwd\LLVM\bin"
-
-      - name: Set up LLVM build tools for msbuild
-        if: matrix.compiler == 'clang-cl'
-        run: |
-          # Not using the LLVM tools that comes with MSVC.
-          Invoke-WebRequest "https://github.com/zufuliu/llvm-utils/releases/download/v22.09/LLVM_VS2017.zip" -OutFile LLVM_VS2017.zip
-          7z x -y "LLVM_VS2017.zip" | Out-Null
-          cmd /c "LLVM_VS2017\install.bat" 1
 
       - name: Fetch cppwinrt executables
         if: matrix.arch != 'arm64'
@@ -170,7 +146,7 @@ jobs:
           $target_version = "1.2.3.4"
           $props = "Configuration=$target_configuration,Platform=$target_platform,CppWinRTBuildVersion=$target_version"
           if ("${{ matrix.compiler }}" -eq "clang-cl") {
-            $props += ",Clang=1,PlatformToolset=LLVM_v143,LLVMInstallDir=$pwd\LLVM"
+            $props += ",Clang=1,PlatformToolset=LLVM_v143,LLVMInstallDir=${{ steps.setup-llvm.outputs.llvm-path }}"
           }
           Add-Content $env:GITHUB_ENV "msbuild_config_props=/p:$props"
 


### PR DESCRIPTION
I extracted the LLVM setup steps into composite actions and enabled caching the LLVM toolchains. The clang-cl jobs are perhaps slightly faster now but not a significant difference.