### PR TITLE
Fix cancellation propagation by moving responsability to awaiter

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -173,19 +173,31 @@ WINRT_EXPORT namespace winrt
             }
         }
 
+        bool enable_cancellation_propagation(bool value) noexcept
+        {
+            return std::exchange(m_propagate_cancellation, value);
+        }
+
+        bool cancellation_propagation_enabled() const noexcept
+        {
+            return m_propagate_cancellation;
+        }
+
     private:
         static inline auto const cancelling_ptr = reinterpret_cast<canceller_t>(1);
 
         std::atomic<canceller_t> m_canceller{ nullptr };
         void* m_context{ nullptr };
+        bool m_propagate_cancellation{ false };
     };
 
-    struct enable_await_cancellation
+    template <typename Derived>
+    struct cancellable_awaiter
     {
-        enable_await_cancellation() noexcept = default;
-        enable_await_cancellation(enable_await_cancellation const&) = default;
+        cancellable_awaiter() noexcept = default;
+        cancellable_awaiter(cancellable_awaiter const&) = default;
 
-        ~enable_await_cancellation()
+        ~cancellable_awaiter()
         {
             if (m_promise)
             {
@@ -193,14 +205,27 @@ WINRT_EXPORT namespace winrt
             }
         }
 
-        void operator=(enable_await_cancellation const&) = delete;
+        void operator=(cancellable_awaiter const&) = delete;
 
-        void set_cancellable_promise(cancellable_promise* promise) noexcept
+    protected:
+        template <typename T>
+        void set_cancellable_promise_from_handle(impl::coroutine_handle<T> const& handle)
         {
-            m_promise = promise;
+            if constexpr (std::is_base_of_v<cancellable_promise, T>)
+            {
+                set_cancellable_promise(&handle.promise());
+            }
         }
 
     private:
+        void set_cancellable_promise(cancellable_promise* promise)
+        {
+            if (promise->cancellation_propagation_enabled())
+            {
+                m_promise = promise;
+                static_cast<Derived*>(this)->enable_cancellation(m_promise);
+            }
+        }
 
         cancellable_promise* m_promise = nullptr;
     };
@@ -308,6 +333,213 @@ namespace winrt::impl
             impl::resume_apartment(context.context, handle, &failure);
         }
     };
