### PR TITLE
Move official build pipelines to OneBranch

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -1,0 +1,193 @@
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+- template: variables/version.yml
+- template: variables/OneBranchVariables.yml
+  parameters:
+    debug: ${{ parameters.debug }}
+
+name: 2.0.$(date:yyMMdd)$(rev:.r)
+
+trigger: none
+
+resources:
+  repositories: 
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.Official.yml@templates
+  parameters:
+    platform:
+      name: 'windows_undocked'
+      product: 'build_tools'
+            
+    cloudvault:
+      enabled: false
+    
+    globalSdl:
+      tsa:
+        enabled: false
+    
+    nugetPublishing:
+      feeds:
+        name: CppWinRT
+
+    stages:
+    - stage: build
+      pool:
+        type: windows
+
+      jobs:
+      - template: .pipelines/jobs/OneBranchBuild.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+          OfficialBuild: true
+
+    - stage: vpack
+      dependsOn: build
+      jobs:
+        - job: Compiler_vpack
+          pool:
+            type: windows
+          variables:
+            ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+
+            ob_createvpack_enabled: true
+            ob_createvpack_packagename: CppWinRT.Compiler
+            ob_createvpack_owneralias: cpp4uwpt
+            ob_createvpack_description: C++/WinRT Compiler
+            ob_createvpack_provData: true
+            ob_createvpack_versionAs: parts
+            ob_createvpack_majorVer: $(MajorVersion)
+            ob_createvpack_minorVer: $(MinorVersion)
+            ob_createvpack_patchVer: $(PatchVersion)
+            ob_createvpack_metadata: $(Build.SourceBranchName).x86.$(Build.BuildNumber).$(Build.SourceVersion)
+            ob_createvpack_target: $(OSBuildToolsRoot)\cppwinrt
+
+          steps:
+            - task: UseDotNet@2
+              continueOnError: true
+              inputs: 
+                packageType: 'runtime'
+                version: '6.x'
+                performMultiLevelLookup: true
+
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download x86 artifacts'
+              inputs:
+                artifactName: 'drop_build_x86'
+                targetPath: '$(Build.SourcesDirectory)/x86'
+
+            - task: CopyFiles@2
+              displayName: 'Stage compiler vpack contents'
+              inputs:
+                SourceFolder: $(Build.SourcesDirectory)/x86
+                Contents: |
+                  cppwinrt/cppwinrt.exe
+                  cppwinrt/cppwinrt.pdb
+                TargetFolder: $(ob_outputDirectory)
+            
+        - job: MSBuild_vpack
+          pool:
+            type: windows
+          variables:
+            ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+
+            ob_createvpack_enabled: true
+            ob_createvpack_packagename: CppWinRT.MSBuild
+            ob_createvpack_owneralias: cpp4uwpt
+            ob_createvpack_description: C++/WinRT MSBuild
+            ob_createvpack_provData: true
+            ob_createvpack_versionAs: parts
+            ob_createvpack_majorVer: $(MajorVersion)
+            ob_createvpack_minorVer: $(MinorVersion)
+            ob_createvpack_patchVer: $(PatchVersion)
+            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
+            ob_createvpack_verbose: true
+            ob_createvpack_target: $(OSBuildToolsRoot)\cppwinrt
+
+          steps:
+            - task: UseDotNet@2
+              continueOnError: true
+              inputs: 
+                packageType: 'runtime'
+                version: '6.x'
+                performMultiLevelLookup: true
+
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download x86 artifacts'
+              inputs:
+                artifactName: 'drop_build_x86'
+                targetPath: '$(Build.SourcesDirectory)/x86'
+
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download x64 artifacts'
+              inputs:
+                artifactName: 'drop_build_x64'
+                targetPath: '$(Build.SourcesDirectory)/x64'
+
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download arm artifacts'
+              inputs:
+                artifactName: 'drop_build_arm'
+                targetPath: '$(Build.SourcesDirectory)/arm'
+
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download arm64 artifacts'
+              inputs:
+                artifactName: 'drop_build_arm64'
+                targetPath: '$(Build.SourcesDirectory)/arm64'
+              
+            - task: CmdLine@2
+              displayName: 'Stage MSBuild vpack contents'
+              inputs:
+                script: |
+                  set TargetDir=$(ob_outputDirectory)
+                  rd /s /q %TargetDir% >nul 2>&1
+                  md %TargetDir%
+                  cd %TargetDir%
+
+                  copy $(Build.SourcesDirectory)\vsix\Microsoft.Cpp.CppWinRT.props
+                  copy $(Build.SourcesDirectory)\nuget\Microsoft.Windows.CppWinRT.props Microsoft.Cpp.CppWinRTEnabled.props 
+                  copy $(Build.SourcesDirectory)\nuget\Microsoft.Windows.CppWinRT.targets Microsoft.Cpp.CppWinRTEnabled.targets
+                  copy $(Build.SourcesDirectory)\nuget\CppWinrtRules.Project.xml CppWinrtRules.Project.xml
+                  echo d | xcopy $(Build.SourcesDirectory)\x86\cppwinrt_fast_forwarder.lib build\native\lib\i386
+                  echo d | xcopy $(Build.SourcesDirectory)\x86\cppwinrt_fast_forwarder.lib build\native\lib\Win32
+                  echo d | xcopy $(Build.SourcesDirectory)\x64\cppwinrt_fast_forwarder.lib  build\native\lib\amd64
+                  echo d | xcopy $(Build.SourcesDirectory)\x64\cppwinrt_fast_forwarder.lib  build\native\lib\x64
+                  echo d | xcopy $(Build.SourcesDirectory)\arm\cppwinrt_fast_forwarder.lib  build\native\lib\arm
+                  echo d | xcopy $(Build.SourcesDirectory)\arm64\cppwinrt_fast_forwarder.lib  build\native\lib\arm64
+
+    - stage: NuGet
+      dependsOn: build
+      jobs:
+      - template: .pipelines/jobs/OneBranchNuGet.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+          OfficialBuild: true
+
+    - stage: Test
+      dependsOn: build
+      jobs:
+      - template: .pipelines/jobs/OneBranchTest.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+
+    - stage: Vsix
+      dependsOn: NuGet
+      jobs:
+      - template: .pipelines/jobs/OneBranchVsix.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+          OfficialBuild: true

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -1,0 +1,70 @@
+parameters:
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+  
+variables:
+- template: variables/version.yml
+- template: variables/OneBranchVariables.yml
+  parameters:
+    debug: ${{ parameters.debug }}
+
+name: PullRequest_2.0.$(date:yyMMdd)$(rev:.r)
+
+trigger: none 
+
+pool:
+  type: windows
+
+resources:
+  repositories: 
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    platform:
+      name: 'windows_undocked'
+      product: 'build_tools'
+    
+    globalSdl:
+      tsa:
+        enabled: false
+      sbom:
+        enabled: true
+
+    stages:
+    - stage: build
+      jobs:
+      - template: .pipelines/jobs/OneBranchBuild.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+
+    - stage: NuGet
+      dependsOn: build
+      jobs:
+      - template: .pipelines/jobs/OneBranchNuGet.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+
+    - stage: Test
+      dependsOn: build
+      jobs:
+      - template: .pipelines/jobs/OneBranchTest.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)
+
+    - stage: Vsix
+      dependsOn: NuGet
+      jobs:
+      - template: .pipelines/jobs/OneBranchVsix.yml@self
+        parameters:
+          BuildConfiguration: $(BuildConfiguration)
+          BuildVersion: $(BuildVersion)

