### PR TITLE
drop constexpr from root_implements_composable_inner::outer()

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -801,7 +801,7 @@ namespace winrt::impl
     struct WINRT_IMPL_EMPTY_BASES root_implements_composable_inner
     {
     protected:
-        static constexpr inspectable_abi* outer() noexcept { return nullptr; }
+        static inspectable_abi* outer() noexcept { return nullptr; }
 
         template <typename, typename, typename>
         friend class produce_dispatch_to_overridable_base;


### PR DESCRIPTION
This removes `constexpr` from the `template <typename D, bool>` implementation of `root_implements_composable_inner::outer()`.

This was causing `nonnull` warnings in GCC such as:

    winrt/base.h: In instantiation of 'int32_t winrt::impl::root_implements<D, I>::GetIids(uint32_t*, winrt::guid**) [with D = py::python_iterable<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >::iterator; I = {winrt::Windows::Foundation::Collections::IIterator<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >}; int32_t = int; uint32_t = unsigned int]':
    winrt/base.h:8163:49:   required from 'winrt::impl::hresult_type winrt::implements<D, I>::GetIids(winrt::impl::count_type*, winrt::impl::guid_type**) [with D = py::python_iterable<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >::iterator; I = {winrt::Windows::Foundation::Collections::IIterator<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >}; winrt::impl::hresult_type = int; winrt::impl::count_type = unsigned int; winrt::impl::guid_type = winrt::guid]'
    winrt/base.h:7197:34:   required from 'int32_t winrt::impl::produce_base<D, I, Enable>::GetIids(uint32_t*, winrt::guid**) [with D = py::python_iterable<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >::iterator; I = winrt::Windows::Foundation::Collections::IIterator<winrt::Windows::Foundation::Collections::IKeyValuePair<winrt::hstring, winrt::hstring> >; Enable = void; int32_t = int; uint32_t = unsigned int]'
    winrt/base.h:7195:27:   required from here
    winrt/base.h:7573:35: error: 'this' pointer is null [-Werror=nonnull]
    7573 |                 return this->outer()->GetIids(count, array);
        |                        ~~~~~~~~~~~^~
    C:/Users/david/Documents/GitHub/pywinrt/projection/winrt-sdk/src/winrt_sdk/cppwinrt/winrt/base.h:1766:39: note: in a call to non-static member function 'virtual int32_t winrt::impl::abi<winrt::Windows::Foundation::IInspectable>::type::GetIids(uint32_t*, winrt::guid**)'
    1766 |             virtual int32_t __stdcall GetIids(uint32_t* count, guid** ids) noexcept = 0;
        |                                       ^~~~~~~

Fixes: https://github.com/microsoft/cppwinrt/issues/1349
