### PR TITLE
Expose configuring /nomidl.

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -43,7 +43,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <InterfaceIdentifierFileName Condition="'%(Midl.InterfaceIdentifierFileName)'==''">nul</InterfaceIdentifierFileName>
             <ProxyFileName Condition="'%(Midl.ProxyFileName)'==''">nul</ProxyFileName>
             <TypeLibraryName Condition="'%(Midl.TypeLibraryName)'==''"></TypeLibraryName>
-            <NoMidl>true</NoMidl>
+            <NoMidl Condition="'%(Midl.NoMidl)'==''">true</NoMidl>
         </Midl>
         <ProjectReference Condition="'$(XamlLanguage)' != 'C++' and '$(CppWinRTEnableDefaultCopyLocalFalse)' == 'true'">
             <!-- By default, for a C++/WinRT project,

--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -43,6 +43,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <InterfaceIdentifierFileName Condition="'%(Midl.InterfaceIdentifierFileName)'==''">nul</InterfaceIdentifierFileName>
             <ProxyFileName Condition="'%(Midl.ProxyFileName)'==''">nul</ProxyFileName>
             <TypeLibraryName Condition="'%(Midl.TypeLibraryName)'==''"></TypeLibraryName>
+            <NoMidl>true</NoMidl>
         </Midl>
         <ProjectReference Condition="'$(XamlLanguage)' != 'C++' and '$(CppWinRTEnableDefaultCopyLocalFalse)' == 'true'">
             <!-- By default, for a C++/WinRT project,

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -463,7 +463,6 @@ $(XamlMetaDataProviderPch)
 
     <!--Insert Midl /references to Platform WinMDs, library reference WinMDs, and direct reference WinMDs-->
     <Target Name="CppWinRTSetMidlReferences"
-            Condition="'$(CppWinRTModernIDL)' != 'false'"
             DependsOnTargets="GetCppWinRTPlatformWinMDReferences;GetCppWinRTDirectWinMDReferences;GetCppWinRTProjectWinMDReferences;$(CppWinRTSetMidlReferencesDependsOn)"
             Inputs="$(MSBuildAllProjects);@(CppWinRTDirectWinMDReferences);@(CppWinRTStaticProjectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
             Outputs="$(CppWinRTMidlResponseFile)">
@@ -475,8 +474,9 @@ $(XamlMetaDataProviderPch)
             <_MidlReferences Include="@(CppWinRTPlatformWinMDReferences)"/>
             <_MidlReferencesDistinct Remove="@(_MidlReferencesDistinct)" />
             <_MidlReferencesDistinct Include="@(_MidlReferences->'%(WinMDPath)'->Distinct())" />
-            <Midl Condition="'%(Midl.DisableReferences)'==''">
-                <AdditionalOptions>%(Midl.AdditionalOptions) %40"$(CppWinRTMidlResponseFile)"</AdditionalOptions>
+            <Midl>
+                <AdditionalOptions Condition="'%(Midl.NoMidl)'!='false'">%(Midl.AdditionalOptions) /nomidl</AdditionalOptions>
+                <AdditionalOptions Condition="'%(Midl.DisableReferences)'!='false' or '%(Midl.NoMidl)'!='false'">%(Midl.AdditionalOptions) /nomidl %40"$(CppWinRTMidlResponseFile)"</AdditionalOptions>
             </Midl>
         </ItemGroup>
         <PropertyGroup>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -463,6 +463,7 @@ $(XamlMetaDataProviderPch)
 
     <!--Insert Midl /references to Platform WinMDs, library reference WinMDs, and direct reference WinMDs-->
     <Target Name="CppWinRTSetMidlReferences"
+            Condition="'$(CppWinRTModernIDL)' != 'false'"
             DependsOnTargets="GetCppWinRTPlatformWinMDReferences;GetCppWinRTDirectWinMDReferences;GetCppWinRTProjectWinMDReferences;$(CppWinRTSetMidlReferencesDependsOn)"
             Inputs="$(MSBuildAllProjects);@(CppWinRTDirectWinMDReferences);@(CppWinRTStaticProjectWinMDReferences);@(CppWinRTDynamicProjectWinMDReferences);@(CppWinRTPlatformWinMDReferences)"
             Outputs="$(CppWinRTMidlResponseFile)">
