### PR TITLE
Add option for using custom license text

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -24,10 +24,8 @@ namespace cppwinrt
         {
             w.write(R"(// C++/WinRT v%
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-)", CPPWINRT_VERSION_STRING);
+%
+)", CPPWINRT_VERSION_STRING, settings.license_template);
         }
         else
         {

--- a/cppwinrt/settings.h
+++ b/cppwinrt/settings.h
@@ -10,6 +10,7 @@ namespace cppwinrt
         std::string output_folder;
         bool base{};
         bool license{};
+        std::string license_template;
         bool brackets{};
         bool verbose{};
         bool component{};


### PR DESCRIPTION
The `-license` option now accepts an optional path argument, which can point to a text file to be used as the license text in the generated header files. The license text is automatically wrapped in a block of single-line comments.

Closes #1261