### PR TITLE
Remove explicitly setting PreferredToolArchitecture, since VS 2022 handles this more comprehensively

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.props
+++ b/nuget/Microsoft.Windows.CppWinRT.props
@@ -13,7 +13,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <PropertyGroup>
-        <PreferredToolArchitecture>x64</PreferredToolArchitecture>
         <CanReferenceWinRT>true</CanReferenceWinRT>
         <CppWinRTPackage Condition="'$(CppWinRTEnabled)' != 'true'">true</CppWinRTPackage>
         <CppWinRTPackage Condition="'$(CppWinRTPackage)' != 'true'">false</CppWinRTPackage>


### PR DESCRIPTION
fixes #1302

With VS 2022, PreferredToolArchitecture is now set appropriately for every architecture (via Microsoft.Cpp.ToolsetLocation.props), so should no longer be set unconditionally by C++/WinRT