### PR TITLE
Cleaning up some warnings for Clang and GCC

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -196,8 +196,10 @@ namespace winrt::impl
 
 #ifdef _WIN64
     inline constexpr uint32_t memory_allocation_alignment{ 16 };
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4324) // structure was padded due to alignment specifier
+#endif
     struct alignas(16) slist_entry
     {
         slist_entry* next;
@@ -217,7 +219,9 @@ namespace winrt::impl
             uint64_t reserved4 : 60;
         } reserved2;
     };
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 #else
     inline constexpr uint32_t memory_allocation_alignment{ 8 };
     struct slist_entry

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -331,7 +331,9 @@ namespace winrt::impl
     com_ptr<event_array<T>> make_event_array(uint32_t const capacity)
     {
         void* raw = ::operator new(sizeof(event_array<T>) + (sizeof(T)* capacity));
+#ifdef _MSC_VER
 #pragma warning(suppress: 6386)
+#endif
         return { new(raw) event_array<T>(capacity), take_ownership_from_abi };
     }
 

--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -453,12 +453,16 @@ namespace winrt::impl
     template <typename T>
     struct pinterface_guid
     {
+#ifdef _MSC_VER
 #pragma warning(suppress: 4307)
+#endif
         static constexpr guid value{ generate_guid(signature<T>::data) };
     };
 
     template <typename T>
+#ifdef _MSC_VER
 #pragma warning(suppress: 4307)
