### PR TITLE
Make compatible with GCC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,9 @@ jobs:
         arch: [i686, x86_64]
         config: [Debug, Release]
     runs-on: windows-latest
+    env:
+      CMAKE_COLOR_DIAGNOSTICS: 1
+      CLICOLOR_FORCE: 1
     steps:
       - uses: actions/checkout@v3
 
@@ -278,6 +281,7 @@ jobs:
           cmake ../ -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} `
             -DDOWNLOAD_WINDOWSNUMERICS=TRUE `
             -DUSE_ANSI_COLOR=TRUE `
+            -DCMAKE_CXX_FLAGS="-fansi-escape-codes" `
             -DENABLE_TEST_SANITIZERS=$sanitizers
           cmake --build . -j2 --target cppwinrt
 
@@ -315,6 +319,9 @@ jobs:
           - { sys: mingw64, arch: x86_64, config: Release }
           - { sys: ucrt64, arch: x86_64, config: Release }
     runs-on: windows-latest
+    env:
+      CMAKE_COLOR_DIAGNOSTICS: 1
+      CLICOLOR_FORCE: 1
     defaults:
       run:
         shell: msys2 {0}
@@ -356,6 +363,9 @@ jobs:
       matrix:
         arch: [i686, x86_64]
     runs-on: ubuntu-22.04
+    env:
+      CMAKE_COLOR_DIAGNOSTICS: 1
+      CLICOLOR_FORCE: 1
     steps:
       - uses: actions/checkout@v3
 
@@ -426,6 +436,9 @@ jobs:
   build-linux-native-cppwinrt:
     name: 'linux: GCC native build + llvm-mingw cross-build tests'
     runs-on: ubuntu-22.04
+    env:
+      CMAKE_COLOR_DIAGNOSTICS: 1
+      CLICOLOR_FORCE: 1
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,7 @@ jobs:
         include:
           - { sys: mingw32, arch: i686, config: Debug }
           - { sys: mingw32, arch: i686, config: Release }
+          - { sys: mingw64, arch: x86_64, config: Debug }
           - { sys: mingw64, arch: x86_64, config: Release }
           - { sys: ucrt64, arch: x86_64, config: Release }
     runs-on: windows-latest
@@ -351,7 +352,7 @@ jobs:
       - name: Build tests
         run: |
           cd build
-          cmake --build . --target test-vanilla test_cpp20 test_win7 test_old
+          cmake --build . -j2 --target test-vanilla test_cpp20 test_win7 test_old
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,12 +443,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cross_toolchain: [gcc, llvm-mingw]
+        # TODO: Enable gcc build once Arch Linux gets more recent mingw-w64 headers (ver. 11 perhaps?)
+        # cross_toolchain: [gcc, llvm-mingw]
+        cross_toolchain: [llvm-mingw]
         cross_arch: [i686, x86_64]
-        include:
-          - cross_toolchain: gcc
-            container:
-              image: archlinux:base-devel
+        # include:
+        #   - cross_toolchain: gcc
+        #     container:
+        #       image: archlinux:base-devel
     runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     defaults:
@@ -515,7 +517,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cross_toolchain: [gcc, llvm-mingw]
+        # TODO: Enable gcc build test when it is buildable
+        # cross_toolchain: [gcc, llvm-mingw]
+        cross_toolchain: [llvm-mingw]
         cross_arch: [i686, x86_64]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
           }
           cmake ../ -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.config }} `
             -DDOWNLOAD_WINDOWSNUMERICS=TRUE `
+            -DUSE_ANSI_COLOR=TRUE `
             -DENABLE_TEST_SANITIZERS=$sanitizers
           cmake --build . -j2 --target cppwinrt
 
@@ -335,7 +336,8 @@ jobs:
           mkdir build
           cd build
           cmake ../ -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-            -DDOWNLOAD_WINDOWSNUMERICS=TRUE
+            -DDOWNLOAD_WINDOWSNUMERICS=TRUE \
+            -DUSE_ANSI_COLOR=TRUE
           cmake --build . --target cppwinrt
 
       - name: Build tests
@@ -412,7 +414,8 @@ jobs:
           cd build
           cmake ../test -G"MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug `
             -DCPPWINRT_PROJECTION_INCLUDE_DIR="../.test/out" `
-            -DDOWNLOAD_WINDOWSNUMERICS=TRUE
+            -DDOWNLOAD_WINDOWSNUMERICS=TRUE `
+            -DUSE_ANSI_COLOR=TRUE
           cmake --build . -j2
 
       - name: Run tests
