### PR TITLE
Fix flaky clock and line-number tests

### DIFF
--- a/test/old_tests/UnitTests/clock.cpp
+++ b/test/old_tests/UnitTests/clock.cpp
@@ -92,8 +92,9 @@ TEST_CASE("clock, time_t")
     REQUIRE(clock::to_time_t(clock::from_time_t(now_tt)) == now_tt);
 
     // Conversions are verified to be consistent. Now, verify that we're correctly converting epochs
-    // Note that time_t has only 1s resolution, so we need to add 1 second of slop on either side.
-    REQUIRE_ORDERED(now1_dt - 1s, clock::from_time_t(now_tt), now2_dt + 1s);
+    // Note that time_t has only 1s resolution, so we need to add 2 seconds of slop on either side.
+    // (One second for measurement error, and another second for rounding error.)
+    REQUIRE_ORDERED(now1_dt - 2s, clock::from_time_t(now_tt), now2_dt + 2s);
 }
 
 TEST_CASE("clock, FILETIME")

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -7,11 +7,10 @@ namespace
 {
     static bool s_loggerCalled = false;
 
-    // Note that we are checking that the source line number matches expectations.  If lines above this are changed
-    // then this value needs to change as well.
     void FailOnLine15()
     {
         // Validate that handler translated exception
+#line 15 // Force next line to be reported as line number 15
         REQUIRE_THROWS_AS(check_hresult(0x80000018), hresult_illegal_delegate_assignment);
     }
 


### PR DESCRIPTION
Clock test needs to take double-rounding of time_t into account.

Fix fragility in line-number test by using `#line` directive.