### PR TITLE
Make headers partially usable with LLVM/libc++ 13

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -642,6 +642,7 @@ WINRT_EXPORT namespace winrt
         return impl::hstring_convert(value);
     }
 
+#if !defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 14000
     inline hstring to_hstring(float value)
     {
         return impl::hstring_convert(value);
@@ -651,6 +652,7 @@ WINRT_EXPORT namespace winrt
     {
         return impl::hstring_convert(value);
     }
+#endif
 
     inline hstring to_hstring(char16_t value)
     {


### PR DESCRIPTION
This works around a compile error due to the floating point version of `std::to_chars` not implemented in libc++ 13, so that C++/WinRT can be used on LLVM 13 with limited support. It should work as long as none of the functions involving coroutines are used.