### PR TITLE
Increase foldability of various templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ C++/WinRT is an entirely standard C++ language projection for Windows Runtime (W
 
 Don't build C++/WinRT yourself - just download the latest version here: https://aka.ms/cppwinrt/nuget
 
+## Working on the compiler
+
 If you really want to build it yourself, the simplest way to do so is to run the `build_test_all.cmd` script in the root directory. Developers needing to work on the C++/WinRT compiler itself should go through the following steps to arrive at an efficient inner loop:
 
 * Open a dev command prompt pointing at the root of the repo.
 * Open the `cppwinrt.sln` solution.
-* Build the x64 Release configuration of the `cppwinrt` project only. Do not attempt to build anything else just yet.
+* Rebuild the x64 Release configuration of the `cppwinrt` project only. Do not attempt to build anything else just yet.
 * Run `build_projection.cmd` in the dev command prompt.
 * Switch to the x64 Debug configuration in Visual Studio and build all projects as needed.
 

--- a/build_nuget.cmd
+++ b/build_nuget.cmd
@@ -1,7 +1,7 @@
 rem @echo off
 
 set target_version=%1
-if "%target_version%"=="" set target_version=1.2.3.4
+if "%target_version%"=="" set target_version=3.0.0.0
 
 call msbuild /m /p:Configuration=Release,Platform=x86,CppWinRTBuildVersion=%target_version% cppwinrt.sln /t:fast_fwd
 call msbuild /m /p:Configuration=Release,Platform=x64,CppWinRTBuildVersion=%target_version% cppwinrt.sln /t:fast_fwd
@@ -10,4 +10,4 @@ call msbuild /m /p:Configuration=Release,Platform=arm64,CppWinRTBuildVersion=%ta
 
 call msbuild /m /p:Configuration=Release,Platform=x86,CppWinRTBuildVersion=%target_version% cppwinrt.sln /t:cppwinrt
 
-nuget pack nuget\Microsoft.Windows.CppWinRT.nuspec -Properties cppwinrt_exe=%cd%\_build\x86\Release\cppwinrt.exe;cppwinrt_fast_fwd_x86=%cd%\_build\x86\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_x64=%cd%\_build\x64\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm=%cd%\_build\arm\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm64=%cd%\_build\arm64\Release\cppwinrt_fast_forwarder.lib 
+nuget pack nuget\Microsoft.Windows.CppWinRT.nuspec -Properties cppwinrt_version=%target_version%;cppwinrt_exe=%cd%\_build\x86\Release\cppwinrt.exe;cppwinrt_fast_fwd_x86=%cd%\_build\x86\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_x64=%cd%\_build\x64\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm=%cd%\_build\arm\Release\cppwinrt_fast_forwarder.lib;cppwinrt_fast_fwd_arm64=%cd%\_build\arm64\Release\cppwinrt_fast_forwarder.lib 

--- a/cppwinrt.sln
+++ b/cppwinrt.sln
@@ -115,6 +115,19 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_cpp20_no_sourcelocatio
 		{D613FB39-5035-4043-91E2-BAB323908AF4} = {D613FB39-5035-4043-91E2-BAB323908AF4}
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D15C8430-A7CD-4616-BD84-243B26A9F1C2}"
+	ProjectSection(SolutionItems) = preProject
+		build_nuget.cmd = build_nuget.cmd
+		build_prior_projection.cmd = build_prior_projection.cmd
+		build_projection.cmd = build_projection.cmd
+		build_test_all.cmd = build_test_all.cmd
+		build_vsix.cmd = build_vsix.cmd
+		compile_tests.cmd = compile_tests.cmd
+		prepare_versionless_diffs.cmd = prepare_versionless_diffs.cmd
+		README.md = README.md
+		run_tests.cmd = run_tests.cmd
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM

--- a/nuget/Microsoft.Windows.CppWinRT.nuspec
+++ b/nuget/Microsoft.Windows.CppWinRT.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>Microsoft.Windows.CppWinRT</id>
-    <version>1.0.0.0</version>
+    <version>$cppwinrt_version$</version>
     <title>C++/WinRT Build Support</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/strings/base_delegate.h
+++ b/strings/base_delegate.h
@@ -6,8 +6,42 @@ namespace winrt::impl
 #pragma warning(disable:4458) // declaration hides class member (okay because we do not use named members of base class)
 #endif
 