--- a/.pipelines/jobs/OneBranchBuild.yml
+++ b/.pipelines/jobs/OneBranchBuild.yml
@@ -30,7 +30,7 @@ jobs:
     ob_artifactSuffix: $(BuildPlatform)
     StagingFolder: $(ob_outputDirectory)
 
-    ${{ if eq(parameters.OfficialBuild, 'false' }}:
+    ${{ if eq(parameters.OfficialBuild, 'false') }}:
       ob_sdl_codeSignValidation_excludes: '-|**\*.exe;-|**\*.dll' 
 
     ob_symbolsPublishing_enabled: ${{ parameters.OfficialBuild }}

--- a/.pipelines/jobs/OneBranchBuild.yml
+++ b/.pipelines/jobs/OneBranchBuild.yml
@@ -1,0 +1,141 @@
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: BuildVersion
+    type: string
+  - name: OutputDirectory
+    type: string
+    default: '$(Build.SourcesDirectory)\out'
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
+jobs:
+- job:
+  pool:
+    type: windows
+  strategy:
+    matrix:
+      x86:
+        BuildPlatform: 'x86'
+      x64:
+        BuildPlatform: 'x64'
+      arm:
+        BuildPlatform: 'arm'
+      arm64:
+        BuildPlatform: 'arm64'
+
+  variables:
+    ob_outputDirectory: ${{ parameters.OutputDirectory }}
+    ob_artifactSuffix: $(BuildPlatform)
+    StagingFolder: $(ob_outputDirectory)
+
+    ${{ if eq(parameters.OfficialBuild, 'false' }}:
+      ob_sdl_codeSignValidation_excludes: '-|**\*.exe;-|**\*.dll' 
+
+    ob_symbolsPublishing_enabled: ${{ parameters.OfficialBuild }}
+    ob_symbolsPublishing_symbolsFolder: '$(ob_outputDirectory)'
+    ob_symbolsPublishing_searchPattern: '**\*.pdb'
+    ob_symbolsPublishing_indexSources: true
+
+  steps:
+    - task: UseDotNet@2
+      continueOnError: true
+      inputs: 
+        packageType: 'runtime'
+        version: '6.x'
+        performMultiLevelLookup: true
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore cppwinrt.sln
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(Build.SourcesDirectory)\cppwinrt.sln'
+
+    - task: VSBuild@1
+      displayName: Build fast_fwd
+      inputs:
+        solution: $(Build.SourcesDirectory)\cppwinrt.sln
+        msbuildArgs: /t:fast_fwd /m /p:CppWinRTBuildVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true
+        platform: $(BuildPlatform)
+        configuration: ${{ parameters.BuildConfiguration }}
+
+    - task: CopyFiles@2
+      displayName: Stage cppwinrt_fast_forwarder.lib
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\_build\$(BuildPlatform)\$(BuildConfiguration)
+        Contents: cppwinrt_fast_forwarder.lib
+        TargetFolder: $(StagingFolder)
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore cppwinrtvisualizer.sln
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(Build.SourcesDirectory)\natvis\cppwinrtvisualizer.sln'
+        
+    - task: VSBuild@1
+      displayName: Build Component visualizer
+      condition: or(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'arm64'))
+      inputs:
+        solution: $(Build.SourcesDirectory)\natvis\cppwinrtvisualizer.sln
+        msbuildArgs: /m /p:Deployment=Component,CppWinRTBuildVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true
+        platform: $(BuildPlatform)
+        configuration: ${{ parameters.BuildConfiguration }}
+        
+    - task: VSBuild@1
+      displayName: Build Standalone visualizer
+      condition: or(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'arm64'))
+      inputs:
+        solution: $(Build.SourcesDirectory)\natvis\cppwinrtvisualizer.sln
+        msbuildArgs: /m /p:Deployment=Standalone,CppWinRTBuildVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true
+        platform: $(BuildPlatform)
+        configuration: ${{ parameters.BuildConfiguration }}
+
+    - task: CopyFiles@2
+      displayName: Stage Component cppwinrtvisualizer.*
+      condition: or(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'arm64'))
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\natvis\$(BuildPlatform)\$(BuildConfiguration)\Component
+        Contents: |
+          cppwinrtvisualizer.dll
+          cppwinrtvisualizer.pdb
+          cppwinrtvisualizer.vsdconfig
+        TargetFolder: $(StagingFolder)\Component
+
+    - task: CopyFiles@2
+      displayName: Stage Standalone cppwinrtvisualizer.*
+      condition: or(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'arm64'))
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\natvis\$(BuildPlatform)\$(BuildConfiguration)\Standalone
+        Contents: |
+          cppwinrtvisualizer.dll
+          cppwinrtvisualizer.pdb
+          cppwinrtvisualizer.vsdconfig
+        TargetFolder: $(StagingFolder)\Standalone
+        
+    - task: VSBuild@1
+      displayName: Build cppwinrt
+      condition: or(eq(variables['BuildPlatform'], 'x86'), eq(variables['BuildPlatform'], 'x64'))
+      inputs:
+        solution: $(Build.SourcesDirectory)\cppwinrt.sln
+        msbuildArgs: /t:cppwinrt /m /p:CppWinRTBuildVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true
+        platform: $(BuildPlatform)
+        configuration: ${{ parameters.BuildConfiguration }}
+        
+    - task: CopyFiles@2
+      displayName: Stage cppwinrt.*
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)\_build\$(BuildPlatform)\$(BuildConfiguration)
+        Contents: |
+          cppwinrt.exe
+          cppwinrt.pdb
+        TargetFolder: $(StagingFolder)\cppwinrt
+
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for cppwinrt binaries'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: '**/*.dll;**/*.exe'
+        search_root: $(StagingFolder)