+
+    struct timespan_awaiter : cancellable_awaiter<timespan_awaiter>
+    {
+        explicit timespan_awaiter(Windows::Foundation::TimeSpan duration) noexcept :
+            m_duration(duration)
+        {
+        }
+
+        void enable_cancellation(cancellable_promise* promise)
+        {
+            promise->set_canceller([](void* context)
+            {
+                auto that = static_cast<timespan_awaiter*>(context);
+                if (that->m_state.exchange(state::canceled, std::memory_order_acquire) == state::pending)
+                {
+                    that->fire_immediately();
+                }
+            }, this);
+        }
+
+        bool await_ready() const noexcept
+        {
+            return m_duration.count() <= 0;
+        }
+
+        template <typename T>
+        void await_suspend(impl::coroutine_handle<T> handle)
+        {
+            set_cancellable_promise_from_handle(handle);
+
+            m_handle = handle;
+            create_threadpool_timer();
+        }
+
+        void await_resume()
+        {
+            if (m_state.exchange(state::idle, std::memory_order_relaxed) == state::canceled)
+            {
+                throw hresult_canceled();
+            }
+        }
+
+    private:
+        void create_threadpool_timer()
+        {
+            m_timer.attach(check_pointer(WINRT_IMPL_CreateThreadpoolTimer(callback, this, nullptr)));
+            int64_t relative_count = -m_duration.count();
+            WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &relative_count, 0, 0);
+
+            state expected = state::idle;
+            if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
+            {
+                fire_immediately();
+            }
+        }
+
+        static int32_t __stdcall fallback_SetThreadpoolTimerEx(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept
+        {
+            return 0; // pretend timer has already triggered and a callback is on its way
+        }
+
+        void fire_immediately() noexcept
+        {
+            static int32_t(__stdcall * handler)(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept;
+            impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolTimerEx", handler, fallback_SetThreadpoolTimerEx);
+
+            if (handler(m_timer.get(), nullptr, 0, 0))
+            {
+                int64_t now = 0;
+                WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &now, 0, 0);
+            }
+        }
+
+        static void __stdcall callback(void*, void* context, void*) noexcept
+        {
+            auto that = reinterpret_cast<timespan_awaiter*>(context);
+            that->m_handle();
+        }
+
+        struct timer_traits
+        {
+            using type = impl::ptp_timer;
+
+            static void close(type value) noexcept
+            {
+                WINRT_IMPL_CloseThreadpoolTimer(value);
+            }
+
+            static constexpr type invalid() noexcept
+            {
+                return nullptr;
+            }
+        };
+
+        enum class state { idle, pending, canceled };
+
+        handle_type<timer_traits> m_timer;
+        Windows::Foundation::TimeSpan m_duration;
+        impl::coroutine_handle<> m_handle;
+        std::atomic<state> m_state{ state::idle };
+    };
+
+    struct signal_awaiter : cancellable_awaiter<signal_awaiter>
+    {
+        signal_awaiter(void* handle, Windows::Foundation::TimeSpan timeout) noexcept :
+            m_timeout(timeout),
+            m_handle(handle)
+        {}
+
+        void enable_cancellation(cancellable_promise* promise)
+        {
+            promise->set_canceller([](void* context)
+            {
+                auto that = static_cast<signal_awaiter*>(context);
+                if (that->m_state.exchange(state::canceled, std::memory_order_acquire) == state::pending)
+                {
+                    that->fire_immediately();
+                }
+            }, this);
+        }
+
+        bool await_ready() const noexcept
+        {
+            return WINRT_IMPL_WaitForSingleObject(m_handle, 0) == 0;
+        }
+
+        template <typename T>
+        void await_suspend(impl::coroutine_handle<T> resume)
+        {
+            set_cancellable_promise_from_handle(resume);
+
+            m_resume = resume;
+            create_threadpool_wait();
+        }
+
+        bool await_resume()
+        {
+            if (m_state.exchange(state::idle, std::memory_order_relaxed) == state::canceled)
+            {
+                throw hresult_canceled();
+            }
+            return m_result == 0;
+        }
+
+    private:
+        static int32_t __stdcall fallback_SetThreadpoolWaitEx(winrt::impl::ptp_wait, void*, void*, void*) noexcept
+        {
+            return 0; // pretend wait has already triggered and a callback is on its way
+        }
+
+        void create_threadpool_wait()
+        {
+            m_wait.attach(check_pointer(WINRT_IMPL_CreateThreadpoolWait(callback, this, nullptr)));
+            int64_t relative_count = -m_timeout.count();
+            int64_t* file_time = relative_count != 0 ? &relative_count : nullptr;
+            WINRT_IMPL_SetThreadpoolWait(m_wait.get(), m_handle, file_time);
+
+            state expected = state::idle;
+            if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
+            {
+                fire_immediately();
+            }
+        }
+
+        void fire_immediately() noexcept
+        {
+            static int32_t(__stdcall * handler)(winrt::impl::ptp_wait, void*, void*, void*) noexcept;
+            impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolWaitEx", handler, fallback_SetThreadpoolWaitEx);
+
+            if (handler(m_wait.get(), nullptr, nullptr, nullptr))
+            {
+                int64_t now = 0;
+                WINRT_IMPL_SetThreadpoolWait(m_wait.get(), WINRT_IMPL_GetCurrentProcess(), &now);
+            }
+        }
+
+        static void __stdcall callback(void*, void* context, void*, uint32_t result) noexcept
+        {
+            auto that = static_cast<signal_awaiter*>(context);
+            that->m_result = result;
+            that->m_resume();
+        }
+
+        struct wait_traits
+        {
+            using type = impl::ptp_wait;
+
+            static void close(type value) noexcept
+            {
+                WINRT_IMPL_CloseThreadpoolWait(value);
+            }
+
+            static constexpr type invalid() noexcept
+            {
+                return nullptr;
+            }
+        };
+
+        enum class state { idle, pending, canceled };
+
+        handle_type<wait_traits> m_wait;
+        Windows::Foundation::TimeSpan m_timeout;
+        void* m_handle;
+        uint32_t m_result{};
+        impl::coroutine_handle<> m_resume{ nullptr };
+        std::atomic<state> m_state{ state::idle };
+    };
 }
 
 WINRT_EXPORT namespace winrt