+    struct implements_delegate_base
+    {
+        WINRT_IMPL_NOINLINE uint32_t inc_ref() noexcept
+        {
+            return ++m_references;
+        }
+
+        WINRT_IMPL_NOINLINE uint32_t dec_ref() noexcept
+        {
+            return --m_references;
+        }
+
+        WINRT_IMPL_NOINLINE uint32_t QueryInterfaceImpl(guid const& id, void** result, unknown_abi* outerAbiPtr, guid const& outerId)
+        {
+            if ((id == outerId) || is_guid_of<Windows::Foundation::IUnknown>(id) || is_guid_of<IAgileObject>(id))
+            {
+                *result = outerAbiPtr;
+                inc_ref();
+                return 0;
+            }
+
+            if (is_guid_of<IMarshal>(id))
+            {
+                return make_marshaler(outerAbiPtr, result);
+            }
+
+            *result = nullptr;
+            return error_no_interface;
+        }
+
+    private:
+        atomic_ref_count m_references{ 1 };
+    };
+
     template <typename T, typename H>
-    struct implements_delegate : abi_t<T>, H, update_module_lock
+    struct implements_delegate : abi_t<T>, implements_delegate_base, H, update_module_lock
     {
         implements_delegate(H&& handler) : H(std::forward<H>(handler))
         {
@@ -15,30 +49,17 @@ namespace winrt::impl
 
         int32_t __stdcall QueryInterface(guid const& id, void** result) noexcept final
         {
-            if (is_guid_of<T>(id) || is_guid_of<Windows::Foundation::IUnknown>(id) || is_guid_of<IAgileObject>(id))
-            {
-                *result = static_cast<abi_t<T>*>(this);
-                AddRef();
-                return 0;
-            }
-
-            if (is_guid_of<IMarshal>(id))
-            {
-                return make_marshaler(this, result);
-            }
-
-            *result = nullptr;
-            return error_no_interface;
+            return QueryInterfaceImpl(id, result, static_cast<abi_t<T>*>(this), guid_of<T>());
         }
 
         uint32_t __stdcall AddRef() noexcept final
         {
-            return ++m_references;
+            return inc_ref();
         }
 
         uint32_t __stdcall Release() noexcept final
         {
-            auto const remaining = --m_references;
+            auto const remaining = dec_ref();
 
             if (remaining == 0)
             {
@@ -47,10 +68,6 @@ namespace winrt::impl
 
             return remaining;
         }
-
-    private:
-
-        atomic_ref_count m_references{ 1 };
     };
 
     template <typename T, typename H>

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -342,26 +342,23 @@ namespace winrt::impl
         return 1;
     }
 
-    struct report_helper
+    WINRT_IMPL_NOINLINE inline bool report_failed_invoke()
     {
-        WINRT_IMPL_NOINLINE static bool report_failed_invoke()
+        int32_t const code = to_hresult();
+
+        static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
+        impl::load_runtime_function(L"combase.dll", "RoTransformError", handler, fallback_RoTransformError);
+        handler(code, 0, nullptr);
+
+        if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED
+            code == static_cast<int32_t>(0x800706BA) || // HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE)
+            code == static_cast<int32_t>(0x89020001))   // JSCRIPT_E_CANTEXECUTE
         {
-            int32_t const code = to_hresult();
-
-            static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
-            impl::load_runtime_function(L"combase.dll", "RoTransformError", handler, fallback_RoTransformError);
-            handler(code, 0, nullptr);
-
-            if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED
-                code == static_cast<int32_t>(0x800706BA) || // HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE)
-                code == static_cast<int32_t>(0x89020001))   // JSCRIPT_E_CANTEXECUTE
-            {
-                return false;
-            }
-
-            return true;
+            return false;
         }
-    };
+
+        return true;
+    }
 
     template <typename Delegate, typename... Arg>
     bool invoke(Delegate const& delegate, Arg const&... args) noexcept
@@ -372,7 +369,7 @@ namespace winrt::impl
         }
         catch (...)
         {
-            return report_helper::report_failed_invoke();
+            return report_failed_invoke();
         }
 
         return true;

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -342,6 +342,24 @@ namespace winrt::impl
         return 1;
     }
 
