### PR TITLE
Fix cpp20 source location test failure resulting from newer compiler

### DIFF
--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -61,13 +61,10 @@ TEST_CASE("custom_error_logger")
     REQUIRE(fileNameSv.find("custom_error.cpp") != std::string::npos);
     const auto functionNameSv = std::string_view(s_loggerArgs.functionName);
     REQUIRE(!functionNameSv.empty());
-#if defined(__GNUC__) && !defined(__clang__)
-    REQUIRE(functionNameSv == "void {anonymous}::FailOnLine15()");
-#elif defined(__GNUC__) && defined(__clang__)
-    REQUIRE(functionNameSv == "void (anonymous namespace)::FailOnLine15()");
-#else
-    REQUIRE(functionNameSv == "void __cdecl `anonymous-namespace'::FailOnLine15(void)");
-#endif
+    // Every compiler has a slightly different naming approach for this function, and even the same
+    // compiler can change its mind over time.  Instead of matching the entire function name just
+    // match against the part we care about.
+    REQUIRE(functionNameSv.find("FailOnLine15" != std::string_view::npos));
 
     REQUIRE(s_loggerArgs.returnAddress);
     REQUIRE(s_loggerArgs.result == static_cast<int32_t>(0x80000018)); // E_ILLEGAL_DELEGATE_ASSIGNMENT)

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -64,7 +64,7 @@ TEST_CASE("custom_error_logger")
     // Every compiler has a slightly different naming approach for this function, and even the same
     // compiler can change its mind over time.  Instead of matching the entire function name just
     // match against the part we care about.
-    REQUIRE(functionNameSv.find("FailOnLine15" != std::string_view::npos));
+    REQUIRE((functionNameSv.find("FailOnLine15") != std::string_view::npos));
 
     REQUIRE(s_loggerArgs.returnAddress);
     REQUIRE(s_loggerArgs.result == static_cast<int32_t>(0x80000018)); // E_ILLEGAL_DELEGATE_ASSIGNMENT)

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -66,7 +66,7 @@ TEST_CASE("custom_error_logger")
 #elif defined(__GNUC__) && defined(__clang__)
     REQUIRE(functionNameSv == "void (anonymous namespace)::FailOnLine15()");
 #else
-    REQUIRE(functionNameSv == "FailOnLine15");
+    REQUIRE(functionNameSv == "void __cdecl `anonymous-namespace'::FailOnLine15(void)");
 #endif
 
     REQUIRE(s_loggerArgs.returnAddress);


### PR DESCRIPTION
What's this all about?
Fix a test case failure caused by changing compiler behavior in a newer compiler version.  The signature that MSVC provides for source_location has changed recently.

Instead of chasing the full decorated name, with each compiler having a slight variation, we now match just the meaningful substring that we care about "FailOnLine15".  This should now be stable across compilers and across compiler versions.

Fixes: #1325
