### PR TITLE
tests: Fix and enable cpp20/custom_error for incoming LLVM 16

### DIFF
--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -36,10 +36,13 @@ namespace
     }
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(_MSC_VER)
 // FIXME: Blocked on __cpp_consteval, see:
 // * https://github.com/microsoft/cppwinrt/pull/1203#issuecomment-1279764927
 // * https://github.com/llvm/llvm-project/issues/57094
+TEST_CASE("custom_error_logger", "[!shouldfail]")
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+// <source_location> not available in libc++ before LLVM 16
 TEST_CASE("custom_error_logger", "[!shouldfail]")
 #else
 TEST_CASE("custom_error_logger")
@@ -61,6 +64,8 @@ TEST_CASE("custom_error_logger")
     REQUIRE(!functionNameSv.empty());
 #if defined(__GNUC__) && !defined(__clang__)
     REQUIRE(functionNameSv == "void {anonymous}::FailOnLine15()");
+#elif defined(__GNUC__) && defined(__clang__)
+    REQUIRE(functionNameSv == "void (anonymous namespace)::FailOnLine15()");
 #else
     REQUIRE(functionNameSv == "FailOnLine15");
 #endif


### PR DESCRIPTION
Tested with a recent llvm-mingw build very close to LLVM 16 rc1.

LLVM 16.0.0 should be releasing two months later. I will look into updating the CI after that.