+    WINRT_IMPL_NOINLINE static bool report_failed_invoke()
+    {
+        int32_t const code = to_hresult();
+
+        static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
+        impl::load_runtime_function(L"combase.dll", "RoTransformError", handler, fallback_RoTransformError);
+        handler(code, 0, nullptr);
+
+        if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED
+            code == static_cast<int32_t>(0x800706BA) || // HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE)
+            code == static_cast<int32_t>(0x89020001))   // JSCRIPT_E_CANTEXECUTE
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     template <typename Delegate, typename... Arg>
     bool invoke(Delegate const& delegate, Arg const&... args) noexcept
     {
@@ -351,18 +369,7 @@ namespace winrt::impl
         }
         catch (...)
         {
-            int32_t const code = to_hresult();
-
-            static int32_t(__stdcall * handler)(int32_t, int32_t, void*) noexcept;
-            impl::load_runtime_function(L"combase.dll", "RoTransformError", handler, fallback_RoTransformError);
-            handler(code, 0, nullptr);
-
-            if (code == static_cast<int32_t>(0x80010108) || // RPC_E_DISCONNECTED
-                code == static_cast<int32_t>(0x800706BA) || // HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE)
-                code == static_cast<int32_t>(0x89020001))   // JSCRIPT_E_CANTEXECUTE
-            {
-                return false;
-            }
+            return report_failed_invoke();
         }
 
         return true;

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1167,35 +1167,36 @@ namespace winrt::impl
                 AddRef();
                 return 0;
             }
-            else if (is_guid_of<Windows::Foundation::IInspectable>(id))
+
+            if constexpr (is_inspectable::value)
             {
-                if constexpr (is_inspectable::value)
+                if (is_guid_of<Windows::Foundation::IInspectable>(id))
                 {
                     *object = find_inspectable();
                     AddRef();
                     return 0;
                 }
             }
-            else if (is_guid_of<impl::IWeakReferenceSource>(id))
+
+            if constexpr (is_weak_ref_source::value)
             {
-                if constexpr (is_weak_ref_source::value)
+                if (is_guid_of<impl::IWeakReferenceSource>(id))
                 {
                     *object = make_weak_ref();
                     return *object ? error_ok : error_bad_alloc;
                 }
             }
-            else if (is_guid_of<impl::IAgileObject>(id))
+            
+            if constexpr (is_agile::value)
             {
-                if constexpr (is_agile::value)
+                if (is_guid_of<impl::IAgileObject>(id))
                 {
                     *object = get_unknown();
                     AddRef();
                     return 0;
                 }
-            }
-            else if (is_guid_of<IMarshal>(id))
-            {
-                if constexpr (is_agile::value)
+
+                if (is_guid_of<IMarshal>(id))
                 {
                     return make_marshaler(get_unknown(), object);
                 }


### PR DESCRIPTION
SizeBench revealed heavily non-foldability of certain C++/WinRT templates contributing to increased Windows binary sizes. Some small tweaks dropped the size of `test.exe` (release, x64) by ~132kb. (5180416 -> 5030400, or 2.8% ... which isn't a super lot, but it's nonzero.

Fixes #1334 and related

## Changes

**Enable nuspec iteration** - Bump the default nuspec version to 3.0.0.0 so `build_nuget.cmd` and iterating with a local nuget source is easier.

**Add solution files** - Niceness for people who live in Visual Studio.

**Fold delegate bases** - Forced the layout of the delegate types to be regular by moving the reference count into a base _before_ the non-ABI types. This folds nearly all the AddRef/QueryInterface instances into one. Releases are still unique because they call up into dtors.

**Fold "report" in invoke** - The invoke helper is a try/catch{report} but the body of "report" is identical on each invoke specialization. Move it to a unique non-inlineable method.

**Fold event::add** - Make the delegate first, then all the "expand the collection" instances are identical.

## Further Work

SizeBench reports the following additional foldability wastage, quoted from the same test.exe:

* make_agile_delegate<> - 3.2kb; the agile thunk is unique basically per delegate `::Invoke` vtable and offset adjusters.
* root_implements::<T1,T2,T3>::query_interface - 4.1kb; again unique per vtable instance, also related to inlining choices
* winrt::event<T1>::add - 3.2kb; all cost related to inlined use of `make_agile_delegate`
* winrt::impl::runtime_class_name<T1,T2>::get() - 1.4kb; should probably switch to std::wstring_view but this may be a breaking change; currently induces an `hstring` construction.
 
## Testing

Tested by `build_and_test.cmd` - all built, all passed