+#endif
     inline constexpr auto name_v
     {
         combine

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -340,7 +340,9 @@ namespace winrt::impl
     template <typename ... T>
     struct uncloaked_iids<interface_list<T...>>
     {
+#ifdef _MSC_VER
 #pragma warning(suppress: 4307)
+#endif
         static constexpr std::array<guid, sizeof...(T)> value{ winrt::guid_of<T>() ... };
     };
 

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1462,6 +1462,10 @@ WINRT_EXPORT namespace winrt
             return result;
         }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
         impl::hresult_type __stdcall QueryInterface(impl::guid_type const& id, void** object) noexcept
         {
             return root_implements_type::QueryInterface(reinterpret_cast<guid const&>(id), object);
@@ -1493,6 +1497,9 @@ WINRT_EXPORT namespace winrt
         {
             return root_implements_type::abi_GetTrustLevel(reinterpret_cast<Windows::Foundation::TrustLevel*>(value));
         }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
         void* find_interface(guid const& id) const noexcept override
         {

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -15,11 +15,13 @@
 
 #define WINRT_IMPL_SHIM(...) (*(abi_t<__VA_ARGS__>**)&static_cast<__VA_ARGS__ const&>(static_cast<D const&>(*this)))
 
+#ifdef _MSC_VER
 // Note: this is a workaround for a false-positive warning produced by the Visual C++ 15.9 compiler.
 #pragma warning(disable : 5046)
 
 // Note: this is a workaround for a false-positive warning produced by the Visual C++ 16.3 compiler.
 #pragma warning(disable : 4268)
+#endif
 
 #if defined(__cpp_lib_coroutine) || defined(__cpp_coroutines) || defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #define WINRT_IMPL_COROUTINES
@@ -87,7 +89,9 @@ typedef struct _GUID GUID;
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD , sourceInformation
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM sourceInformation
 
+#ifdef _MSC_VER
 #pragma detect_mismatch("WINRT_SOURCE_LOCATION", "true")
+#endif
 #else
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT
 #define WINRT_IMPL_SOURCE_LOCATION_ARGS
@@ -96,5 +100,7 @@ typedef struct _GUID GUID;
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM
 
+#ifdef _MSC_VER
 #pragma detect_mismatch("WINRT_SOURCE_LOCATION", "false")
+#endif
 #endif

--- a/strings/base_string_input.h
+++ b/strings/base_string_input.h
@@ -3,13 +3,17 @@ WINRT_EXPORT namespace winrt::param
 {
     struct hstring
     {
+#ifdef _MSC_VER
 #pragma warning(suppress: 26495)
+#endif
         hstring() noexcept : m_handle(nullptr) {}
         hstring(hstring const& values) = delete;
         hstring& operator=(hstring const& values) = delete;
         hstring(std::nullptr_t) = delete;
 
+#ifdef _MSC_VER
 #pragma warning(suppress: 26495)
+#endif
         hstring(winrt::hstring const& value) noexcept : m_handle(get_abi(value))
         {
         }

--- a/strings/base_version.h
+++ b/strings/base_version.h
@@ -4,13 +4,13 @@ extern "C"
 __declspec(selectany)
 char const * const WINRT_version = "C++/WinRT version:" CPPWINRT_VERSION;
 
+#if defined(_MSC_VER)
 #ifdef _M_IX86
 #pragma comment(linker, "/include:_WINRT_version")
 #else
 #pragma comment(linker, "/include:WINRT_version")
 #endif
 
-#if defined(_MSC_VER)
 #pragma detect_mismatch("C++/WinRT version", CPPWINRT_VERSION)
 #endif
 

--- a/test/old_tests/Component/pch.h
+++ b/test/old_tests/Component/pch.h
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif
 
 #include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Composable.h"

--- a/test/old_tests/Composable/precomp.hpp
+++ b/test/old_tests/Composable/precomp.hpp
@@ -1,6 +1,8 @@
 ﻿#pragma once
 
+#ifdef _MSC_VER
 #pragma warning(disable:4100)
+#endif
 
 #include "winrt/Windows.Foundation.h"
 #include "winrt/Composable.h"

--- a/test/old_tests/UnitTests/Errors.cpp
+++ b/test/old_tests/UnitTests/Errors.cpp
@@ -66,7 +66,9 @@ void test_exception(HRESULT const code, std::wstring_view message)
     }
 }
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4702)  // unreachable code
+#endif
 TEST_CASE("Errors")
 {
     // These won't throw.

--- a/test/old_tests/UnitTests/IReference.cpp
+++ b/test/old_tests/UnitTests/IReference.cpp
@@ -1,7 +1,9 @@
 #include "pch.h"
 #include "catch.hpp"
 
+#ifdef _MSC_VER
 #pragma warning(disable:4471) // a forward declaration of an unscoped enumeration must have an underlying type
+#endif
 #include <windows.foundation.h>
 
 using namespace winrt;

--- a/test/old_tests/UnitTests/Main.cpp
+++ b/test/old_tests/UnitTests/Main.cpp
@@ -15,9 +15,9 @@ int main(int argc, char * argv[])
     init_apartment();
     std::set_terminate([]{ reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     SetThreadUILanguage(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US));
     int const result = Catch::Session().run(argc, argv);
 

--- a/test/old_tests/UnitTests/apartment_context.cpp
+++ b/test/old_tests/UnitTests/apartment_context.cpp
@@ -35,6 +35,11 @@ namespace
         context2 = nullptr;
         REQUIRE(!context2);
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
         // Self-copy-assignment
         context = context;
         REQUIRE(context);
@@ -42,6 +47,9 @@ namespace
         // Self-move-assignment
         context = std::move(context);
         REQUIRE(context);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
         co_await context;
     }

--- a/test/old_tests/UnitTests/apartment_context.cpp
+++ b/test/old_tests/UnitTests/apartment_context.cpp
@@ -76,6 +76,8 @@ namespace
 
 #endif
 
+// Exclude on mingw-w64 to suppress `-Wunused-function`
+#if !defined(__MINGW32__)
     bool is_nta_on_mta()
     {
         APTTYPE type;
@@ -83,6 +85,7 @@ namespace
         check_hresult(CoGetApartmentType(&type, &qualifier));
         return (type == APTTYPE_NA) && (qualifier == APTTYPEQUALIFIER_NA_ON_MTA || qualifier == APTTYPEQUALIFIER_NA_ON_IMPLICIT_MTA);
     }
+#endif
 
     bool is_mta()
     {

--- a/test/old_tests/UnitTests/com_ref.cpp
+++ b/test/old_tests/UnitTests/com_ref.cpp
@@ -13,7 +13,14 @@ namespace
 }
 
 #ifdef __CRT_UUID_DECL
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 __CRT_UUID_DECL(IClassic, 0x52bb7805, 0xe46e, 0x46f9, 0x85, 0x08, 0x86, 0x60, 0x6d, 0x2f, 0x6b, 0xc1);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 TEST_CASE("com_ref agile_ref")

--- a/test/old_tests/UnitTests/constexpr.cpp
+++ b/test/old_tests/UnitTests/constexpr.cpp
@@ -2,7 +2,9 @@
 #include "catch.hpp"
 #include "string_view_compare.h"
 
+#ifdef _MSC_VER
 #pragma warning(disable:4471) // a forward declaration of an unscoped enumeration must have an underlying type
+#endif
 #include <Windows.Applicationmodel.Activation.h>
 
 using namespace std::string_view_literals;

--- a/test/old_tests/UnitTests/enum_flags.cpp
+++ b/test/old_tests/UnitTests/enum_flags.cpp
@@ -1,7 +1,9 @@
 #include "pch.h"
 #include "catch.hpp"
 
+#ifdef _MSC_VER
 #pragma warning(disable:4471) // a forward declaration of an unscoped enumeration must have an underlying type
+#endif
 #include <Windows.ApplicationModel.Appointments.h>
 #include "winrt/Windows.ApplicationModel.Appointments.h"
 

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -482,7 +482,9 @@ TEST_CASE("hresult, exception")
     }
 }
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4702)  // unreachable code
+#endif
 TEST_CASE("hresult, throw_last_error")
 {
     SetLastError(ERROR_CANCELLED);

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -3,7 +3,7 @@
 
 // Missing in mingw-w64
 #ifndef E_BOUNDS
-#define E_BOUNDS (0x8000000B)
+#define E_BOUNDS ((HRESULT)0x8000000B)
 #endif
 
 extern "C" BOOL __stdcall RoOriginateLanguageException(HRESULT error, void* message, void* languageException);

--- a/test/old_tests/UnitTests/meta.cpp
+++ b/test/old_tests/UnitTests/meta.cpp
@@ -1,7 +1,9 @@
 #include "pch.h"
 #include "catch.hpp"
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4505)
+#endif
 
 using namespace winrt;
 using namespace Windows::Foundation;