@@ -474,9 +475,11 @@ $(XamlMetaDataProviderPch)
             <_MidlReferences Include="@(CppWinRTPlatformWinMDReferences)"/>
             <_MidlReferencesDistinct Remove="@(_MidlReferencesDistinct)" />
             <_MidlReferencesDistinct Include="@(_MidlReferences->'%(WinMDPath)'->Distinct())" />
-            <Midl>
-                <AdditionalOptions Condition="'%(Midl.NoMidl)'!='false'">%(Midl.AdditionalOptions) /nomidl</AdditionalOptions>
-                <AdditionalOptions Condition="'%(Midl.DisableReferences)'!='false' or '%(Midl.NoMidl)'!='false'">%(Midl.AdditionalOptions) /nomidl %40"$(CppWinRTMidlResponseFile)"</AdditionalOptions>
+            <Midl Condition="'%(Midl.NoMidl)'!='false'">
+                <AdditionalOptions>%(Midl.AdditionalOptions) /nomidl</AdditionalOptions>
+            </Midl>
+            <Midl Condition="'%(Midl.DisableReferences)'=='' and '%(Midl.NoMidl)'!='false'">
+                <AdditionalOptions>%(Midl.AdditionalOptions) %40"$(CppWinRTMidlResponseFile)"</AdditionalOptions>
             </Midl>
         </ItemGroup>
         <PropertyGroup>
@@ -883,7 +886,6 @@ $(XamlMetaDataProviderPch)
         <Midl Condition="'$(CppWinRTModernIDL)' != 'false'">
             <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' != ''">$(WindowsSDK_MetadataFoundationPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
             <AdditionalMetadataDirectories Condition="'%(AdditionalMetadataDirectories)' == '' And '$(WindowsSDK_MetadataFoundationPath)' == ''">$(WindowsSDK_MetadataPath);%(AdditionalMetadataDirectories)</AdditionalMetadataDirectories>
-            <AdditionalOptions>%(AdditionalOptions) /nomidl</AdditionalOptions>
         </Midl>
         <Link>
             <AdditionalDependencies Condition="'$(CppWinRTLibs)' != 'false'">%(AdditionalDependencies);WindowsApp.lib</AdditionalDependencies>

--- a/test/nuget/NuGetTest.sln
+++ b/test/nuget/NuGetTest.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29025.244
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestApp", "TestApp\TestApp.vcxproj", "{A8BDBDE9-1A3D-4F5E-8668-9F6E84790D44}"
 EndProject
