### PR TITLE
Fix workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI Tests
+
 on:
-  push:
   pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
Previously, the trigger would run the workflow for "each push and PR to master" when it should be for "each PR and push to master". This should significantly cut down on the resources needed for a workflow. 