--- a/test/test/await_completed.cpp
+++ b/test/test/await_completed.cpp
@@ -62,6 +62,7 @@ namespace
         // is the ABI breaking change with MSVC standard-conforming coroutines.)
         REQUIRE(consumed <= sync_usage);
 #else
+        (void)sync_usage;
         // MSVC standard-conforming coroutines (as well as gcc and clang coroutines)
         // support "bool await_suspend" just fine.
         REQUIRE(consumed == 0);

--- a/test/test/custom_error.cpp
+++ b/test/test/custom_error.cpp
@@ -114,7 +114,7 @@ TEST_CASE("custom_error_logger")
 #endif
 
     REQUIRE(s_loggerArgs.returnAddress);
-    REQUIRE(s_loggerArgs.result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
+    REQUIRE(s_loggerArgs.result == static_cast<int32_t>(0x80000018)); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
 
     // Remove global handler
     winrt_throw_hresult_handler = nullptr;

--- a/test/test/disconnected.cpp
+++ b/test/test/disconnected.cpp
@@ -35,6 +35,8 @@ namespace
         co_return 123;
     }
 
+// Exclude on mingw-w64 to suppress `-Wunused-function`
+#if !defined(__MINGW32__)
     bool is_mta()
     {
         APTTYPE type;
@@ -42,6 +44,7 @@ namespace
         check_hresult(CoGetApartmentType(&type, &qualifier));
         return type == APTTYPE_MTA;
     }