@@ -453,7 +456,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_FLAGS="-static" \
             -DCPPWINRT_PROJECTION_INCLUDE_DIR=/tmp/cppwinrt \
-            -DDOWNLOAD_WINDOWSNUMERICS=TRUE
+            -DDOWNLOAD_WINDOWSNUMERICS=TRUE \
+            -DUSE_ANSI_COLOR=TRUE
           cmake --build build/cross-tests -j2
 
       - name: Upload built tests
@@ -484,7 +488,7 @@ jobs:
           $has_failed_tests = 0
           foreach ($test_exe in $test_exes) {
             echo "::group::Run '$test_exe'"
-            & .\$test_exe
+            & .\$test_exe --use-colour yes
             echo "::endgroup::"
             if ($LastExitCode -ne 0) {
               echo "::error::Test '$test_exe' failed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,9 +344,13 @@ jobs:
         run: |
           mkdir build
           cd build
+          if [[ "${{ matrix.arch }}" = "i686" ]]; then
+            skip_large_pch_arg="-DSKIP_LARGE_PCH=TRUE"
+          fi
           cmake ../ -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             -DDOWNLOAD_WINDOWSNUMERICS=TRUE \
-            -DUSE_ANSI_COLOR=TRUE
+            -DUSE_ANSI_COLOR=TRUE \
+            $skip_large_pch_arg
           cmake --build . --target cppwinrt
 
       - name: Build tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,51 @@ jobs:
           $env:UBSAN_OPTIONS = "print_stacktrace=1"
           ctest --verbose
 
+  test-msys2-gcc-cppwinrt:
+    name: 'gcc/msys2: Build and test (${{ matrix.sys }}, ${{ matrix.config }})'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: mingw32, arch: i686, config: Debug }
+          - { sys: mingw32, arch: i686, config: Release }
+          - { sys: mingw64, arch: x86_64, config: Release }
+          - { sys: ucrt64, arch: x86_64, config: Release }
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          pacboy: >-
+            crt:p
+            gcc:p
+            binutils:p
+            cmake:p
+            ninja:p
+
+      - uses: actions/checkout@v3
+
+      - name: Build cppwinrt
+        run: |
+          mkdir build
+          cd build
+          cmake ../ -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+            -DDOWNLOAD_WINDOWSNUMERICS=TRUE
+          cmake --build . --target cppwinrt
+
+      - name: Build tests
+        run: |
+          cd build
+          cmake --build . --target test-vanilla test_cpp20 test_win7 test_old
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --verbose
+
   build-linux-cross-cppwinrt:
     name: 'cross: Cross-build from Linux'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.sys}}
+          update: true
           pacboy: >-
             crt:p
             gcc:p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: mingw32, arch: i686, config: Debug }
           - { sys: mingw32, arch: i686, config: Release }
           - { sys: mingw64, arch: x86_64, config: Debug }
           - { sys: mingw64, arch: x86_64, config: Release }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,13 +439,32 @@ jobs:
           ctest --verbose
 
   build-linux-native-cppwinrt:
-    name: 'linux: GCC native build + llvm-mingw cross-build tests'
+    name: 'linux: GCC native build + mingw-w64 cross-build tests'
+    strategy:
+      fail-fast: false
+      matrix:
+        cross_toolchain: [gcc, llvm-mingw]
+        cross_arch: [i686, x86_64]
+        include:
+          - cross_toolchain: gcc
+            container:
+              image: archlinux:base-devel
     runs-on: ubuntu-22.04
+    container: ${{ matrix.container }}
+    defaults:
+      run:
+        shell: bash
     env:
       CMAKE_COLOR_DIAGNOSTICS: 1
       CLICOLOR_FORCE: 1
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install build tools
+        if: matrix.cross_toolchain == 'gcc'
+        run: |
+          pacman --noconfirm -Suuy
+          pacman --needed --noconfirm -S cmake ninja git
 
       - name: Build cppwinrt
         run: |
