### PR TITLE
Stack usage reduction in apartment switching, and lifetime fixes

### DIFF
--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -135,9 +135,12 @@ namespace winrt::impl
             }
             else
             {
-                resume_apartment(m_context, std::exchange(m_handle, {}), &m_awaiter->failure);
+                auto handle = std::exchange(m_handle, {});
+                if (!resume_apartment(m_context, handle, &m_awaiter->failure))
+                {
+                    handle.resume();
+                }
             }
-
         }
     };
 
@@ -182,7 +185,6 @@ namespace winrt::impl
     private:
         auto register_completed_callback(coroutine_handle<> handle)
         {
-            auto extend_lifetime = async;
             async.Completed(disconnect_aware_handler(this, handle));
 #ifdef _RESUMABLE_FUNCTIONS_SUPPORTED
             if (!suspending.exchange(false, std::memory_order_acquire))

--- a/test/test_cpp20/await_completed.cpp
+++ b/test/test_cpp20/await_completed.cpp
@@ -38,8 +38,22 @@ namespace
         uintptr_t consumed = initial - approximate_stack_pointer();
         REQUIRE(consumed == 0);
     }
+
+    IAsyncAction TestApartmentContextNop()
+    {
+        // co_await the same apartment and confirm that stack does not grow.
+        winrt::apartment_context same_context;
+        uintptr_t initial = approximate_stack_pointer();
+        co_await same_context;
+        uintptr_t consumed = initial - approximate_stack_pointer();
+        REQUIRE(consumed == 0);
+    }
 }
 TEST_CASE("await_completed_await")
 {
     SyncCompletion().get();
+}
+TEST_CASE("apartment_context_nop")
+{
+    TestApartmentContextNop().get();
 }


### PR DESCRIPTION
The big deal here is that we fix `co_await apartment_context` so that it consumes no stack[1] if you are already in the destination context. This is a big win for loops that do apartment switching.

To do this, `impl::resume_apartment` now returns `true` if it wants the caller to resume the coroutine synchronously, rather than doing it directly. If the caller is `await_suspend`, then it can propagate that result to the coroutine infrastructure and avoid stack build-up.

Fixed a lifetime issue in `apartment_awaiter`, which copied the context too soon. It needs to copy it in the `await_suspend`, because the coroutine is to resume synchronously in the new apartment, which under the old code would destruct the context while `await_suspend` was still using it. This shifts a refcount update from one place to another, so no net change.

We no longer need to extend the lifetime of the `IAsyncAction` now that we detect and defer synchronous resumption. This deletes a refcount update.

[1] Older builds of MSVC have code generation issues for `bool await_suspend`, so we deftly avoid them here, in the same way we avoided them for `co_await IAsyncAction`. (Though the existing code in many awaiters such as `final_suspend_awaiter` still use `bool await_suspend`, so maybe it's okay to assume MSVC 16.11 or later?)