@@ -319,213 +551,21 @@ WINRT_EXPORT namespace winrt
     }
 #endif
 
-    [[nodiscard]] inline auto resume_after(Windows::Foundation::TimeSpan duration) noexcept
+    [[nodiscard]] inline impl::timespan_awaiter resume_after(Windows::Foundation::TimeSpan duration) noexcept
     {
-        struct awaitable : enable_await_cancellation
-        {
-            explicit awaitable(Windows::Foundation::TimeSpan duration) noexcept :
-                m_duration(duration)
-            {
-            }
-
-            void enable_cancellation(cancellable_promise* promise)
-            {
-                promise->set_canceller([](void* context)
-                {
-                    auto that = static_cast<awaitable*>(context);
-                    if (that->m_state.exchange(state::canceled, std::memory_order_acquire) == state::pending)
-                    {
-                        that->fire_immediately();
-                    }
-                }, this);
-            }
-
-            bool await_ready() const noexcept
-            {
-                return m_duration.count() <= 0;
-            }
-
-            void await_suspend(impl::coroutine_handle<> handle)
-            {
-                m_handle = handle;
-                m_timer.attach(check_pointer(WINRT_IMPL_CreateThreadpoolTimer(callback, this, nullptr)));
-                int64_t relative_count = -m_duration.count();
-                WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &relative_count, 0, 0);
-
-                state expected = state::idle;
-                if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
-                {
-                    fire_immediately();
-                }
-            }
-
-            void await_resume()
-            {
-                if (m_state.exchange(state::idle, std::memory_order_relaxed) == state::canceled)
-                {
-                    throw hresult_canceled();
-                }
-            }
-
-        private:
-
-            static int32_t __stdcall fallback_SetThreadpoolTimerEx(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept
-            {
-                return 0; // pretend timer has already triggered and a callback is on its way
-            }
-
-            void fire_immediately() noexcept
-            {
-                static int32_t(__stdcall* handler)(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept;
-                impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolTimerEx", handler, fallback_SetThreadpoolTimerEx);
-
-                if (handler(m_timer.get(), nullptr, 0, 0))
-                {
-                    int64_t now = 0;
-                    WINRT_IMPL_SetThreadpoolTimer(m_timer.get(), &now, 0, 0);
-                }
-            }
-
-            static void __stdcall callback(void*, void* context, void*) noexcept
-            {
-                auto that = reinterpret_cast<awaitable*>(context);
-                that->m_handle();
-            }
-
-            struct timer_traits
-            {
-                using type = impl::ptp_timer;
-
-                static void close(type value) noexcept
-                {
-                    WINRT_IMPL_CloseThreadpoolTimer(value);
-                }
-
-                static constexpr type invalid() noexcept
-                {
-                    return nullptr;
-                }
-            };
-
-            enum class state { idle, pending, canceled };
-
-            handle_type<timer_traits> m_timer;
-            Windows::Foundation::TimeSpan m_duration;
-            impl::coroutine_handle<> m_handle;
-            std::atomic<state> m_state{ state::idle };
-        };
-
-        return awaitable{ duration };
+        return impl::timespan_awaiter{ duration };
     }
 
 #ifdef WINRT_IMPL_COROUTINES
-    inline auto operator co_await(Windows::Foundation::TimeSpan duration)
+    inline impl::timespan_awaiter operator co_await(Windows::Foundation::TimeSpan duration)
     {
         return resume_after(duration);
     }
 #endif
 
-    [[nodiscard]] inline auto resume_on_signal(void* handle, Windows::Foundation::TimeSpan timeout = {}) noexcept
+    [[nodiscard]] inline impl::signal_awaiter resume_on_signal(void* handle, Windows::Foundation::TimeSpan timeout = {}) noexcept
     {
-        struct awaitable : enable_await_cancellation
-        {
-            awaitable(void* handle, Windows::Foundation::TimeSpan timeout) noexcept :
-                m_timeout(timeout),
-                m_handle(handle)
-            {}
-
-            void enable_cancellation(cancellable_promise* promise)
-            {
-                promise->set_canceller([](void* context)
-                {
-                    auto that = static_cast<awaitable*>(context);
-                    if (that->m_state.exchange(state::canceled, std::memory_order_acquire) == state::pending)
-                    {
-                        that->fire_immediately();
-                    }
-                }, this);
-            }
-
-            bool await_ready() const noexcept
-            {
-                return WINRT_IMPL_WaitForSingleObject(m_handle, 0) == 0;
-            }
-
-            void await_suspend(impl::coroutine_handle<> resume)
-            {
-                m_resume = resume;
-                m_wait.attach(check_pointer(WINRT_IMPL_CreateThreadpoolWait(callback, this, nullptr)));
-                int64_t relative_count = -m_timeout.count();
-                int64_t* file_time = relative_count != 0 ? &relative_count : nullptr;
-                WINRT_IMPL_SetThreadpoolWait(m_wait.get(), m_handle, file_time);
-
-                state expected = state::idle;
-                if (!m_state.compare_exchange_strong(expected, state::pending, std::memory_order_release))
-                {
-                    fire_immediately();
-                }
-            }
-
-            bool await_resume()
-            {
-                if (m_state.exchange(state::idle, std::memory_order_relaxed) == state::canceled)
-                {
-                    throw hresult_canceled();
-                }
-                return m_result == 0;
-            }
-
-        private:
-            static int32_t __stdcall fallback_SetThreadpoolWaitEx(winrt::impl::ptp_wait, void*, void*, void*) noexcept
-            {
-                return 0; // pretend wait has already triggered and a callback is on its way
-            }
-
-            void fire_immediately() noexcept
-            {
-                static int32_t(__stdcall* handler)(winrt::impl::ptp_wait, void*, void*, void*) noexcept;
-                impl::load_runtime_function(L"kernel32.dll", "SetThreadpoolWaitEx", handler, fallback_SetThreadpoolWaitEx);
-
-                if (handler(m_wait.get(), nullptr, nullptr, nullptr))
-                {
-                    int64_t now = 0;
-                    WINRT_IMPL_SetThreadpoolWait(m_wait.get(), WINRT_IMPL_GetCurrentProcess(), &now);
-                }
-            }
-
-            static void __stdcall callback(void*, void* context, void*, uint32_t result) noexcept
-            {
-                auto that = static_cast<awaitable*>(context);
-                that->m_result = result;
-                that->m_resume();
-            }
-
-            struct wait_traits
-            {
-                using type = impl::ptp_wait;
-
-                static void close(type value) noexcept
-                {
-                    WINRT_IMPL_CloseThreadpoolWait(value);
-                }
-
-                static constexpr type invalid() noexcept
-                {
-                    return nullptr;
-                }
-            };
-
-            enum class state { idle, pending, canceled };
-
-            handle_type<wait_traits> m_wait;
-            Windows::Foundation::TimeSpan m_timeout;
-            void* m_handle;
-            uint32_t m_result{};
-            impl::coroutine_handle<> m_resume{ nullptr };
-            std::atomic<state> m_state{ state::idle };
-        };
-
-        return awaitable{ handle, timeout };
+        return impl::signal_awaiter{ handle, timeout };
     }
 
     struct thread_pool

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -346,7 +346,7 @@ namespace winrt::impl
         // on the return value of resume_after.
         // This might be related to upstream bug:
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99575
-        awaitable(awaitable &&other) noexcept :
+        timespan_awaiter(timespan_awaiter &&other) noexcept :
             m_timer{std::move(other.m_timer)},
             m_duration{std::move(other.m_duration)},
             m_handle{std::move(other.m_handle)},
@@ -460,7 +460,7 @@ namespace winrt::impl
         // on the return value of resume_on_signal.
         // This might be related to upstream bug:
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99575
-        awaitable(awaitable &&other) noexcept :
+        signal_awaiter(signal_awaiter &&other) noexcept :
             m_wait{std::move(other.m_wait)},
             m_timeout{std::move(other.m_timeout)},
             m_handle{std::move(other.m_handle)},

--- a/test/test/async_propagate_cancel.cpp
+++ b/test/test/async_propagate_cancel.cpp
@@ -104,7 +104,7 @@ namespace
     }
 
     template <typename F>
