### PR TITLE
Use safe DLL loading (avoid current directory)

### DIFF
--- a/strings/base_activation.h
+++ b/strings/base_activation.h
@@ -39,7 +39,7 @@ namespace winrt::impl
 
         if (hr == impl::error_not_initialized)
         {
-            auto usage = reinterpret_cast<int32_t(__stdcall*)(void** cookie) noexcept>(WINRT_IMPL_GetProcAddress(WINRT_IMPL_LoadLibraryW(L"combase.dll"), "CoIncrementMTAUsage"));
+            auto usage = reinterpret_cast<int32_t(__stdcall*)(void** cookie) noexcept>(WINRT_IMPL_GetProcAddress(load_library(L"combase.dll"), "CoIncrementMTAUsage"));
 
             if (!usage)
             {
@@ -66,7 +66,7 @@ namespace winrt::impl
         {
             path.resize(count);
             path += L".dll";
-            library_handle library(WINRT_IMPL_LoadLibraryW(path.c_str()));
+            library_handle library(load_library(path.c_str()));
             path.resize(path.size() - 4);
 
             if (!library)

--- a/strings/base_agile_ref.h
+++ b/strings/base_agile_ref.h
@@ -126,6 +126,11 @@ namespace winrt::impl
         atomic_ref_count m_references{ 1 };
     };
 
+    inline void* load_library(wchar_t const* library) noexcept
+    {
+        return WINRT_IMPL_LoadLibraryExW(library, nullptr, 0x00001000 /* LOAD_LIBRARY_SEARCH_DEFAULT_DIRS */);
+    }
+
     template <typename F, typename L>
     void load_runtime_function(wchar_t const* library, char const* name, F& result, L fallback) noexcept
     {
@@ -134,7 +139,7 @@ namespace winrt::impl
             return;
         }
 
-        result = reinterpret_cast<F>(WINRT_IMPL_GetProcAddress(WINRT_IMPL_LoadLibraryW(library), name));
+        result = reinterpret_cast<F>(WINRT_IMPL_GetProcAddress(load_library(library), name));
 
         if (result)
         {

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -24,7 +24,7 @@ __declspec(selectany) int32_t(__stdcall* winrt_activation_handler)(void* classId
 
 extern "C"
 {
-    void* __stdcall WINRT_IMPL_LoadLibraryW(wchar_t const* name) noexcept WINRT_IMPL_LINK(LoadLibraryW, 4);
+    void* __stdcall WINRT_IMPL_LoadLibraryExW(wchar_t const* name, void* unused, uint32_t flags) noexcept WINRT_IMPL_LINK(LoadLibraryExW, 12);
     int32_t __stdcall WINRT_IMPL_FreeLibrary(void* library) noexcept WINRT_IMPL_LINK(FreeLibrary, 4);
     void* __stdcall WINRT_IMPL_GetProcAddress(void* library, char const* name) noexcept WINRT_IMPL_LINK(GetProcAddress, 8);
 


### PR DESCRIPTION
This avoids DLL planting issues during the fallback search for a base trust server. It uses the `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` flag, which searches the usual places, including the application directory, but excludes the current directory. The flag is supported on Win8 onward, as well as on Win7 if you have KB2533623 installed (which you really should). If you need to support versions of Win7 that haven't been patched since 2011, then stick with whatever version of C++/WinRT you are currently using.