### PR TITLE
FIx build on macOS and add CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,34 @@ jobs:
             exit 1
           }
 
+  build-macos-native-cppwinrt:
+    name: 'macOS: GCC native build'
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      CMAKE_COLOR_DIAGNOSTICS: 1
+      CLICOLOR_FORCE: 1
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build cppwinrt
+        run: |
+          cmake -S . -B build/native/ \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=$PWD/install/
+          cmake --build build/native/ --target install -j2
+
+      - name: Test run (cppwinrt -?)
+        run: |
+          install/bin/cppwinrt -?
+
+      - name: Test run (build projection using Windows.winmd)
+        run: |
+          curl -o Windows.winmd -L https://github.com/microsoft/windows-rs/raw/master/crates/libs/metadata/default/Windows.winmd
+          install/bin/cppwinrt -in Windows.winmd -out build/out -verbose
+
   build-msvc-natvis:
     name: 'Build natvis'
     strategy:

--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -104,22 +104,32 @@ namespace cppwinrt
             f(*static_cast<T*>(this));
         }
 
-        void write(int32_t const value)
+        void write(int const value)
         {
             write(std::to_string(value));
         }
 
-        void write(uint32_t const value)
+        void write(unsigned int const value)
         {
             write(std::to_string(value));
         }
 
-        void write(int64_t const value)
+        void write(signed long const value)
         {
             write(std::to_string(value));
         }
 
-        void write(uint64_t const value)
+        void write(unsigned long const value)
+        {
+            write(std::to_string(value));
+        }
+
+        void write(signed long long const value)
+        {
+            write(std::to_string(value));
+        }
+
+        void write(unsigned long long const value)
         {
             write(std::to_string(value));
         }


### PR DESCRIPTION
Define more `writer_base::write` overloads. Apparently macOS typedefs `size_t` as `unsigned long` but `uint64_t` as `unsigned long long`, which causes ambiguous function resolution when calling `write(size_t)`.