-    void Check(F make)
+    void CheckWithWait(F make, bool wait)
     {
         handle completed{ CreateEvent(nullptr, true, false, nullptr) };
         auto async = make();
@@ -117,6 +117,12 @@ namespace
                 SetEvent(completed.get());
             });
 
+        if (wait)
+        {
+            // ensure we hit the co_await that's cancellable before trying to cancel.
+            Sleep(1000);
+        }
+
         async.Cancel();
 
         // Wait indefinitely if a debugger is present, to make it easier to debug this test.
@@ -125,6 +131,13 @@ namespace
         REQUIRE(async.Status() == AsyncStatus::Canceled);
         REQUIRE(async.ErrorCode() == HRESULT_FROM_WIN32(ERROR_CANCELLED));
         REQUIRE_THROWS_AS(async.GetResults(), hresult_canceled);
+    }
+
+    template <typename F>
+    void Check(F make)
+    {
+        CheckWithWait(make, false);
+        CheckWithWait(make, true);
     }
 }
 

--- a/test/test/await_completed.cpp
+++ b/test/test/await_completed.cpp
@@ -27,14 +27,19 @@ namespace
     }
 #endif
 
-    // Simple awaiter that (inefficiently) resumes from inside
+    // Simple awaiter that (inefficiently) resumes from inside a function nested in
     // await_suspend, for the purpose of measuring how much stack it consumes.
     // This is the best we can do with MSVC prerelease coroutines prior to 16.11.