--- a/.pipelines/jobs/OneBranchNuGet.yml
+++ b/.pipelines/jobs/OneBranchNuGet.yml
@@ -1,0 +1,76 @@
+# Build the NuGet package
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: BuildVersion
+    type: string
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
+jobs:
+  - job:
+    pool:
+      type: windows
+    
+    variables:
+      ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+      ob_nugetPublishing_enabled: ${{ parameters.OfficialBuild }}
+      PackageVersion: ${{ parameters.BuildVersion }}
+
+    steps:
+      - task: UseDotNet@2
+        continueOnError: true
+        inputs: 
+          packageType: 'runtime'
+          version: '6.x'
+          performMultiLevelLookup: true
+
+      - task: NuGetToolInstaller@1
+        displayName: Use NuGet 6.0.2
+        continueOnError: True
+        inputs:
+          versionSpec: 6.0.2
+
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download x86 artifacts'
+        inputs:
+          artifactName: 'drop_build_x86'
+          targetPath: '$(Build.SourcesDirectory)/x86'
+
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download x64 artifacts'
+        inputs:
+          artifactName: 'drop_build_x64'
+          targetPath: '$(Build.SourcesDirectory)/x64'
+
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download arm artifacts'
+        inputs:
+          artifactName: 'drop_build_arm'
+          targetPath: '$(Build.SourcesDirectory)/arm'
+
+      - task: DownloadPipelineArtifact@1
+        displayName: 'Download arm64 artifacts'
+        inputs:
+          artifactName: 'drop_build_arm64'
+          targetPath: '$(Build.SourcesDirectory)/arm64'
+            
+      - task: NuGetCommand@2
+        displayName: 'Build NuGet package'
+        inputs:
+          command: 'pack'
+          packagesToPack: 'nuget/Microsoft.Windows.CppWinRT.nuspec'
+          versioningScheme: byEnvVar
+          versionEnvVar: 'PackageVersion'
+          buildProperties: 'cppwinrt_exe=$(Build.SourcesDirectory)\x86\cppwinrt\cppwinrt.exe;cppwinrt_fast_fwd_x86=$(Build.SourcesDirectory)\x86\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_x64=$(Build.SourcesDirectory)\x64\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm=$(Build.SourcesDirectory)\arm\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm64=$(Build.SourcesDirectory)\arm64\cppwinrt_fast_forwarder.lib'
+          packDestination: $(ob_outputDirectory)\packages
+
+      - task: onebranch.pipeline.signing@1
+        displayName: '🔒 Onebranch Signing for NuGet package'
+        condition: eq(${{ parameters.OfficialBuild }}, 'true')
+        inputs:
+          command: sign
+          signing_profile: external_distribution
+          files_to_sign: 'Microsoft.Windows.CppWinRT.*.nupkg'
+          search_root: $(ob_outputDirectory)\packages