@@ -465,12 +484,18 @@ jobs:
 
       - id: setup-llvm
         name: Set up llvm-mingw
+        if: matrix.cross_toolchain == 'llvm-mingw'
         uses: ./.github/actions/setup-llvm-mingw
+
+      - name: Install GCC cross compiler
+        if: matrix.cross_toolchain == 'gcc'
+        run: |
+          pacman --needed --noconfirm -S mingw-w64-gcc
 
       - name: Cross-build tests using projection
         run: |
           cmake -S test -B build/cross-tests --toolchain "$PWD/cross-mingw-toolchain.cmake" \
-            -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
+            -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.cross_arch }} \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_FLAGS="-static" \
             -DCPPWINRT_PROJECTION_INCLUDE_DIR=/tmp/cppwinrt \
@@ -481,15 +506,17 @@ jobs:
       - name: Upload built tests
         uses: actions/upload-artifact@v3
         with:
-          name: linux-native-cppwinrt-cross-build-tests-x86_64-bin
+          name: linux-native-cppwinrt-cross-build-tests-${{ matrix.cross_toolchain }}-${{ matrix.cross_arch }}-bin
           path: build/cross-tests/*.exe
 
   test-linux-native-cppwinrt-cross-tests:
     name: 'linux: Run llvm-mingw cross-build tests'
     needs: build-linux-native-cppwinrt
     strategy:
+      fail-fast: false
       matrix:
-        arch: [x86_64]
+        cross_toolchain: [gcc, llvm-mingw]
+        cross_arch: [i686, x86_64]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -497,7 +524,7 @@ jobs:
       - name: Fetch test executables
         uses: actions/download-artifact@v3
         with:
-          name: linux-native-cppwinrt-cross-build-tests-${{ matrix.arch }}-bin
+          name: linux-native-cppwinrt-cross-build-tests-${{ matrix.cross_toolchain }}-${{ matrix.cross_arch }}-bin
           path: ./
 
       - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ ExternalProject_Add(winmd
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
 )
 add_dependencies(cppwinrt winmd)
 ExternalProject_Get_Property(winmd SOURCE_DIR)

--- a/strings/base_chrono.h
+++ b/strings/base_chrono.h
@@ -47,7 +47,7 @@ WINRT_EXPORT namespace winrt
 
         static time_point from_time_t(time_t time) noexcept
         {
-            return std::chrono::time_point_cast<duration>(from_sys(std::chrono::system_clock::from_time_t(time)));
+            return from_sys(std::chrono::time_point_cast<duration>(std::chrono::system_clock::from_time_t(time)));
         }
 
         static file_time to_file_time(time_point const& time) noexcept

--- a/strings/base_chrono.h
+++ b/strings/base_chrono.h
@@ -42,7 +42,7 @@ WINRT_EXPORT namespace winrt
 
         static time_t to_time_t(time_point const& time) noexcept
         {
-            return static_cast<time_t>(std::chrono::system_clock::to_time_t(to_sys(std::chrono::time_point_cast<std::chrono::system_clock::duration>(time))));
+            return static_cast<time_t>(std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::system_clock::duration>(to_sys(time))));
         }
 
         static time_point from_time_t(time_t time) noexcept

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -556,18 +556,35 @@ WINRT_EXPORT namespace winrt
         return awaitable{ handle, timeout };
     }
 
+    // HACK: GCC does not compile co_await on thread_pool because it wants
+    // a copy constructor. Since m_pool is not copyable, in order to provide
+    // a workaround we have to wrap it in a shared_ptr. Apply this workaround
+    // only for GCC so we don't affect other compilers.
+    // This might be related to upstream bug:
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103963
     struct thread_pool
     {
         thread_pool() :
+#if defined(__GNUC__) && !defined(__clang__)
+            m_pool(std::make_shared<handle_type<pool_traits>>(
+                check_pointer(WINRT_IMPL_CreateThreadpool(nullptr))))
+#else
             m_pool(check_pointer(WINRT_IMPL_CreateThreadpool(nullptr)))
+#endif
         {
-            m_environment.Pool = m_pool.get();
+            m_environment.Pool = get_pool();
         }
+
+#if defined(__GNUC__) && !defined(__clang__)
+        // HACK: See above
+        thread_pool(thread_pool const&) = default;
+        thread_pool &operator=(thread_pool const&) = delete;
+#endif
 
         void thread_limits(uint32_t const high, uint32_t const low)
         {
-            WINRT_IMPL_SetThreadpoolThreadMaximum(m_pool.get(), high);
-            check_bool(WINRT_IMPL_SetThreadpoolThreadMinimum(m_pool.get(), low));
+            WINRT_IMPL_SetThreadpoolThreadMaximum(get_pool(), high);
+            check_bool(WINRT_IMPL_SetThreadpoolThreadMinimum(get_pool(), low));
         }
 
         bool await_ready() const noexcept
@@ -632,7 +649,21 @@ WINRT_EXPORT namespace winrt
             uint32_t Size{ sizeof(environment) };
         };
 
+        pool_traits::type get_pool() const
+        {
+#if defined(__GNUC__) && !defined(__clang__)
+            return m_pool->get();
+#else
+            return m_pool.get();
+#endif
+        }
+
+#if defined(__GNUC__) && !defined(__clang__)
+        // HACK: See above
+        std::shared_ptr<handle_type<pool_traits>> m_pool;
+#else
         handle_type<pool_traits> m_pool;
+#endif
         environment m_environment;
     };
 

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -328,6 +328,19 @@ WINRT_EXPORT namespace winrt
             {
             }
 
+#if defined(__GNUC__) && !defined(__clang__)
+            // HACK: GCC seems to require a move when calling operator co_await
+            // on the return value of resume_after.
+            // This might be related to upstream bug:
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99575
+            awaitable(awaitable &&other) noexcept :
+                m_timer{std::move(other.m_timer)},
+                m_duration{std::move(other.m_duration)},
+                m_handle{std::move(other.m_handle)},
+                m_state{other.m_state.load()}
+            {}
+#endif
+
             void enable_cancellation(cancellable_promise* promise)
             {
                 promise->set_canceller([](void* context)
@@ -433,6 +446,21 @@ WINRT_EXPORT namespace winrt
                 m_timeout(timeout),
                 m_handle(handle)
             {}
+
+#if defined(__GNUC__) && !defined(__clang__)
+            // HACK: GCC seems to require a move when calling operator co_await
+            // on the return value of resume_on_signal.
+            // This might be related to upstream bug:
+            // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99575
+            awaitable(awaitable &&other) noexcept :
+                m_wait{std::move(other.m_wait)},
+                m_timeout{std::move(other.m_timeout)},
+                m_handle{std::move(other.m_handle)},
+                m_result{std::move(other.m_result)},
+                m_resume{std::move(other.m_resume)},
+                m_state{other.m_state.load()}
+            {}
+#endif
 
             void enable_cancellation(cancellable_promise* promise)
             {

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -93,9 +93,15 @@ extern "C"
 #endif
 #elif defined(__GNUC__)
 #if defined(__i386__)
-#define WINRT_IMPL_LINK(function, count) __asm__(".weak _WINRT_IMPL_" #function "@" #count "\n.set _WINRT_IMPL_" #function "@" #count ", _" #function "@" #count);
+#define WINRT_IMPL_LINK(function, count) __asm__( \
+    ".globl _" #function "@" #count "\n\t" \
+    ".weak _WINRT_IMPL_" #function "@" #count "\n\t" \
+    ".set _WINRT_IMPL_" #function "@" #count ", _" #function "@" #count);
 #else
-#define WINRT_IMPL_LINK(function, count) __asm__(".weak WINRT_IMPL_" #function "\n.set WINRT_IMPL_" #function ", " #function);
+#define WINRT_IMPL_LINK(function, count) __asm__( \
+    ".globl " #function "\n\t" \
+    ".weak WINRT_IMPL_" #function "\n\t" \
+    ".set WINRT_IMPL_" #function ", " #function);
 #endif
 #endif
 

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -27,7 +27,9 @@
 
 #if __has_include(<windowsnumerics.impl.h>)
 #define WINRT_IMPL_NUMERICS
+#if __has_include(<directxmath.h>)
 #include <directxmath.h>
+#endif
 #endif
 
 #ifndef WINRT_LEAN_AND_MEAN

--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -27,9 +27,7 @@
 
 #if __has_include(<windowsnumerics.impl.h>)
 #define WINRT_IMPL_NUMERICS
-#if __has_include(<directxmath.h>)
 #include <directxmath.h>
-#endif
 #endif
 
 #ifndef WINRT_LEAN_AND_MEAN

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -488,11 +488,23 @@ namespace winrt::impl
 
         T const& object;
 
+#if !defined(__GNUC__) || defined(__clang__)
         template <typename R>
         operator R const& () const noexcept
         {
             return reinterpret_cast<R const&>(object);
         }
+#else
+        // HACK: GCC does not handle template deduction of const T& conversion
+        // function according to CWG issue 976. To make this compile on GCC,
+        // we have to intentionally drop the const qualifier.
+        // Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61663
+        template <typename R>
+        operator R& () const noexcept
+        {
+            return const_cast<R&>(reinterpret_cast<R const&>(object));
+        }
+#endif
     };
 
     template <typename T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,13 @@ if(ENABLE_TEST_SANITIZERS)
 endif()
 
 
+set(USE_ANSI_COLOR FALSE CACHE BOOL "Enable ANSI colour output for Catch2 test runner.")
+if(USE_ANSI_COLOR)
+    add_compile_definitions(CATCH_CONFIG_COLOUR_ANSI)
+    set(TEST_COLOR_ARG "--use-colour yes")
+endif()
+
+
 add_subdirectory(test)
 add_subdirectory(test_cpp20)
 add_subdirectory(test_win7)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,9 @@ if(USE_ANSI_COLOR)
 endif()
 
 
+set(SKIP_LARGE_PCH FALSE CACHE BOOL "Skip building large precompiled headers.")
+
+
 add_subdirectory(test)
 add_subdirectory(test_cpp20)
 add_subdirectory(test_win7)

--- a/test/old_tests/UnitTests/CMakeLists.txt
+++ b/test/old_tests/UnitTests/CMakeLists.txt
@@ -47,11 +47,13 @@ endforeach()
 add_executable(test_old Main.cpp ${TEST_SRCS})
 target_link_libraries(test_old runtimeobject synchronization)
 
-target_precompile_headers(test_old PRIVATE pch.h)
-set_source_files_properties(
-    conditional_implements_pure.cpp
-    PROPERTIES SKIP_PRECOMPILE_HEADERS true
-)
+if(NOT SKIP_LARGE_PCH)
+    target_precompile_headers(test_old PRIVATE pch.h)
+    set_source_files_properties(
+        conditional_implements_pure.cpp
+        PROPERTIES SKIP_PRECOMPILE_HEADERS true
+    )
+endif()
 
 add_dependencies(test_old build-cppwinrt-projection)
 

--- a/test/old_tests/UnitTests/CMakeLists.txt
+++ b/test/old_tests/UnitTests/CMakeLists.txt
@@ -57,5 +57,5 @@ add_dependencies(test_old build-cppwinrt-projection)
 
 add_test(
     NAME test_old
-    COMMAND "$<TARGET_FILE:test_old>"
+    COMMAND "$<TARGET_FILE:test_old>" ${TEST_COLOR_ARG}
 )

--- a/test/old_tests/UnitTests/agile_ref.cpp
+++ b/test/old_tests/UnitTests/agile_ref.cpp
@@ -39,6 +39,9 @@ IAsyncAction test_agile_ref()
 #if defined(__clang__) && defined(_MSC_VER) && (defined(_M_IX86) || defined(__i386__))
 // FIXME: Test is known to crash from calling invalid address on x86 when built with Clang.
 TEST_CASE("agile_ref", "[.clang-crash]")
+#elif defined(__GNUC__) && !defined(__clang__)
+// FIXME: Test is known to randomly crash or abort when built with GCC (segfaults under appverifier).
+TEST_CASE("agile_ref", "[.gcc-crash]")
 #else
 TEST_CASE("agile_ref")
 #endif

--- a/test/old_tests/UnitTests/async.cpp
+++ b/test/old_tests/UnitTests/async.cpp
@@ -1566,10 +1566,12 @@ namespace
         co_await resume_on_signal(signal); // should not suspend because already signaled
         REQUIRE(caller == GetCurrentThreadId()); // still on calling thread
 
-        REQUIRE(false == co_await resume_on_signal(signal, 1us)); // should suspend but timeout
+        bool suspend_but_timeout_result = co_await resume_on_signal(signal, 1us);
+        REQUIRE(false == suspend_but_timeout_result); // should suspend but timeout
         REQUIRE(caller != GetCurrentThreadId()); // now on background thread
 
-        REQUIRE(true == co_await resume_on_signal(signal, 1s)); // should eventually succeed
+        bool suspend_and_succeed_result = co_await resume_on_signal(signal, 1s);
+        REQUIRE(true == suspend_and_succeed_result); // should eventually succeed
     }
 }
 

--- a/test/old_tests/UnitTests/hstring.cpp
+++ b/test/old_tests/UnitTests/hstring.cpp
@@ -272,7 +272,6 @@ TEST_CASE("hstring,operator,std::wstring_view")
     REQUIRE(L"abc" == ws);
 
     hs.clear();
-    REQUIRE(L"abc" == ws);
     ws = hs;
     REQUIRE(ws.empty());
 }

--- a/test/old_tests/UnitTests/weak.cpp
+++ b/test/old_tests/UnitTests/weak.cpp
@@ -50,8 +50,8 @@ namespace
         }
     };
 
-// FIXME: Fail to compile with Clang due to incomplete type.
-#if !defined(__clang__)
+// FIXME: Fail to compile with Clang and GCC due to incomplete type.
+#if !defined(__clang__) && !defined(__GNUC__)
     struct WeakWithSelfReference : implements<WeakWithSelfReference, IStringable>
     {
         winrt::weak_ref<WeakWithSelfReference> weak_self = get_weak();
@@ -447,8 +447,8 @@ TEST_CASE("weak,assignment")
     // Not constructible from L"" (because Uri constructor is explicit)
     static_assert(!std::is_constructible_v<weak_ref<Uri>, const wchar_t*>);
 
-// FIXME: WeakWithSelfReference fails to compile with Clang.
-#if !defined(__clang__)
+// FIXME: WeakWithSelfReference fails to compile with Clang and GCC.
+#if !defined(__clang__) && !defined(__GNUC__)
     // Constructible from com_ptr<Derived> because com_ptr<Derived> is
     // implicitly convertible to com_ptr<Base>.
     struct Derived : WeakWithSelfReference {};
@@ -487,8 +487,8 @@ TEST_CASE("weak,no_module_lock")
     REQUIRE(get_module_lock() == object_count);
 }
 
-// FIXME: WeakWithSelfReference fails to compile with Clang.
-#if !defined(__clang__)
+// FIXME: WeakWithSelfReference fails to compile with Clang and GCC.
+#if !defined(__clang__) && !defined(__GNUC__)
 TEST_CASE("weak,self")
 {
     // The REQUIRE statements are in the WeakWithSelfReference class itself.

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -67,6 +67,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC seems to miscompile out_params_bad.cpp if -fdevirtualize is enabled.
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108040
     set_source_files_properties(out_params_bad.cpp PROPERTIES COMPILE_OPTIONS "-fno-devirtualize")
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        # GCC miscompiles multi_threaded_vector.cpp with -O3
+        set_source_files_properties(multi_threaded_vector.cpp PROPERTIES COMPILE_OPTIONS "-O2")
+    endif()
 endif()
 
 add_dependencies(test-vanilla build-cppwinrt-projection)

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -39,6 +39,16 @@ list(APPEND BROKEN_TESTS
     when
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # FIXME: GCC does not compile co_await on thread_pool because it wants
+    # a copy constructor. Disabling this test for now.
+    # This might be related to upstream bug:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103963
+    list(APPEND BROKEN_TESTS
+        thread_pool
+    )
+endif()
+
 # Exclude broken tests
 foreach(TEST_SRCS_EXCLUDE_ITEM IN LISTS BROKEN_TESTS)
     list(FILTER TEST_SRCS EXCLUDE REGEX "/${TEST_SRCS_EXCLUDE_ITEM}\\.cpp")

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -78,5 +78,5 @@ add_dependencies(test-vanilla build-cppwinrt-projection)
 
 add_test(
     NAME test
-    COMMAND "$<TARGET_FILE:test-vanilla>"
+    COMMAND "$<TARGET_FILE:test-vanilla>" ${TEST_COLOR_ARG}
 )

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -63,6 +63,12 @@ set_source_files_properties(
     PROPERTIES SKIP_PRECOMPILE_HEADERS true
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # GCC seems to miscompile out_params_bad.cpp if -fdevirtualize is enabled.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108040
+    set_source_files_properties(out_params_bad.cpp PROPERTIES COMPILE_OPTIONS "-fno-devirtualize")
+endif()
+
 add_dependencies(test-vanilla build-cppwinrt-projection)
 
 add_test(

--- a/test/test/async_propagate_cancel.cpp
+++ b/test/test/async_propagate_cancel.cpp
@@ -132,7 +132,8 @@ namespace
 // FIXME: Test is known to segfault when built with Clang.
 TEST_CASE("async_propagate_cancel", "[.clang-crash]")
 #else
-TEST_CASE("async_propagate_cancel")
+// FIXME: mayfail because of https://github.com/microsoft/cppwinrt/issues/1243
+TEST_CASE("async_propagate_cancel", "[!mayfail]")
 #endif
 {
     Check(Action);

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -109,7 +109,7 @@ TEST_CASE("custom_error_logger")
     REQUIRE(s_loggerArgs.functionName == nullptr);
 #else
     // GCC/Clang can only compile these tests in C++20 mode. If source_location
-    // is available these fields will be filled in. Don't do any cheks here
+    // is available these fields will be filled in. Don't do any checks here
     // because these are already tested in `test_cpp20/custom_error.cpp`.
 #endif
 

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -102,10 +102,21 @@ TEST_CASE("custom_error_logger")
     // Validate that handler translated exception
     REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
     REQUIRE(s_loggerCalled);
+#ifndef __cpp_lib_source_location
     // In C++17 these fields cannot be filled in so they are expected to be empty.
     REQUIRE(s_loggerArgs.lineNumber == 0);
     REQUIRE(s_loggerArgs.fileName == nullptr);
     REQUIRE(s_loggerArgs.functionName == nullptr);
+#else
+    // GCC can only compile these tests in C++20 so these fields will be filled in.
+    REQUIRE(s_loggerArgs.lineNumber == 103);
+    const auto fileNameSv = std::string_view(s_loggerArgs.fileName);
+    REQUIRE(!fileNameSv.empty());
+    REQUIRE(fileNameSv.find("custom_error.cpp") != std::string::npos);
+    const auto functionNameSv = std::string_view(s_loggerArgs.functionName);
+    REQUIRE(!functionNameSv.empty());
+    // Don't check the function name here. It is tested in `test_cpp20/custom_error.cpp`.
+#endif
 
     REQUIRE(s_loggerArgs.returnAddress);
     REQUIRE(s_loggerArgs.result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -108,14 +108,9 @@ TEST_CASE("custom_error_logger")
     REQUIRE(s_loggerArgs.fileName == nullptr);
     REQUIRE(s_loggerArgs.functionName == nullptr);
 #else
-    // GCC can only compile these tests in C++20 so these fields will be filled in.
-    REQUIRE(s_loggerArgs.lineNumber == 103);
-    const auto fileNameSv = std::string_view(s_loggerArgs.fileName);
-    REQUIRE(!fileNameSv.empty());
-    REQUIRE(fileNameSv.find("custom_error.cpp") != std::string::npos);
-    const auto functionNameSv = std::string_view(s_loggerArgs.functionName);
-    REQUIRE(!functionNameSv.empty());
-    // Don't check the function name here. It is tested in `test_cpp20/custom_error.cpp`.
+    // GCC/Clang can only compile these tests in C++20 mode. If source_location
+    // is available these fields will be filled in. Don't do any cheks here
+    // because these are already tested in `test_cpp20/custom_error.cpp`.
 #endif
 
     REQUIRE(s_loggerArgs.returnAddress);

--- a/test/test_cpp20/CMakeLists.txt
+++ b/test/test_cpp20/CMakeLists.txt
@@ -42,5 +42,5 @@ add_dependencies(test_cpp20 build-cppwinrt-projection)
 
 add_test(
     NAME test_cpp20
-    COMMAND "$<TARGET_FILE:test_cpp20>"
+    COMMAND "$<TARGET_FILE:test_cpp20>" ${TEST_COLOR_ARG}
 )

--- a/test/test_cpp20/CMakeLists.txt
+++ b/test/test_cpp20/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(CMAKE_CXX_STANDARD 20)
-# std::format, std::ranges::is_heap, std::views::reverse, std::ranges::max
-# are experimental in libc++ as of Clang 15.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # std::format, std::ranges::is_heap, std::views::reverse, std::ranges::max
+    # are experimental in libc++ as of Clang 15.
+    # FIXME: Should probably use compile test instead?
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
+endif()
 
 if(ENABLE_TEST_SANITIZERS)
     # As of LLVM 15, custom_error.cpp doesn't build with ASAN due to:

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -59,7 +59,11 @@ TEST_CASE("custom_error_logger")
     REQUIRE(fileNameSv.find("custom_error.cpp") != std::string::npos);
     const auto functionNameSv = std::string_view(s_loggerArgs.functionName);
     REQUIRE(!functionNameSv.empty());
+#if defined(__GNUC__) && !defined(__clang__)
+    REQUIRE(functionNameSv == "void {anonymous}::FailOnLine15()");
+#else
     REQUIRE(functionNameSv == "FailOnLine15");
+#endif
 
     REQUIRE(s_loggerArgs.returnAddress);
     REQUIRE(s_loggerArgs.result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)

--- a/test/test_win7/CMakeLists.txt
+++ b/test/test_win7/CMakeLists.txt
@@ -54,5 +54,5 @@ add_dependencies(test_win7 build-cppwinrt-projection)
 
 add_test(
     NAME test_win7
-    COMMAND "$<TARGET_FILE:test_win7>"
+    COMMAND "$<TARGET_FILE:test_win7>" ${TEST_COLOR_ARG}
 )

--- a/test/test_win7/CMakeLists.txt
+++ b/test/test_win7/CMakeLists.txt
@@ -32,6 +32,16 @@ list(APPEND BROKEN_TESTS
     when
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # FIXME: GCC does not compile co_await on thread_pool because it wants
+    # a copy constructor. Disabling this test for now.
+    # This might be related to upstream bug:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103963
+    list(APPEND BROKEN_TESTS
+        thread_pool
+    )
+endif()
+
 # Exclude broken tests
 foreach(TEST_SRCS_EXCLUDE_ITEM IN LISTS BROKEN_TESTS)
     list(FILTER TEST_SRCS EXCLUDE REGEX "/${TEST_SRCS_EXCLUDE_ITEM}\\.cpp")


### PR DESCRIPTION
Changes for GCC compatibility:

- Added GCC-only hack for `winrt::impl::bind_in` mentioned in https://github.com/microsoft/cppwinrt/pull/1234 (upstream: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61663)
- Fixed the `WINRT_IMPL_LINK` macro to properly declare the symbol as global (__GNUC__).
- Added GCC-only hack move constructors to the awaitables in `resume_after` and `resume_on_signal` because GCC adds useless moves in `co_await` (suspect to be https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99575)
- ~~Added GCC-only hack copy constructor to `thread_pool` because GCC seems to want it when building the `thread_pool.cpp` test (suspect to be https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103963)~~
    - ~~Note that this also changes the `m_pool` field to be a `std::shared_ptr`.~~
    - (reverted)
- Fixed signed overflow in `winrt::clock` if `system_clock` has nanosecond resolution
- Miscellaneous test fixes and disabled some unbuildable or unreliable tests
- Added CI for GCC using msys2
    - I also tried adding a cross build test, but Ubuntu has only GCC 10 and even the mingw-w64 on Arch Linux isn't recent enough to have sufficiently working headers (some fixes are not in the latest release).

General changes:

- Enabled colour diagnostics and test output for all CI builds
- ~~Include `directxmath.h` only if it exists (for compatibility with older mingw-w64 headers)~~ (reverted)
- Tagged async_propagate_cancel test as mayfail so that it doesn't block CI (please fix with https://github.com/microsoft/cppwinrt/issues/1243)

I am not happy with the move/copy constructor hacks, but they seem unavoidable unless GCC have their bugs fixed...

CC @Biswa96 @mstorsjo