+    // This simulates the behavior of await_adapter.
     struct resume_sync_from_await_suspend
     {
         bool await_ready() { return false; }
-        void await_suspend(winrt::impl::coroutine_handle<> h) { h(); }
+        template <typename T>
+        void await_suspend(winrt::impl::coroutine_handle<T> h) { resume_inner(h); }
         void await_resume() { }
+
+    private:
+        void resume_inner(winrt::impl::coroutine_handle<> h) { h(); }
     };
 
     IAsyncAction SyncCompletion()


### PR DESCRIPTION
& make propagation tests more reliable at detecting future failures. Relying on a race proved to be not reliable, as shown by #1228 only causing intermittent failures instead of consistent ones.

Some notes:
- I made cancellable_awaiter use CRTP to avoid a virtual call to enable_cancellation, but this comes at the size of potential code size increase. Can easily revert to a virtual call to make cancellable_awaiter a non-template.
- I had to move the awaiters for resume_on_signal and resume_after to be outside of their respective functions, otherwise I could not make await_suspend a template.
- Are there any docs changes needed? I know this blog post will probably need one: https://devblogs.microsoft.com/oldnewthing/20200923-00/?p=104261
- I guess now everybody can make cancellable promises by deriving from impl::cancellable_promise?
- If cppwinrt v3 happens, should we make cancellation propagation always on?

Fixes #1243 