### PR TITLE
Make the formatter for IStringable const

### DIFF
--- a/strings/base_stringable_format.h
+++ b/strings/base_stringable_format.h
@@ -1,7 +1,7 @@
 
 #ifdef __cpp_lib_format
 template <typename FormatContext>
-auto std::formatter<winrt::Windows::Foundation::IStringable, wchar_t>::format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc)
+auto std::formatter<winrt::Windows::Foundation::IStringable, wchar_t>::format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc) const
 {
     return std::formatter<winrt::hstring, wchar_t>::format(obj.ToString(), fc);
 }

--- a/strings/base_stringable_format_1.h
+++ b/strings/base_stringable_format_1.h
@@ -4,6 +4,6 @@ template <>
 struct std::formatter<winrt::Windows::Foundation::IStringable, wchar_t> : std::formatter<winrt::hstring, wchar_t>
 {
     template <typename FormatContext>
-    auto format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc);
+    auto format(winrt::Windows::Foundation::IStringable const& obj, FormatContext& fc) const;
 };
 #endif


### PR DESCRIPTION
Without this, `IStringable` and types which implement `IStringable` technically did not meet the [`formattable` concept](http://eel.is/c++draft/format.formattable), which uses a `const formatter<remove_cvref_t<T>, charT>` to verify for formattability.