+#endif
 }
 
 TEST_CASE("disconnected,handler,1")

--- a/test/test/event_clear.cpp
+++ b/test/test/event_clear.cpp
@@ -16,11 +16,13 @@ TEST_CASE("event_clear")
         {
             counter += 1;
         });
+    (void)a;
 
     auto b = event.add([&](auto && ...)
         {
             counter += 10;
         });
+    (void)b;
 
     REQUIRE(counter == 0);
     event(0, 0);

--- a/test/test/guid.cpp
+++ b/test/test/guid.cpp
@@ -20,7 +20,7 @@ TEST_CASE("guid")
     STATIC_REQUIRE_GUID_EQUAL(winrt::guid("00112233-4455-6677-8899-aabbccddeeff"), expected);
 
     REQUIRE(winrt::guid("00112233-4455-6677-8899-aabbccddeeff") == expected);
-    REQUIRE(winrt::guid({ "{00112233-4455-6677-8899-aabbccddeeff}" + 1, 36 }) == expected);
+    REQUIRE(winrt::guid({ &"{00112233-4455-6677-8899-aabbccddeeff}"[1], 36 }) == expected);
     REQUIRE(winrt::guid("{00112233-4455-6677-8899-aabbccddeeff}") == expected);
     REQUIRE(winrt::guid("(00112233-4455-6677-8899-aabbccddeeff)") == expected);
 

--- a/test/test/inspectable_interop.cpp
+++ b/test/test/inspectable_interop.cpp
@@ -33,15 +33,22 @@ namespace
             throw hresult_not_implemented();
         }
 
-        hstring GetRuntimeClassName()
+        hstring GetRuntimeClassName() const
         {
             return L"Sample";
         }
 
-        Windows::Foundation::TrustLevel GetTrustLevel()
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+        Windows::Foundation::TrustLevel GetTrustLevel() const noexcept
         {
             return Windows::Foundation::TrustLevel::PartialTrust;
         }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
         int32_t __stdcall JustSayNo() noexcept final
         {

--- a/test/test/inspectable_interop.cpp
+++ b/test/test/inspectable_interop.cpp
@@ -14,7 +14,14 @@ namespace
 }
 
 #ifdef __CRT_UUID_DECL
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 __CRT_UUID_DECL(IBadInterop, 0xed0dd761, 0xc31e, 0x4803, 0x8c, 0xf9, 0x22, 0xa2, 0xcb, 0x20, 0xec, 0x47)
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 namespace

--- a/test/test/main.cpp
+++ b/test/test/main.cpp
@@ -14,9 +14,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     SetThreadUILanguage(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US));
     return Catch::Session().run(argc, argv);
 }

--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -152,7 +152,7 @@ namespace concurrent_collections
         concurrency_checked_random_access_iterator(container const* c, iterator it) : iterator(it), owner(c) {}
 
         // Implicit conversion from non-const iterator to const iterator.
-        concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator<container, ConvertibleFrom> other) : owner(other.owner), iterator(other.inner()) { }
+        concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator<container, ConvertibleFrom> other) : iterator(other.inner()), owner(other.owner) { }
 
         concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator const&) = default;
         concurrency_checked_random_access_iterator& operator=(concurrency_checked_random_access_iterator const&) = default;

--- a/test/test/multi_threaded_common.h
+++ b/test/test/multi_threaded_common.h
@@ -149,7 +149,7 @@ namespace concurrent_collections
         container const* owner;
 
         concurrency_checked_random_access_iterator() : owner(nullptr) {}