@@ -44,6 +44,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestStaticLibrary7", "TestStaticLibrary7\TestStaticLibrary7.vcxproj", "{F89C2185-7834-443D-A449-53BD52FFEA3B}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ConsoleApplication1", "ConsoleApplication1\ConsoleApplication1.vcxproj", "{4DD64EAE-4B27-415A-863E-55CB8D5863DD}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestProxyStub", "TestProxyStub\TestProxyStub.vcxproj", "{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -301,6 +303,22 @@ Global
 		{4DD64EAE-4B27-415A-863E-55CB8D5863DD}.Release|x64.Build.0 = Release|x64
 		{4DD64EAE-4B27-415A-863E-55CB8D5863DD}.Release|x86.ActiveCfg = Release|Win32
 		{4DD64EAE-4B27-415A-863E-55CB8D5863DD}.Release|x86.Build.0 = Release|Win32
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|ARM.ActiveCfg = Debug|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|ARM.Build.0 = Debug|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|ARM64.Build.0 = Debug|ARM64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|x64.ActiveCfg = Debug|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|x64.Build.0 = Debug|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|x86.ActiveCfg = Debug|Win32
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Debug|x86.Build.0 = Debug|Win32
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|ARM.ActiveCfg = Release|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|ARM.Build.0 = Release|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|ARM64.ActiveCfg = Release|ARM64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|ARM64.Build.0 = Release|ARM64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|x64.ActiveCfg = Release|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|x64.Build.0 = Release|x64
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|x86.ActiveCfg = Release|Win32
+		{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/nuget/TestApp/TestApp.vcxproj
+++ b/test/nuget/TestApp/TestApp.vcxproj
@@ -143,6 +143,9 @@
     </Text>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\TestProxyStub\TestProxyStub.vcxproj">
+      <Project>{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\TestRuntimeComponent1\TestRuntimeComponent1.vcxproj">
       <Project>{e0ebbe54-c046-4611-b048-3ce893b1df8a}</Project>
     </ProjectReference>

--- a/test/nuget/TestProxyStub/IAsyncContract.idl
+++ b/test/nuget/TestProxyStub/IAsyncContract.idl
@@ -1,0 +1,11 @@
+import "Windows.Foundation.idl";
+import "IAsyncContractParameter.idl";
+
+namespace TestProxyStub
+{
+    [uuid("A388AC69-7C0F-4CCB-B108-E091BE3DAB88")]
+    interface IAsyncContract
+    {
+        Windows.Foundation.IAsyncAction RunAsync(IAsyncContractParameter parameter);
+    };
+}

--- a/test/nuget/TestProxyStub/IAsyncContractParameter.idl
+++ b/test/nuget/TestProxyStub/IAsyncContractParameter.idl
@@ -1,0 +1,11 @@
+import "Windows.Foundation.idl";
+
+namespace TestProxyStub
+{
+    [uuid("F219AC9A-9858-4F66-8DA7-47A9E08438AC")]
+    interface IAsyncContractParameter
+    {
+        String Name{ get; };
+        Object Details{ get; };
+    };
+}

--- a/test/nuget/TestProxyStub/TestProxyStub.def
+++ b/test/nuget/TestProxyStub/TestProxyStub.def
@@ -1,0 +1,3 @@
+EXPORTS
+    DllCanUnloadNow         PRIVATE
+    DllGetClassObject       PRIVATE

--- a/test/nuget/TestProxyStub/TestProxyStub.vcxproj
+++ b/test/nuget/TestProxyStub/TestProxyStub.vcxproj
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(ProjectDir)..\..\..\nuget\Microsoft.Windows.CppWinRT.props" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{98E28FC8-2EB7-4544-9B6A-941462C6D3E2}</ProjectGuid>
+    <RootNamespace>TestProxyStub</RootNamespace>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
+    <!-- All generated code -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>onecore.lib;onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>TestProxyStub.def</ModuleDefinitionFile>
+    </Link>
+    <Midl>
+      <GenerateClientFiles>Stub</GenerateClientFiles>
+      <GenerateServerFiles>Stub</GenerateServerFiles>
+      <GenerateStublessProxies>true</GenerateStublessProxies>
+      <DllDataFileName>$(IntDir)dlldata.c</DllDataFileName>
+      <HeaderFileName>$(IntDir)%(FileName).h</HeaderFileName>
+      <InterfaceIdentifierFileName>$(IntDir)%(FileName)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>$(IntDir)%(FileName)_p.c</ProxyFileName>
+      <AdditionalMetadataDirectories>$(WindowsSDK_UnionMetadataPath)</AdditionalMetadataDirectories>
+      <PrependWithABINamepsace>true</PrependWithABINamepsace>
+      <DisableReferences>false</DisableReferences>
+    </Midl>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="$(IntDir)IAsyncContract.h" />
+    <ClInclude Include="$(IntDir)IAsyncContract_p.h" />
+    <ClInclude Include="$(IntDir)IAsyncContractParameter.h" />
+    <ClInclude Include="$(IntDir)IAsyncContractParameter_p.h" />
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(IntDir)dlldata.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)IAsyncContract_i.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)IAsyncContract_p.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)\IAsyncContractParameter_i.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(IntDir)\IAsyncContractParameter_p.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestProxyStub.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="IAsyncContract.idl">
+      <NoMidl>false</NoMidl>
+    </Midl>
+    <Midl Include="IAsyncContractParameter.idl">
+      <NoMidl>false</NoMidl>
+    </Midl>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(ProjectDir)..\..\..\nuget\Microsoft.Windows.CppWinRT.targets" />
+</Project>

--- a/test/nuget/TestProxyStub/pch.cpp
+++ b/test/nuget/TestProxyStub/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/test/nuget/TestProxyStub/pch.h
+++ b/test/nuget/TestProxyStub/pch.h
@@ -1,0 +1,8 @@
+//
+// pch.h
+// Header for platform projection include files
+//
+
+#pragma once
+
+#include <windows.h>


### PR DESCRIPTION
This change makes it easier to generate proxy stubs by allowing modern idl to generate proxy stubs code. Midl supports this and so it seems like a good idea for cppwinrt to expose it.

/cc @Scottj1s