### PR TITLE
Update GitHub action LLVM version to 17.0.5

### DIFF
--- a/.github/actions/setup-llvm-msvc/action.yml
+++ b/.github/actions/setup-llvm-msvc/action.yml
@@ -4,7 +4,7 @@ inputs:
   llvm-version:
     description: 'LLVM version'
     required: true
-    default: '15.0.5'
+    default: '17.0.5'
 outputs:
   llvm-path:
     description: "The path in which LLVM is installed to"

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -22,6 +22,10 @@
     Optionally add /t:<project> to only build a given a solution project:
 
         msbuild /m /p:Configuration=Debug,Platform=x64,Clang=1 cppwinrt.sln /t:cppwinrt
+
+    If you have deployed the LLVM toolset elsewhere, add its path to the configuration:
+
+        msbuild /m /p:Configuration=Debug,Platform=x64,Clang=1,LLVMToolsVersion=17.0.5,LLVMInstallDir=C:\llvm cppwinrt.sln
   -->
 
   <PropertyGroup Condition="'$(Clang)'=='1'">

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -35,12 +35,7 @@ namespace
     }
 }
 
-#if defined(__clang__) && defined(_MSC_VER)
-// FIXME: Blocked on __cpp_consteval, see:
-// * https://github.com/microsoft/cppwinrt/pull/1203#issuecomment-1279764927
-// * https://github.com/llvm/llvm-project/issues/57094
-TEST_CASE("custom_error_logger", "[!shouldfail]")
-#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 170000
 // <source_location> not available in libc++ before LLVM 16
 TEST_CASE("custom_error_logger", "[!shouldfail]")
 #else


### PR DESCRIPTION
In #1372 it looks like the build VMs were updated to a more recent VS and VCRT and STL combination, requiring an updated LLVM toolchain. This bumps the target LLM version to match.