--- a/.pipelines/jobs/OneBranchTest.yml
+++ b/.pipelines/jobs/OneBranchTest.yml
@@ -1,0 +1,114 @@
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: BuildVersion
+    type: string
+
+jobs:
+- job:
+  pool:
+    type: windows
+  strategy:
+    matrix:
+      test.x86:
+        TestExe: 'test'
+        TestProject: 'test'
+        BuildPlatform: 'x86'
+      test_cpp20.x86:
+        TestExe: 'test_cpp20'
+        TestProject: 'test_cpp20'
+        BuildPlatform: 'x86'
+      test_cpp20_no_sourcelocation.x86:
+        TestExe: 'test_cpp20_no_sourcelocation'
+        TestProject: 'test_cpp20_no_sourcelocation'
+        BuildPlatform: 'x86'
+      test_win7.x86:
+        TestExe: 'test_win7'
+        TestProject: 'test_win7'
+        BuildPlatform: 'x86'
+      test_fast.x86:
+        TestExe: 'test_fast'
+        TestProject: 'test_fast'
+        BuildPlatform: 'x86'
+      test_slow.x86:
+        TestExe: 'test_slow'
+        TestProject: 'test_slow'
+        BuildPlatform: 'x86'
+      test_old.x86:
+        TestExe: 'test_old'
+        TestProject: 'old_tests\test_old'
+        BuildPlatform: 'x86'
+      test_module_lock_custom.x86:
+        TestExe: 'test_module_lock_custom'
+        TestProject: 'test_module_lock_custom'
+        BuildPlatform: 'x86'
+      test_module_lock_none.x86:
+        TestExe: 'test_module_lock_none'
+        TestProject: 'test_module_lock_none'
+        BuildPlatform: 'x86'
+
+  variables:
+    ob_outputDirectory: $(Build.SourcesDirectory)\out
+    ob_artifactSuffix: $(TestExe).$(BuildPlatform)
+    ob_sdl_codeSignValidation_excludes: '-|**\*.exe;-|**\*.dll' 
+
+    BuildPath: '$(Build.SourcesDirectory)/_build/$(BuildPlatform)/${{ parameters.BuildConfiguration }}'
+  
+  steps:
+    - task: UseDotNet@2
+      continueOnError: true
+      inputs: 
+        packageType: 'runtime'
+        version: '6.x'
+        performMultiLevelLookup: true
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download cppwinrt executable'
+      inputs:
+        artifactName: 'drop_build_$(BuildPlatform)'
+        targetPath: '$(Pipeline.Workspace)'
+
+    - task: CopyFiles@2
+      displayName: 'Patch cppwinrt executable into build directory'
+      inputs:
+        sourceFolder: '$(Pipeline.Workspace)'
+        Contents: '**\cppwinrt.exe'
+        TargetFolder: $(BuildPath)
+        flattenFolders: true
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore cppwinrt.sln
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(Build.SourcesDirectory)\cppwinrt.sln'
+
+    - task: PowerShell@2
+      displayName: Remove cppwinrt dependency from test projects
+      inputs:
+        targetType: inline
+        script: |
+          # Hack-ish: We already have a built exe, so we want to avoid rebuilding cppwinrt
+          mv cppwinrt.sln cppwinrt.sln.orig
+          Get-Content cppwinrt.sln.orig |
+            Where-Object { -not $_.Contains("{D613FB39-5035-4043-91E2-BAB323908AF4} = {D613FB39-5035-4043-91E2-BAB323908AF4}") } |
+            Set-Content cppwinrt.sln
+          "Modified contents"
+          Get-Content cppwinrt.sln
+      
+    - task: CmdLine@2
+      displayName: Run cppwinrt to build projection
+      inputs:
+        script: $(BuildPath)\cppwinrt.exe -in local -out $(BuildPath) -verbose
+
+    - task: VSBuild@1
+      displayName: Build test
+      inputs:
+        solution: $(Build.SourcesDirectory)\cppwinrt.sln
+        msbuildArgs: /t:test\$(TestProject) /m /p:CppWinRTBuildVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true /bl:$(ob_outputDirectory)\output.binlog
+        platform: $(BuildPlatform)
+        configuration: ${{ parameters.BuildConfiguration }}
+
+    - task: CmdLine@2
+      displayName: Run test
+      inputs:
+        script: $(BuildPath)\$(TestExe).exe

