### PR TITLE
Fix object usage after move in make_delegate_with_shared_state

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -42,7 +42,8 @@ namespace winrt::impl
     std::pair<T, H*> make_delegate_with_shared_state(H&& handler)
     {
         auto d = make_delegate<T, H>(std::forward<H>(handler));
-        return { std::move(d), reinterpret_cast<delegate<T, H>*>(get_abi(d)) };
+        auto abi = reinterpret_cast<delegate<T, H>*>(get_abi(d));
+        return { std::move(d), abi };
     }
 
     template <typename Async>


### PR DESCRIPTION
The function make_delegate_with_shared_state (from strings/base_coroutine_foundation.h) uses on object after it was moved. 'd' is moved using std::move and then it's passed to get_abi. The usage of 'd' after it was moved it undefined.