### PR TITLE
Improve error reporting for clock test

### DIFF
--- a/test/old_tests/UnitTests/clock.cpp
+++ b/test/old_tests/UnitTests/clock.cpp
@@ -77,8 +77,7 @@ TEST_CASE("clock, time_t")
 
     // Conversions are verified to be consistent. Now, verify that we're correctly converting epochs
     const auto diff = duration_cast<milliseconds>(abs(clock::now() - clock::from_time_t(time(nullptr)))).count();
-    const auto one_second = milliseconds{ 1000 }.count();
-    REQUIRE(diff < one_second);
+    REQUIRE(diff < 1000);
 }
 
 TEST_CASE("clock, FILETIME")

--- a/test/old_tests/UnitTests/clock.cpp
+++ b/test/old_tests/UnitTests/clock.cpp
@@ -76,8 +76,9 @@ TEST_CASE("clock, time_t")
     REQUIRE(clock::to_time_t(clock::from_time_t(now_tt)) == now_tt);
 
     // Conversions are verified to be consistent. Now, verify that we're correctly converting epochs
-    const auto diff = abs(clock::now() - clock::from_time_t(time(nullptr)));
-    REQUIRE(diff < seconds{ 1 });
+    const auto diff = duration_cast<milliseconds>(abs(clock::now() - clock::from_time_t(time(nullptr)))).count();
+    const auto one_second = milliseconds{ 1000 }.count();
+    REQUIRE(diff < one_second);
 }
 
 TEST_CASE("clock, FILETIME")


### PR DESCRIPTION
This test fails intermittently but it's hard to tell what's wrong since the error report doesn't include the failing values. This just ensures that we can see the values when it fails and perhaps gain some more insight in the failure. 