--- a/.pipelines/jobs/OneBranchVsix.yml
+++ b/.pipelines/jobs/OneBranchVsix.yml
@@ -1,0 +1,147 @@
+parameters:
+  - name: BuildConfiguration
+    type: string
+  - name: BuildVersion
+    type: string
+  - name: OfficialBuild
+    type: boolean
+    default: false
+
+jobs:
+- job:
+  pool:
+    type: windows
+  strategy:
+    matrix:
+      Standalone:
+        Deployment: 'Standalone'
+        VsVersion: 'Dev17'
+        VsixFilename: Microsoft.Windows.CppWinRT.$(VsVersion)
+      Component:
+        Deployment: 'Component'
+        VsVersion: 'Dev17'
+        VsixFilename: Microsoft.Windows.CppWinRT.$(VsVersion)
+      Dev16:
+        Deployment: 'Standalone'
+        VsVersion: 'Dev16'
+        VsixFilename: Microsoft.Windows.CppWinRT
+  
+  variables:
+    ob_outputDirectory: $(Build.SourcesDirectory)\out
+    ob_artifactSuffix: $(VsVersion)_$(Deployment)
+
+    BuildFolder: $(Build.SourcesDirectory)\vsix\$(VsVersion)\bin\${{ parameters.BuildConfiguration }}\$(Deployment)
+
+    ob_symbolsPublishing_enabled: true
+    ob_symbolsPublishing_symbolsFolder: '$(ob_outputDirectory)'
+    ob_symbolsPublishing_searchPattern: '**\*.pdb'
+    ob_symbolsPublishing_indexSources: true
+    
+  steps:
+    - task: UseDotNet@2
+      continueOnError: true
+      inputs: 
+        packageType: 'sdk'
+        version: '6.x'
+        performMultiLevelLookup: true
+
+    - task: NuGetToolInstaller@1
+      displayName: Use NuGet 6.0.2
+      continueOnError: True
+      inputs:
+        versionSpec: 6.0.2
+
+    - task: NuGetCommand@2
+      displayName: NuGet restore
+      inputs:
+        command: 'restore'
+        restoreSolution: '$(Build.SourcesDirectory)\vsix\vsix.sln'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download x86 binaries'
+      inputs:
+        artifactName: 'drop_build_x86'
+        targetPath: '$(Build.SourcesDirectory)\x86'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download x64 binaries'
+      inputs:
+        artifactName: 'drop_build_x64'
+        targetPath: '$(Build.SourcesDirectory)\x64'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download arm binaries'
+      inputs:
+        artifactName: 'drop_build_arm'
+        targetPath: '$(Build.SourcesDirectory)\arm'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download arm64 binaries'
+      inputs:
+        artifactName: 'drop_build_arm64'
+        targetPath: '$(Build.SourcesDirectory)\arm64'
+    
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download NuGet'
+      inputs:
+        artifactName: 'drop_NuGet_'
+        targetPath: '$(Pipeline.Workspace)\nuget'
+
+    - task: VSBuild@1
+      displayName: Build VSIX
+      inputs:
+        solution: $(Build.SourcesDirectory)\vsix\vsix.sln
+        msbuildArgs: /t:vsix_$(VsVersion) /m /p:CppWinRTVersion=${{ parameters.BuildVersion }},clean_intermediate_files=true,Deployment=$(Deployment),NatvisDirx86=$(Build.SourcesDirectory)\x86\$(Deployment)\,NatvisDirx64=$(Build.SourcesDirectory)\x64\$(Deployment)\,NatvisDirarm64=$(Build.SourcesDirectory)\arm64\$(Deployment)\,NupkgDir=$(Pipeline.Workspace)\nuget\packages /bl:$(ob_outputDirectory)\output.binlog
+        platform: 'Any CPU'
+        configuration: ${{ parameters.BuildConfiguration }}
+
+    - task: ExtractFiles@1
+      displayName: Extract VSIX contents for signing
+      inputs:
+        archiveFilePatterns: '$(BuildFolder)\$(VsixFilename).vsix'
+        destinationFolder: '$(Agent.TempDirectory)\$(VsixFilename)'
+        overwriteExistingFiles: true
+
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for VSIX contents'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: '**/Microsoft.Windows.CppWinRT.*.dll'
+        search_root: '$(Agent.TempDirectory)\$(VsixFilename)'
+    
+    - task: ArchiveFiles@2
+      displayName: 'Repack signed VSIX contents'
+      inputs:
+        rootFolderOrFile: '$(Agent.TempDirectory)\$(VsixFilename)'
+        includeRootFolder: false
+        archiveFile: '$(ob_outputDirectory)\$(VsixFilename).vsix'
+
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for VSIX'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: '$(VsixFilename).vsix'
+        search_root: '$(ob_outputDirectory)'
+
+    - task: CopyFiles@2
+      displayName: Stage VSIX Manifest
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)\vsix'
+        Contents: |
+          extension.manifest.json
+          overview.md
+        TargetFolder: '$(ob_outputDirectory)'
+
+    - task: CopyFiles@2
+      displayName: Stage VSIX json and symbols
+      inputs:
+        SourceFolder: $(Buildfolder)
+        Contents: |
+          $(VsixFilename).pdb
+          $(VsixFilename).json
+        TargetFolder: '$(ob_outputDirectory)'
+    

