### PR TITLE
Add a clang-specific impl->projection conversion operator

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -110,12 +110,12 @@ namespace winrt::impl
     template <typename D, typename I, typename Enable>
     struct producer_convert : producer<D, typename default_interface<I>::type>
     {
-        operator producer_ref<I> const() const noexcept
+        operator producer_ref<I>() const noexcept
         {
             return { (produce<D, typename default_interface<I>::type>*)this };
         }
 
-        operator producer_vtable<I> const() const noexcept
+        operator producer_vtable<I>() const noexcept
         {
             return { (void*)this };
         }

--- a/test/old_tests/UnitTests/as_implements.cpp
+++ b/test/old_tests/UnitTests/as_implements.cpp
@@ -74,16 +74,6 @@ TEST_CASE("as_implements")
     REQUIRE(foo.get() == foo2.get());
 }
 
-TEST_CASE("as_implements_uniform_initialization")
-{
-    // uniform initialization relies on IStringable(IStringable&&),
-    // which requires non-const rvalue semantics.
-    com_ptr<Foo> foo = make_self<Foo>();
-    IStringable stringable{ foo.as<IStringable>() };
-    com_ptr<Foo> foo2 = stringable.as<Foo>();
-    REQUIRE(foo.get() == foo2.get());
-}
-
 TEST_CASE("as_implements_inheritance")
 {
     com_ptr<Bar> bar = make_self<Bar>();
@@ -147,4 +137,14 @@ TEST_CASE("as_implements_inheritance")
         com_ptr<Foo> foo2 = foo->get_strong_foo();
         REQUIRE(bar.get() == foo2.get());
     }
+}
+
+TEST_CASE("convert_to_implements_via_uniform_initialization")
+{
+    // uniform initialization relies on IStringable(IStringable&&),
+    // which requires non-const rvalue semantics.
+    com_ptr<Foo> foo = make_self<Foo>();
+    IStringable stringable{ *foo };
+    com_ptr<Foo> foo2 = stringable.as<Foo>();
+    REQUIRE(foo.get() == foo2.get());
 }

--- a/test/old_tests/UnitTests/as_implements.cpp
+++ b/test/old_tests/UnitTests/as_implements.cpp
@@ -74,6 +74,16 @@ TEST_CASE("as_implements")
     REQUIRE(foo.get() == foo2.get());
 }
 
+TEST_CASE("as_implements_uniform_initialization")
+{
+    // uniform initialization relies on IStringable(IStringable&&),
+    // which requires non-const rvalue semantics.
+    com_ptr<Foo> foo = make_self<Foo>();
+    IStringable stringable{ foo.as<IStringable>() };
+    com_ptr<Foo> foo2 = stringable.as<Foo>();
+    REQUIRE(foo.get() == foo2.get());
+}
+
 TEST_CASE("as_implements_inheritance")
 {
     com_ptr<Bar> bar = make_self<Bar>();


### PR DESCRIPTION
In Clang, the conversion from `producer_convert` to `const producer_ref<I>`
does not allow for the move-initialization of `I` via `I(I&&)` (implicit
or explicit) due to a language misspecification¹.

In brief², we cannot offer zero-cost initialization of projected types
from implementation types _in all meaningful cases_ in projects compiled
with clang.

Until it improves (which is tracked in llvm/llvm-project#17056), this
conversion operator will allow for C++/WinRT code to compile with Clang.

Closes #1273

¹ http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#2077 documents
the language standard bug that results in this.

² In non-brief, https://stackoverflow.com/a/70654432