-        concurrency_checked_random_access_iterator(container const* c, iterator it) : owner(c), iterator(it) {}
+        concurrency_checked_random_access_iterator(container const* c, iterator it) : iterator(it), owner(c) {}
 
         // Implicit conversion from non-const iterator to const iterator.
         concurrency_checked_random_access_iterator(concurrency_checked_random_access_iterator<container, ConvertibleFrom> other) : owner(other.owner), iterator(other.inner()) { }
@@ -256,7 +256,7 @@ namespace concurrent_collections
 
         concurrency_guard() = default;
         concurrency_guard(concurrency_guard const& other) noexcept
-            : m_lock(0), hook(other.hook)
+            : hook(other.hook), m_lock(0)
         {
             auto guard = other.lock_nonconst();
         }

--- a/test/test/tearoff.cpp
+++ b/test/test/tearoff.cpp
@@ -181,7 +181,7 @@ namespace
             Closed = true;
         }
 
-        winrt::hstring GetRuntimeClassName()
+        winrt::hstring GetRuntimeClassName() const
         {
             return L"RuntimeClassName";
         }

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -66,7 +66,7 @@ TEST_CASE("custom_error_logger")
 #endif
 
     REQUIRE(s_loggerArgs.returnAddress);
-    REQUIRE(s_loggerArgs.result == 0x80000018); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
+    REQUIRE(s_loggerArgs.result == static_cast<int32_t>(0x80000018)); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
 
     // Remove global handler
     winrt_throw_hresult_handler = nullptr;

--- a/test/test_cpp20/main.cpp
+++ b/test/test_cpp20/main.cpp
@@ -14,9 +14,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_fast/main.cpp
+++ b/test/test_fast/main.cpp
@@ -10,9 +10,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_fast_fwd/main.cpp
+++ b/test/test_fast_fwd/main.cpp
@@ -13,9 +13,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_module_lock_custom/main.cpp
+++ b/test/test_module_lock_custom/main.cpp
@@ -63,8 +63,8 @@ int main(int const argc, char** argv)
 {
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }

--- a/test/test_module_lock_none/main.cpp
+++ b/test/test_module_lock_none/main.cpp
@@ -68,8 +68,8 @@ int main(int const argc, char** argv)
 {
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }

--- a/test/test_slow/main.cpp
+++ b/test/test_slow/main.cpp
@@ -10,9 +10,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }
 

--- a/test/test_win7/inspectable_interop.cpp
+++ b/test/test_win7/inspectable_interop.cpp
@@ -13,7 +13,14 @@ namespace
 }
 
 #ifdef __CRT_UUID_DECL
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 __CRT_UUID_DECL(IBadInterop, 0xed0dd761, 0xc31e, 0x4803, 0x8c, 0xf9, 0x22, 0xa2, 0xcb, 0x20, 0xec, 0x47)
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 namespace

--- a/test/test_win7/inspectable_interop.cpp
+++ b/test/test_win7/inspectable_interop.cpp
@@ -32,15 +32,22 @@ namespace
             throw hresult_not_implemented();
         }
 
-        hstring GetRuntimeClassName()
+        hstring GetRuntimeClassName() const
         {
             return L"Sample";
         }
 
-        Windows::Foundation::TrustLevel GetTrustLevel()
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+        Windows::Foundation::TrustLevel GetTrustLevel() const noexcept
         {
             return Windows::Foundation::TrustLevel::PartialTrust;
         }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
         int32_t __stdcall JustSayNo() noexcept final
         {

--- a/test/test_win7/main.cpp
+++ b/test/test_win7/main.cpp
@@ -14,9 +14,9 @@ int main(int const argc, char** argv)
     init_apartment();
     std::set_terminate([] { reportFatal("Abnormal termination"); ExitProcess(1); });
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    (void)_CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
     return Catch::Session().run(argc, argv);
 }
 


### PR DESCRIPTION
Fixed or suppressed some warnings in the headers when using Clang and GCC. The last commit ("gcc: Fix -Wclass-memaccess warning") involved a small refactoring.