--- a/.pipelines/variables/OneBranchVariables.yml
+++ b/.pipelines/variables/OneBranchVariables.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+  system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 1
+  NUGET_XMLDOC_MODE: none
+
+  # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022@sha256:57a4885980ad4deec119d0e3c84abeebc57573c03b3da0ea63971fc9c0eadf45' 
+
+  Codeql.Enabled: true #  CodeQL once every 3 days on the default branch for all languages its applicable to in that pipeline.
+  GDN_USE_DOTNET: true

--- a/.pipelines/variables/version.yml
+++ b/.pipelines/variables/version.yml
@@ -1,0 +1,7 @@
+variables:
+  MajorVersion: "2"
+  MinorVersion: "0"
+  VersionDate: $[format('{0:yyMMdd}', pipeline.startTime)]
+  VersionCounter: $[counter(variables['VersionDate'], 1)]
+  BuildVersion: $(MajorVersion).$(MinorVersion).$(VersionDate).$(VersionCounter)
+  PatchVersion: $(VersionDate)$(VersionCounter)


### PR DESCRIPTION
This moves our official build pipelines to OneBranch.

There are actually two pipelines here: OneBranch.Official and OneBranch.PullRequest. The PullRequest pipeline is an option to run when sources are synced to a private mirror, just to validate that everything is still working, but without code signing and skipping other publishing steps for vpacks and nuget.

There are still some bizarre test failures when running the tests within the OneBranch containerized environment. I'll keep an action item on myself to run down the investigation on that (or mitigate it some other way), but we'll have lots of testing in our CI pipelines, so it's not an emergency right now.