### PR TITLE
Add UTF-8 path support

### DIFF
--- a/cppwinrt/app.manifest
+++ b/cppwinrt/app.manifest
@@ -3,6 +3,7 @@
 <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
         <ws2:longPathAware>true</ws2:longPathAware>
+        <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </windowsSettings>
 </application>
 </assembly>


### PR DESCRIPTION
This takes advantage of a Windows 10 manifest property to set the [process code page to UTF-8](https://docs.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page#set-a-process-code-page-to-utf-8).

Prior to this update:

```
cppwinrt.exe -in d:\Test❤️\Windows.winmd -out d:\Test❤️
cppwinrt : error Path 'd:\Test??\Windows.winmd' is not a file or directory
```

With this update:

```
D:\git\cppwinrt\_build\x86\Release\cppwinrt.exe -in d:\Test❤️\Windows.winmd -out d:\Test❤️
```

Input is parsed correctly and output is generated correctly.

I'm reluctant to add a test for this scenario to avoid complicating the build.

Fixes: #1306