### PR TITLE
Implement and consume non-originating hresults

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -23,10 +23,5 @@
     <StackTraceFormat>ShortInfo</StackTraceFormat>
     <StackTracePointReplacement>,</StackTracePointReplacement>
     <TestCaseTimeout>20000</TestCaseTimeout><!-- 20s in Milliseconds -->
-    <Overrides>
-      <Source dllfilter="CatchDll_Dummy" filter="Catch_Dummy">
-        <TestCaseTimeout>10</TestCaseTimeout><!-- Milliseconds -->
-      </Source>
-    </Overrides>
   </Catch2Adapter>
 </RunSettings>

--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>1</MaxCpuCount>
+    <ResultsDirectory>.\TestResults</ResultsDirectory><!-- Path relative to solution directory -->
+    <TestSessionTimeout>60000</TestSessionTimeout><!-- Milliseconds -->
+    <ForceListContent>true</ForceListContent>
+
+  </RunConfiguration>
+
+  <!-- Adapter Specific sections -->
+
+  <!-- Catch2 adapter -->
+  <Catch2Adapter>
+    <Logging>Verbose</Logging>
+    <FilenameFilter>^test</FilenameFilter><!-- Regex filter -->
+    <ForceListContent>true</ForceListContent>
+    <CombinedTimeout>30000</CombinedTimeout><!-- 30s in Milliseconds -->
+    <DebugBreak>on</DebugBreak>
+    <IncludeHidden>true</IncludeHidden>
+    <Logging>Normal</Logging>
+    <MessageFormat>StatsOnly</MessageFormat>
+    <StackTraceFormat>ShortInfo</StackTraceFormat>
+    <StackTracePointReplacement>,</StackTracePointReplacement>
+    <TestCaseTimeout>20000</TestCaseTimeout><!-- 20s in Milliseconds -->
+    <Overrides>
+      <Source dllfilter="CatchDll_Dummy" filter="Catch_Dummy">
+        <TestCaseTimeout>10</TestCaseTimeout><!-- Milliseconds -->
+      </Source>
+    </Overrides>
+  </Catch2Adapter>
+</RunSettings>

--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ a dev command prompt at the root of the repo _after_ following the above build i
 * Run `build_prior_projection.cmd` in the dev command prompt as well
 * Run `prepare_versionless_diffs.cmd` which removes version stamps on both current and prior projection
 * Use a directory-level differencing tool to compare `_build\$(arch)\$(flavor)\winrt` and `_reference\$(arch)\$(flavor)\winrt`
+
+## Testing
+This repository uses the [Catch2](https://github.com/catchorg/Catch2) testing framework. You can run `build_tests_all.cmd` to run the test from a Visual Studio command line. This will build and run the tests. To Debug the tests, you can debug the associated `_build\$(arch)\$(flavor)\<test>.exe` under the debugger of your choice. 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,6 @@ a dev command prompt at the root of the repo _after_ following the above build i
 * Use a directory-level differencing tool to compare `_build\$(arch)\$(flavor)\winrt` and `_reference\$(arch)\$(flavor)\winrt`
 
 ## Testing
-This repository uses the [Catch2](https://github.com/catchorg/Catch2) testing framework. You can run `build_tests_all.cmd` to run the test from a Visual Studio command line. This will build and run the tests. To Debug the tests, you can debug the associated `_build\$(arch)\$(flavor)\<test>.exe` under the debugger of your choice. 
+This repository uses the [Catch2](https://github.com/catchorg/Catch2) testing framework.
+- From a Visual Studio command line, you should run `build_tests_all.cmd` to build and run the tests. To Debug the tests, you can debug the associated `_build\$(arch)\$(flavor)\<test>.exe` under the debugger of your choice.
+- Optionally, you can install the [Catch2Adapter](https://marketplace.visualstudio.com/items?itemName=JohnnyHendriks.ext01) to run the tests from Visual Studio.

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1368,6 +1368,11 @@ namespace cppwinrt
             w.write(R"(
         auto TryLookup(param_type<K> const& key) const
         {
+            //if (auto ignoreError = as<IIgnoreNextError>())
+            //{
+            //    ignoreError->IgnoreNextError();
+            //}
+
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
@@ -1394,6 +1399,11 @@ namespace cppwinrt
             w.write(R"(
         auto TryLookup(param_type<K> const& key) const
         {
+            //if (auto ignoreError = as<IIgnoreNextError>())
+            //{
+            //    ignoreError->IgnoreNextError();
+            //}
+
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
@@ -1416,6 +1426,10 @@ namespace cppwinrt
 
         auto TryRemove(param_type<K> const& key) const
         {
+            /*if (auto ignoreError = as<IIgnoreNextError>())
+            {
+                ignoreError->IgnoreNextError();
+            }*/
             return 0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Remove(get_abi(key)));
         }
 )");

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1368,11 +1368,6 @@ namespace cppwinrt
             w.write(R"(
         auto TryLookup(param_type<K> const& key) const
         {
-            //if (auto ignoreError = as<IIgnoreNextError>())
-            //{
-            //    ignoreError->IgnoreNextError();
-            //}
-
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
@@ -1399,11 +1394,6 @@ namespace cppwinrt
             w.write(R"(
         auto TryLookup(param_type<K> const& key) const
         {
-            //if (auto ignoreError = as<IIgnoreNextError>())
-            //{
-            //    ignoreError->IgnoreNextError();
-            //}
-
             if constexpr (std::is_base_of_v<Windows::Foundation::IUnknown, V>)
             {
                 V result{ nullptr };
@@ -1426,10 +1416,6 @@ namespace cppwinrt
 
         auto TryRemove(param_type<K> const& key) const
         {
-            /*if (auto ignoreError = as<IIgnoreNextError>())
-            {
-                ignoreError->IgnoreNextError();
-            }*/
             return 0 == impl::check_hresult_allow_bounds(WINRT_IMPL_SHIM(Windows::Foundation::Collections::IMap<K, V>)->Remove(get_abi(key)));
         }
 )");

--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -77,15 +77,6 @@ namespace winrt::impl
     };
 }
 
-//struct WINRT_IMPL_NOVTABLE IIgnoreNextError : unknown_abi
-//{
-//    virtual void __stdcall IgnoreNextError() noexcept = 0;
-//};
-//
-//template <> inline constexpr guid guid_v<IIgnoreNextError>{ 0x5b0d3235, 0x4dba, 0x4d44, { 0x86,0x5e,0x8f,0x1d,0x0e,0x4f,0xd0,0x4d } };
-//
-
-
 WINRT_EXPORT namespace winrt
 {
     template <typename D, typename T, typename Version = impl::no_collection_version>

--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -503,7 +503,7 @@ WINRT_EXPORT namespace winrt
         };
     };
 
-    template <typename D, typename K, typename V, bool ShouldOriginate = true, typename Version = impl::no_collection_version>
+    template <typename D, typename K, typename V, bool avoid_bounds_error_origination = false, typename Version = impl::no_collection_version>
     struct map_view_base : iterable_base<D, Windows::Foundation::Collections::IKeyValuePair<K, V>, Version>
     {
         V Lookup(K const& key) const
@@ -513,7 +513,7 @@ WINRT_EXPORT namespace winrt
 
             if (pair == static_cast<D const&>(*this).get_container().end())
             {
-                if constexpr (ShouldOriginate)
+                if constexpr (avoid_bounds_error_origination)
                 {
                     throw hresult_out_of_bounds();
                 }
@@ -546,8 +546,8 @@ WINRT_EXPORT namespace winrt
 
     };
 
-    template <typename D, typename K, typename V, bool ShouldOriginate = true>
-    struct map_base : map_view_base<D, K, V, ShouldOriginate, impl::collection_version>
+    template <typename D, typename K, typename V, bool avoid_bounds_error_origination = false>
+    struct map_base : map_view_base<D, K, V, avoid_bounds_error_origination, impl::collection_version>
     {
         Windows::Foundation::Collections::IMapView<K, V> GetView() const
         {
@@ -579,7 +579,7 @@ WINRT_EXPORT namespace winrt
             auto found = container.find(static_cast<D const&>(*this).wrap_value(key));
             if (found == container.end())
             {
-                if constexpr (ShouldOriginate)
+                if constexpr (avoid_bounds_error_origination)
                 {
                     throw hresult_out_of_bounds();
                 }
@@ -602,8 +602,8 @@ WINRT_EXPORT namespace winrt
         }
     };
 
-    template <typename D, typename K, typename V, bool ShouldOriginate = true>
-    struct observable_map_base : map_base<D, K, V, ShouldOriginate>
+    template <typename D, typename K, typename V, bool avoid_bounds_error_origination = false>
+    struct observable_map_base : map_base<D, K, V, avoid_bounds_error_origination>
     {
         event_token MapChanged(Windows::Foundation::Collections::MapChangedEventHandler<K, V> const& handler)
         {
@@ -617,20 +617,20 @@ WINRT_EXPORT namespace winrt
 
         bool Insert(K const& key, V const& value)
         {
-            bool const result = map_base<D, K, V, ShouldOriginate>::Insert(key, value);
+            bool const result = map_base<D, K, V, avoid_bounds_error_origination>::Insert(key, value);
             call_changed(Windows::Foundation::Collections::CollectionChange::ItemInserted, key);
             return result;
         }
 
         void Remove(K const& key)
         {
-            map_base<D, K, V, ShouldOriginate>::Remove(key);
+            map_base<D, K, V, avoid_bounds_error_origination>::Remove(key);
             call_changed(Windows::Foundation::Collections::CollectionChange::ItemRemoved, key);
         }
 
         void Clear() noexcept
         {
-            map_base<D, K, V, ShouldOriginate>::Clear();
+            map_base<D, K, V, avoid_bounds_error_origination>::Clear();
             call_changed(Windows::Foundation::Collections::CollectionChange::Reset, impl::empty_value<K>());
         }
 

--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -602,7 +602,7 @@ WINRT_EXPORT namespace winrt
         }
     };
 
-    template <typename D, typename K, typename V, bool ShouldOriginate>
+    template <typename D, typename K, typename V, bool ShouldOriginate = true>
     struct observable_map_base : map_base<D, K, V, ShouldOriginate>
     {
         event_token MapChanged(Windows::Foundation::Collections::MapChangedEventHandler<K, V> const& handler)

--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -77,6 +77,15 @@ namespace winrt::impl
     };
 }
 
+//struct WINRT_IMPL_NOVTABLE IIgnoreNextError : unknown_abi
+//{
+//    virtual void __stdcall IgnoreNextError() noexcept = 0;
+//};
+//
+//template <> inline constexpr guid guid_v<IIgnoreNextError>{ 0x5b0d3235, 0x4dba, 0x4d44, { 0x86,0x5e,0x8f,0x1d,0x0e,0x4f,0xd0,0x4d } };
+//
+
+
 WINRT_EXPORT namespace winrt
 {
     template <typename D, typename T, typename Version = impl::no_collection_version>
@@ -513,7 +522,14 @@ WINRT_EXPORT namespace winrt
 
             if (pair == static_cast<D const&>(*this).get_container().end())
             {
-                throw hresult_out_of_bounds();
+                if (m_dontOriginateBoundsError)
+                {
+                    throw non_originating_hresult_out_of_bounds();
+                }
+                else
+                {
+                    throw hresult_out_of_bounds();
+                }
             }
 
             return static_cast<D const&>(*this).unwrap_value(pair->second);
@@ -536,6 +552,16 @@ WINRT_EXPORT namespace winrt
             first = nullptr;
             second = nullptr;
         }
+
+    //    // IIgnoreNextError
+    //    void IgnoreNextError()
+    //    {
+    //        m_ignoreNextError = true;
+    //    }
+    //private:
+    //    bool m_ignoreNextError{ false };
+    protected:
+        bool m_dontOriginateBoundsError{ false };
     };
 
     template <typename D, typename K, typename V>
@@ -571,7 +597,14 @@ WINRT_EXPORT namespace winrt
             auto found = container.find(static_cast<D const&>(*this).wrap_value(key));
             if (found == container.end())
             {
-                throw hresult_out_of_bounds();
+                if (map_view_base<D, K, V, impl::collection_version>::m_dontOriginateBoundsError)
+                {
+                    throw non_originating_hresult_out_of_bounds();
+                }
+                else
+                {
+                    throw hresult_out_of_bounds();
+                }
             }
             this->increment_version();
             removedNode = container.extract(found);

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -81,7 +81,7 @@ WINRT_EXPORT namespace winrt::param
         }
 
         map(std::initializer_list<std::pair<K const, V>> values, bool dontOriginateError = false) :
-            m_interface(impl::make_input_map<K, V>(std::map<K, V>(values, dontOriginateError)))
+            m_interface(impl::make_input_map<K, V>(std::map<K, V>(values), dontOriginateError))
         {
         }
 

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -1,10 +1,10 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container, typename ThreadingBase, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, typename ThreadingBase, bool avoid_bounds_error_origination = false>
     struct map_impl :
-        implements<map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_base<map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, K, V, ShouldOriginate>,
+        implements<map_impl<K, V, Container, ThreadingBase, avoid_bounds_error_origination>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_base<map_impl<K, V, Container, ThreadingBase, avoid_bounds_error_origination>, K, V, avoid_bounds_error_origination>,
         ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
@@ -29,13 +29,13 @@ namespace winrt::impl
         Container m_values;
     };
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate>
-    using input_map = map_impl<K, V, Container, single_threaded_collection_base, ShouldOriginate>;
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
+    using input_map = map_impl<K, V, Container, single_threaded_collection_base, avoid_bounds_error_origination>;
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
     auto make_input_map(Container&& values)
     {
-        return make<input_map<K, V, Container, ShouldOriginate>>(std::forward<Container>(values));
+        return make<input_map<K, V, Container, avoid_bounds_error_origination>>(std::forward<Container>(values));
     }
 }
 

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -29,7 +29,7 @@ namespace winrt::impl
         Container m_values;
     };
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool ShouldOriginate>
     using input_map = map_impl<K, V, Container, single_threaded_collection_base, ShouldOriginate>;
 
     template <typename K, typename V, typename Container, bool ShouldOriginate = true>
@@ -41,7 +41,7 @@ namespace winrt::impl
 
 WINRT_EXPORT namespace winrt::param
 {
-    template <typename K, typename V, bool ShouldOriginate = true>
+    template <typename K, typename V>
     struct map
     {
         using value_type = Windows::Foundation::Collections::IKeyValuePair<K, V>;
@@ -67,18 +67,18 @@ WINRT_EXPORT namespace winrt::param
 
         template <typename Compare, typename Allocator>
         map(std::map<K, V, Compare, Allocator>&& values) :
-            m_interface(impl::make_input_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>(std::move(values)))
+            m_interface(impl::make_input_map<K, V>(std::move(values)))
         {
         }
 
         template <typename Hash, typename KeyEqual, typename Allocator>
         map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values) :
-            m_interface(impl::make_input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>(std::move(values)))
+            m_interface(impl::make_input_map<K, V>(std::move(values)))
         {
         }
 
         map(std::initializer_list<std::pair<K const, V>> values) :
-            m_interface(impl::make_input_map<K, V, std::map<K, V>, ShouldOriginate>(std::map<K, V>(values)))
+            m_interface(impl::make_input_map<K, V>(std::map<K, V>(values)))
         {
         }
 
@@ -101,8 +101,8 @@ WINRT_EXPORT namespace winrt::param
         bool m_owned{ true };
     };
 
-    template <typename K, typename V, bool ShouldOriginate = true>
-    auto get_abi(map<K, V, ShouldOriginate> const& object) noexcept
+    template <typename K, typename V>
+    auto get_abi(map<K, V> const& object) noexcept
     {
         return *(void**)(&object);
     }

--- a/strings/base_collections_input_map.h
+++ b/strings/base_collections_input_map.h
@@ -9,8 +9,9 @@ namespace winrt::impl
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit map_impl(Container&& values) : m_values(std::forward<Container>(values))
-        {
+        explicit map_impl(Container&& values, bool dontOriginateError = false) : m_values(std::forward<Container>(values))
+        { 
+            this->m_dontOriginateBoundsError = dontOriginateError;
         }
 
         auto& get_container() noexcept
@@ -35,9 +36,9 @@ namespace winrt::impl
     using input_map = map_impl<K, V, Container, single_threaded_collection_base>;
 
     template <typename K, typename V, typename Container>
-    auto make_input_map(Container&& values)
+    auto make_input_map(Container&& values, bool dontOriginateError = false)
     {
-        return make<input_map<K, V, Container>>(std::forward<Container>(values));
+        return make<input_map<K, V, Container>>(std::forward<Container>(values), dontOriginateError);
     }
 }
 
@@ -68,19 +69,19 @@ WINRT_EXPORT namespace winrt::param
         }
 
         template <typename Compare, typename Allocator>
-        map(std::map<K, V, Compare, Allocator>&& values) :
-            m_interface(impl::make_input_map<K, V>(std::move(values)))
+        map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false) :
+            m_interface(impl::make_input_map<K, V>(std::move(values), dontOriginateError))
         {
         }
 
         template <typename Hash, typename KeyEqual, typename Allocator>
-        map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values) :
-            m_interface(impl::make_input_map<K, V>(std::move(values)))
+        map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false) :
+            m_interface(impl::make_input_map<K, V>(std::move(values), dontOriginateError))
         {
         }
 
-        map(std::initializer_list<std::pair<K const, V>> values) :
-            m_interface(impl::make_input_map<K, V>(std::map<K, V>(values)))
+        map(std::initializer_list<std::pair<K const, V>> values, bool dontOriginateError = false) :
+            m_interface(impl::make_input_map<K, V>(std::map<K, V>(values, dontOriginateError)))
         {
         }
 

--- a/strings/base_collections_input_map_view.h
+++ b/strings/base_collections_input_map_view.h
@@ -1,10 +1,10 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container>
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
     struct input_map_view :
-        implements<input_map_view<K, V, Container>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_view_base<input_map_view<K, V, Container>, K, V>
+        implements<input_map_view<K, V, Container, ShouldOriginate>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_view_base<input_map_view<K, V, Container, ShouldOriginate>, K, V, ShouldOriginate>
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
@@ -22,11 +22,11 @@ namespace winrt::impl
         Container const m_values;
     };
 
-    template <typename K, typename V, typename Container>
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
     struct scoped_input_map_view :
         input_scope,
-        implements<scoped_input_map_view<K, V, Container>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_view_base<scoped_input_map_view<K, V, Container>, K, V>
+        implements<scoped_input_map_view<K, V, Container, ShouldOriginate>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_view_base<scoped_input_map_view<K, V, Container, ShouldOriginate>, K, V, ShouldOriginate>
     {
         void abi_enter() const
         {
@@ -53,18 +53,18 @@ namespace winrt::impl
         Container const& m_values;
     };
 
-    template <typename K, typename V, typename Container>
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
     auto make_input_map_view(Container&& values)
     {
-        return make<input_map_view<K, V, Container>>(std::forward<Container>(values));
+        return make<input_map_view<K, V, Container, ShouldOriginate>>(std::forward<Container>(values));
     }
 
-    template <typename K, typename V, typename Container>
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
     auto make_scoped_input_map_view(Container const& values)
     {
         using interface_type = wfc::IMapView<K, V>;
         std::pair<interface_type, input_scope*> result;
-        auto ptr = new scoped_input_map_view<K, V, Container>(values);
+        auto ptr = new scoped_input_map_view<K, V, Container, ShouldOriginate>(values);
         *put_abi(result.first) = to_abi<interface_type>(ptr);
         result.second = ptr;
         return result;

--- a/strings/base_collections_input_map_view.h
+++ b/strings/base_collections_input_map_view.h
@@ -1,10 +1,10 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
     struct input_map_view :
-        implements<input_map_view<K, V, Container, ShouldOriginate>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_view_base<input_map_view<K, V, Container, ShouldOriginate>, K, V, ShouldOriginate>
+        implements<input_map_view<K, V, Container, avoid_bounds_error_origination>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_view_base<input_map_view<K, V, Container, avoid_bounds_error_origination>, K, V, avoid_bounds_error_origination>
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
@@ -22,11 +22,11 @@ namespace winrt::impl
         Container const m_values;
     };
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
     struct scoped_input_map_view :
         input_scope,
-        implements<scoped_input_map_view<K, V, Container, ShouldOriginate>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        map_view_base<scoped_input_map_view<K, V, Container, ShouldOriginate>, K, V, ShouldOriginate>
+        implements<scoped_input_map_view<K, V, Container, avoid_bounds_error_origination>, non_agile, no_weak_ref, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        map_view_base<scoped_input_map_view<K, V, Container, avoid_bounds_error_origination>, K, V, avoid_bounds_error_origination>
     {
         void abi_enter() const
         {
@@ -53,18 +53,18 @@ namespace winrt::impl
         Container const& m_values;
     };
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
     auto make_input_map_view(Container&& values)
     {
-        return make<input_map_view<K, V, Container, ShouldOriginate>>(std::forward<Container>(values));
+        return make<input_map_view<K, V, Container, avoid_bounds_error_origination>>(std::forward<Container>(values));
     }
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
     auto make_scoped_input_map_view(Container const& values)
     {
         using interface_type = wfc::IMapView<K, V>;
         std::pair<interface_type, input_scope*> result;
-        auto ptr = new scoped_input_map_view<K, V, Container, ShouldOriginate>(values);
+        auto ptr = new scoped_input_map_view<K, V, Container, avoid_bounds_error_origination>(values);
         *put_abi(result.first) = to_abi<interface_type>(ptr);
         result.second = ptr;
         return result;

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -4,7 +4,7 @@ namespace winrt::impl
     template <typename K, typename V, typename Container, bool ShouldOriginate = true>
     using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base, ShouldOriginate>;
 
-    template <typename K, typename V, typename Container, typename ThreadingBase, bool ShouldOriginate = true>
+    template <typename K, typename V, typename Container, typename ThreadingBase, bool ShouldOriginate>
     struct observable_map_impl :
         implements<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
         observable_map_base<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, K, V, ShouldOriginate>,
@@ -32,85 +32,87 @@ namespace winrt::impl
         Container m_values;
     };
 
-    template <typename K, typename V, typename Container>
-    using observable_map = observable_map_impl<K, V, Container, single_threaded_collection_base>;
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    using observable_map = observable_map_impl<K, V, Container, single_threaded_collection_base, ShouldOriginate>;
 
-    template <typename K, typename V, typename Container>
-    using multi_threaded_observable_map = observable_map_impl<K, V, Container, multi_threaded_collection_base>;
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    using multi_threaded_observable_map = observable_map_impl<K, V, Container, multi_threaded_collection_base, ShouldOriginate>;
 }
 
 WINRT_EXPORT namespace winrt
 {
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map()
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+
+
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map()
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map()
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map()
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
     }
 
-    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
     }
 }
 

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -1,21 +1,18 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container>
-    using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base>;
+    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
+    using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base, ShouldOriginate>;
 
-    template <typename K, typename V, typename Container, typename ThreadingBase>
+    template <typename K, typename V, typename Container, typename ThreadingBase, bool ShouldOriginate = true>
     struct observable_map_impl :
-        implements<observable_map_impl<K, V, Container, ThreadingBase>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        observable_map_base<observable_map_impl<K, V, Container, ThreadingBase>, K, V>,
+        implements<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        observable_map_base<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, K, V, ShouldOriginate>,
         ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit observable_map_impl(Container&& values, bool dontOriginateError = false) : m_values(std::forward<Container>(values))
-        {
-            this->m_dontOriginateBoundsError = dontOriginateError;
-        }
+        explicit observable_map_impl(Container&& values) : m_values(std::forward<Container>(values)) {}
 
         auto& get_container() noexcept
         {
@@ -45,75 +42,75 @@ namespace winrt::impl
 WINRT_EXPORT namespace winrt
 {
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map()
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map()
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map()
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map()
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
     }
 }
 

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -12,8 +12,9 @@ namespace winrt::impl
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
 
-        explicit observable_map_impl(Container&& values) : m_values(std::forward<Container>(values))
+        explicit observable_map_impl(Container&& values, bool dontOriginateError = false) : m_values(std::forward<Container>(values))
         {
+            this->m_dontOriginateBoundsError = dontOriginateError;
         }
 
         auto& get_container() noexcept
@@ -44,75 +45,75 @@ namespace winrt::impl
 WINRT_EXPORT namespace winrt
 {
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map()
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(bool dontOriginateError = false)
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values)
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map()
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values)
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map()
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(bool dontOriginateError = false)
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map()
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{}, dontOriginateError);
     }
 
     template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values), dontOriginateError);
     }
 
     template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
-    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values, bool dontOriginateError = false)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values), dontOriginateError);
     }
 }
 

--- a/strings/base_collections_map.h
+++ b/strings/base_collections_map.h
@@ -1,13 +1,13 @@
 
 namespace winrt::impl
 {
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
-    using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base, ShouldOriginate>;
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
+    using multi_threaded_map = map_impl<K, V, Container, multi_threaded_collection_base, avoid_bounds_error_origination>;
 
-    template <typename K, typename V, typename Container, typename ThreadingBase, bool ShouldOriginate>
+    template <typename K, typename V, typename Container, typename ThreadingBase, bool avoid_bounds_error_origination>
     struct observable_map_impl :
-        implements<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
-        observable_map_base<observable_map_impl<K, V, Container, ThreadingBase, ShouldOriginate>, K, V, ShouldOriginate>,
+        implements<observable_map_impl<K, V, Container, ThreadingBase, avoid_bounds_error_origination>, wfc::IObservableMap<K, V>, wfc::IMap<K, V>, wfc::IMapView<K, V>, wfc::IIterable<wfc::IKeyValuePair<K, V>>>,
+        observable_map_base<observable_map_impl<K, V, Container, ThreadingBase, avoid_bounds_error_origination>, K, V, avoid_bounds_error_origination>,
         ThreadingBase
     {
         static_assert(std::is_same_v<Container, std::remove_reference_t<Container>>, "Must be constructed with rvalue.");
@@ -32,87 +32,157 @@ namespace winrt::impl
         Container m_values;
     };
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
-    using observable_map = observable_map_impl<K, V, Container, single_threaded_collection_base, ShouldOriginate>;
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
+    using observable_map = observable_map_impl<K, V, Container, single_threaded_collection_base, avoid_bounds_error_origination>;
 
-    template <typename K, typename V, typename Container, bool ShouldOriginate = true>
-    using multi_threaded_observable_map = observable_map_impl<K, V, Container, multi_threaded_collection_base, ShouldOriginate>;
+    template <typename K, typename V, typename Container, bool avoid_bounds_error_origination = false>
+    using multi_threaded_observable_map = observable_map_impl<K, V, Container, multi_threaded_collection_base, avoid_bounds_error_origination>;
 }
 
 WINRT_EXPORT namespace winrt
 {
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map()
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map_avoid_originate()
+    {
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::map<K, V, Compare, Allocator>{});
     }
 
-
-
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map_avoid_originate(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::input_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> single_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> single_threaded_map_avoid_originate(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::input_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map()
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map_avoid_originate()
+    {
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map_avoid_originate(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IMap<K, V> multi_threaded_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IMap<K, V> multi_threaded_map_avoid_originate(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map()
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map_avoid_originate()
+    {
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map_avoid_originate(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::observable_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> single_threaded_observable_map_avoid_originate(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map()
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::map<K, V, Compare, Allocator>{});
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::map<K, V, Compare, Allocator>{});
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map_avoid_originate()
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::map<K, V, Compare, Allocator>{});
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::map<K, V, Compare, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>>>(std::move(values));
+    }
+    
+    template <typename K, typename V, typename Compare = std::less<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map_avoid_originate(std::map<K, V, Compare, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::map<K, V, Compare, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 
-    template <typename K, typename V, bool ShouldOriginate = true, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
     Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
     {
-        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, ShouldOriginate>>(std::move(values));
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>>>(std::move(values));
+    }
+
+    template <typename K, typename V, typename Hash = std::hash<K>, typename KeyEqual = std::equal_to<K>, typename Allocator = std::allocator<std::pair<K const, V>>>
+    Windows::Foundation::Collections::IObservableMap<K, V> multi_threaded_observable_map_avoid_originate(std::unordered_map<K, V, Hash, KeyEqual, Allocator>&& values)
+    {
+        return make<impl::multi_threaded_observable_map<K, V, std::unordered_map<K, V, Hash, KeyEqual, Allocator>, true /*avoid_bounds_error_origination*/>>(std::move(values));
     }
 }
 

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -202,11 +202,10 @@ namespace winrt::impl
 
         static fire_and_forget cancel_asynchronously(Async async)
         {
-            auto asyncRef = async;
             co_await winrt::resume_background();
             try
             {
-                asyncRef.Cancel();
+                async.Cancel();
             }
             catch (hresult_error const&)
             {
@@ -352,9 +351,9 @@ namespace winrt::impl
             return m_promise->enable_cancellation_propagation(value);
         }
 
-        bool avoid_logging(bool value = true) const noexcept
+        bool avoid_cancel_origination(bool value = true) const noexcept
         {
-            return m_promise->enable_avoid_rooriginate_cancel(value);
+            return m_promise->enable_avoid_cancel_origination(value);
         }
     private:
 
@@ -489,7 +488,7 @@ namespace winrt::impl
                 if (m_status.load(std::memory_order_relaxed) == AsyncStatus::Started)
                 {
                     m_status.store(AsyncStatus::Canceled, std::memory_order_relaxed);
-                    if (cancellable_promise::avoid_rooriginate_cancel_enabled())
+                    if (cancellable_promise::avoid_cancel_origination_enabled())
                     {
                         m_exception = std::make_exception_ptr(non_originating_hresult_canceled());
                     }
@@ -644,7 +643,7 @@ namespace winrt::impl
         {
             if (Status() == AsyncStatus::Canceled)
             {
-                if (cancellable_promise::avoid_rooriginate_cancel_enabled())
+                if (cancellable_promise::avoid_cancel_origination_enabled())
                 {
                     throw winrt::non_originating_hresult_canceled();
                 }

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -629,6 +629,10 @@ namespace winrt::impl
             {
                 m_status.store(AsyncStatus::Canceled, std::memory_order_relaxed);
             }
+            catch (non_originating_hresult_canceled const&)
+            {
+                m_status.store(AsyncStatus::Canceled, std::memory_order_relaxed);
+            }
             catch (...)
             {
                 m_status.store(AsyncStatus::Error, std::memory_order_relaxed);

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -180,12 +180,23 @@ WINRT_EXPORT namespace winrt
             return m_propagate_cancellation;
         }
 
+        bool enable_avoid_rooriginate_cancel(bool value) noexcept
+        {
+            return std::exchange(m_avoid_rooriginate_cancel, value);
+        }
+
+        bool avoid_rooriginate_cancel_enabled() const noexcept
+        {
+            return m_avoid_rooriginate_cancel;
+        }
+
     private:
         static inline auto const cancelling_ptr = reinterpret_cast<canceller_t>(1);
 
         std::atomic<canceller_t> m_canceller{ nullptr };
         void* m_context{ nullptr };
         bool m_propagate_cancellation{ false };
+        bool m_avoid_rooriginate_cancel{ false };
     };
 
     template <typename Derived>

--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -180,14 +180,14 @@ WINRT_EXPORT namespace winrt
             return m_propagate_cancellation;
         }
 
-        bool enable_avoid_rooriginate_cancel(bool value) noexcept
+        bool enable_avoid_cancel_origination(bool value) noexcept
         {
-            return std::exchange(m_avoid_rooriginate_cancel, value);
+            return std::exchange(m_avoid_cancel_origination, value);
         }
 
-        bool avoid_rooriginate_cancel_enabled() const noexcept
+        bool avoid_cancel_origination_enabled() const noexcept
         {
-            return m_avoid_rooriginate_cancel;
+            return m_avoid_cancel_origination;
         }
 
     private:
@@ -196,7 +196,7 @@ WINRT_EXPORT namespace winrt
         std::atomic<canceller_t> m_canceller{ nullptr };
         void* m_context{ nullptr };
         bool m_propagate_cancellation{ false };
-        bool m_avoid_rooriginate_cancel{ false };
+        bool m_avoid_cancel_origination{ false };
     };
 
     template <typename Derived>

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -181,6 +181,9 @@ WINRT_EXPORT namespace winrt
 {
     struct hresult_error
     {
+        struct avoid_originate_t {};
+        static constexpr avoid_originate_t avoid_originate{};
+
         using from_abi_t = take_ownership_from_abi_t;
         static constexpr auto from_abi{ take_ownership_from_abi };
 
@@ -206,25 +209,13 @@ WINRT_EXPORT namespace winrt
             originate(code, nullptr WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
-        explicit hresult_error(hresult const code, bool avoidOrigination WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
+        explicit hresult_error(hresult const code, avoid_originate_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
-            if (!avoidOrigination)
-            {
-                originate(code, nullptr WINRT_IMPL_SOURCE_LOCATION_FORWARD);
-            }
         }
 
         hresult_error(hresult const code, param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
             originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
-        }
-
-        hresult_error(hresult const code, param::hstring const& message, bool avoidOrigination WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
-        {
-            if (!avoidOrigination)
-            {
-                originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
-            }
         }
 
         hresult_error(hresult const code, take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
@@ -448,14 +439,17 @@ WINRT_EXPORT namespace winrt
 
     struct non_originating_hresult_canceled : hresult_error
     {
-        non_originating_hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_canceled, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, message, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_canceled, hresult_error::avoid_originate WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) = delete;
+        non_originating_hresult_canceled(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) = delete;
+
     };
 
     struct non_originating_hresult_out_of_bounds : hresult_error
     {
-        non_originating_hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_out_of_bounds, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_out_of_bounds, message, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_out_of_bounds, hresult_error::avoid_originate WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) = delete;
+        non_originating_hresult_out_of_bounds(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) = delete;
     };
 
     [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -206,9 +206,25 @@ WINRT_EXPORT namespace winrt
             originate(code, nullptr WINRT_IMPL_SOURCE_LOCATION_FORWARD);
         }
 
+        explicit hresult_error(hresult const code, bool avoidOrigination WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
+        {
+            if (!avoidOrigination)
+            {
+                originate(code, nullptr WINRT_IMPL_SOURCE_LOCATION_FORWARD);
+            }
+        }
+
         hresult_error(hresult const code, param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
         {
             originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
+        }
+
+        hresult_error(hresult const code, param::hstring const& message, bool avoidOrigination WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
+        {
+            if (!avoidOrigination)
+            {
+                originate(code, get_abi(message) WINRT_IMPL_SOURCE_LOCATION_FORWARD);
+            }
         }
 
         hresult_error(hresult const code, take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : m_code(verify_error(code))
@@ -294,7 +310,7 @@ WINRT_EXPORT namespace winrt
             return m_code;
         }
 
-    protected:
+    private:
 
         void originate(hresult const code, void* message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept
         {
@@ -337,29 +353,6 @@ WINRT_EXPORT namespace winrt
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-    };
-
-    struct non_originating_hresult_error : hresult_error
-    {
-    protected:
-        void originate(hresult const /*code*/, void* /*message*/ WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept
-        {
-            // override and do nothing. 
-        }
-    };
-
-    struct non_originating_hresult_canceled : hresult_error
-    {
-        non_originating_hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_access_denied WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_canceled(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-    };
-
-    struct non_originating_hresult_out_of_bounds : hresult_error
-    {
-        non_originating_hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_access_denied WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
-        non_originating_hresult_out_of_bounds(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_access_denied : hresult_error
@@ -451,6 +444,18 @@ WINRT_EXPORT namespace winrt
         hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_canceled WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
         hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
         hresult_canceled(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+    };
+
+    struct non_originating_hresult_canceled : hresult_error
+    {
+        non_originating_hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_canceled, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_canceled, message, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+    };
+
+    struct non_originating_hresult_out_of_bounds : hresult_error
+    {
+        non_originating_hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_out_of_bounds, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_out_of_bounds, message, true /*don't originate*/ WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     [[noreturn]] inline WINRT_IMPL_NOINLINE void throw_hresult(hresult const result WINRT_IMPL_SOURCE_LOCATION_ARGS)

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -294,7 +294,7 @@ WINRT_EXPORT namespace winrt
             return m_code;
         }
 
-    private:
+    protected:
 
         void originate(hresult const code, void* message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept
         {
@@ -315,7 +315,7 @@ WINRT_EXPORT namespace winrt
             com_ptr<impl::IErrorInfo> info;
             WINRT_VERIFY_(0, WINRT_IMPL_GetErrorInfo(0, info.put_void()));
             WINRT_VERIFY(info.try_as(m_info));
-        }
+        }  
 
         static hresult verify_error(hresult const code) noexcept
         {
@@ -337,6 +337,29 @@ WINRT_EXPORT namespace winrt
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
+    };
+
+    struct non_originating_hresult_error : hresult_error
+    {
+    protected:
+        void originate(hresult const /*code*/, void* /*message*/ WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept
+        {
+            // override and do nothing. 
+        }
+    };
+
+    struct non_originating_hresult_canceled : hresult_error
+    {
+        non_originating_hresult_canceled(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_access_denied WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_canceled(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_canceled(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+    };
+
+    struct non_originating_hresult_out_of_bounds : hresult_error
+    {
+        non_originating_hresult_out_of_bounds(WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM) noexcept : hresult_error(impl::error_access_denied WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_out_of_bounds(param::hstring const& message WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, message WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
+        non_originating_hresult_out_of_bounds(take_ownership_from_abi_t WINRT_IMPL_SOURCE_LOCATION_ARGS) noexcept : hresult_error(impl::error_access_denied, take_ownership_from_abi WINRT_IMPL_SOURCE_LOCATION_FORWARD) {}
     };
 
     struct hresult_access_denied : hresult_error

--- a/strings/base_macros.h
+++ b/strings/base_macros.h
@@ -85,9 +85,9 @@ typedef struct _GUID GUID;
 // Some projects may decide to disable std::source_location support to prevent source code information from ending up in their
 // release binaries, or to reduce binary size.  Defining WINRT_NO_SOURCE_LOCATION will prevent this feature from activating.
 #if defined(__cpp_lib_source_location) && !defined(WINRT_NO_SOURCE_LOCATION)
-#define WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT , std::source_location const& sourceInformation
-#define WINRT_IMPL_SOURCE_LOCATION_ARGS , std::source_location const& sourceInformation = std::source_location::current()
-#define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM std::source_location const& sourceInformation = std::source_location::current()
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_NO_DEFAULT , [[maybe_unused]] std::source_location const& sourceInformation
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS , [[maybe_unused]]std::source_location const& sourceInformation = std::source_location::current()
+#define WINRT_IMPL_SOURCE_LOCATION_ARGS_SINGLE_PARAM [[maybe_unused]] std::source_location const& sourceInformation = std::source_location::current()
 
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD , sourceInformation
 #define WINRT_IMPL_SOURCE_LOCATION_FORWARD_SINGLE_PARAM sourceInformation

--- a/test/old_tests/UnitTests/Errors.cpp
+++ b/test/old_tests/UnitTests/Errors.cpp
@@ -233,6 +233,7 @@ TEST_CASE("Errors")
 
     // Make sure trimming works.
     hresult_error e(E_FAIL, L":) is \u263A \n \t ");
+    auto x = e.message();
     REQUIRE(e.message() == L":) is \u263A");
 
     // Make sure delegates propagate correctly.

--- a/test/old_tests/UnitTests/hresult_error.cpp
+++ b/test/old_tests/UnitTests/hresult_error.cpp
@@ -494,7 +494,7 @@ TEST_CASE("hresult, throw_last_error")
 TEST_CASE("hresult, trim_hresult_message")
 {
     hresult_error e(E_FAIL, L":) is \u263A \n \t ");
-
+    auto x = e.message();
     REQUIRE(e.message() == L":) is \u263A");
 }
 
@@ -580,6 +580,7 @@ TEST_CASE("hresult, to_message")
     }
     catch (...)
     {
+        auto  x = to_message();
         REQUIRE(to_message() == L"oh no, invalid handle");
     }
 }

--- a/test/test/async_check_cancel.cpp
+++ b/test/test/async_check_cancel.cpp
@@ -133,7 +133,7 @@ namespace
         winrt_throw_hresult_handler = exceptionLogger;
 
         auto cancel = co_await get_cancellation_token();
-        cancel.avoid_logging(true);
+        cancel.avoid_cancel_origination(true);
 
         co_await resume_on_signal(event);
 
@@ -172,7 +172,7 @@ namespace
 
         async.Cancel();
         SetEvent(start.get());
-        REQUIRE(WaitForSingleObject(completed.get(), 100000) == WAIT_OBJECT_0);
+        REQUIRE(WaitForSingleObject(completed.get(), IsDebuggerPresent() ? INFINITE : 1000) == WAIT_OBJECT_0);
 
         REQUIRE(async.Status() == AsyncStatus::Canceled);
         REQUIRE(async.ErrorCode() == HRESULT_FROM_WIN32(ERROR_CANCELLED));

--- a/test/test/async_check_cancel.cpp
+++ b/test/test/async_check_cancel.cpp
@@ -108,7 +108,6 @@ namespace
 
         co_await resume_on_signal(event);
         auto cancel = co_await get_cancellation_token();
-        cancel.avoid_logging(true);
 
         if (cancel())
         {
@@ -133,9 +132,10 @@ namespace
         REQUIRE(!winrt_throw_hresult_handler);
         winrt_throw_hresult_handler = exceptionLogger;
 
-        co_await resume_on_signal(event);
         auto cancel = co_await get_cancellation_token();
         cancel.avoid_logging(true);
+
+        co_await resume_on_signal(event);
 
         if (cancel())
         {
@@ -172,7 +172,7 @@ namespace
 
         async.Cancel();
         SetEvent(start.get());
-        REQUIRE(WaitForSingleObject(completed.get(), 1000) == WAIT_OBJECT_0);
+        REQUIRE(WaitForSingleObject(completed.get(), 100000) == WAIT_OBJECT_0);
 
         REQUIRE(async.Status() == AsyncStatus::Canceled);
         REQUIRE(async.ErrorCode() == HRESULT_FROM_WIN32(ERROR_CANCELLED));
@@ -187,10 +187,10 @@ TEST_CASE("async_check_cancel", "[.clang-crash]")
 TEST_CASE("async_check_cancel")
 #endif
 {
-    //Check(Action);
-    //Check(ActionWithProgress);
-    //Check(Operation);
-    //Check(OperationWithProgress);
+    Check(Action);
+    Check(ActionWithProgress);
+    Check(Operation);
+    Check(OperationWithProgress);
     Check(OperationCancelLogged);
     Check(OperationAvoidLoggingCancel);
 }

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -84,7 +84,7 @@ TEST_CASE("custom_error_logger")
 
         // now create an empty map that _doesn't_ log
         s_loggerCalled = false;
-        IMap<hstring, int> c2 = single_threaded_map<hstring, int>(std::map<hstring, int>{}, true);
+        IMap<hstring, int> c2 = single_threaded_map<hstring, int, false>(std::map<hstring, int>{});
         val = c2.TryLookup(L"hello"sv);
         REQUIRE(!val);
         // ensure that the logger wasn't called

--- a/test/test_cpp20/custom_error.cpp
+++ b/test/test_cpp20/custom_error.cpp
@@ -64,32 +64,41 @@ TEST_CASE("custom_error_logger")
 
     REQUIRE(s_loggerArgs.returnAddress);
     REQUIRE(s_loggerArgs.result == static_cast<int32_t>(0x80000018)); // E_ILLEGAL_DELEGATE_ASSIGNMENT)
+}
 
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 170000
+// <source_location> not available in libc++ before LLVM 16
+TEST_CASE("custom_error_logger_with_avoid_origination", "[!shouldfail]")
+#else
+TEST_CASE("custom_error_logger_with_avoid_origination")
+#endif
+{
+    // Set up global handler
+    REQUIRE(!s_loggerCalled);
+    REQUIRE(!winrt_throw_hresult_handler);
+    winrt_throw_hresult_handler = logger;
+
+    // Log a try lookup
+    IMap<hstring, int> c = single_threaded_map<hstring, int>();
+    c.Insert(L"hello"sv, 1);
+    c.Lookup(L"hello"sv);
+    auto val = c.TryLookup(L"hello"sv);
+    REQUIRE(val);
+    c.Remove(L"hello"sv);
+    REQUIRE(!s_loggerCalled);
+    // Now after we remove the item, TryLookup will fail and the logger will be called.  
+
+    val = c.TryLookup(L"hello"sv);
+    REQUIRE(!val);
+    REQUIRE(s_loggerCalled);
+
+    // now create an empty map that _doesn't_ log
     s_loggerCalled = false;
-
-    {
-        // Log a try lookup
-        IMap<hstring, int> c = single_threaded_map<hstring, int>();
-        c.Insert(L"hello"sv, 1);
-        c.Lookup(L"hello"sv);
-        auto val = c.TryLookup(L"hello"sv);
-        REQUIRE(val);
-        c.Remove(L"hello"sv);
-        REQUIRE(!s_loggerCalled);
-        // Now after we remove the item, TryLookup will fail and the logger will be called.  
-
-        val = c.TryLookup(L"hello"sv);
-        REQUIRE(!val);
-        REQUIRE(s_loggerCalled);
-
-        // now create an empty map that _doesn't_ log
-        s_loggerCalled = false;
-        IMap<hstring, int> c2 = single_threaded_map<hstring, int, false>(std::map<hstring, int>{});
-        val = c2.TryLookup(L"hello"sv);
-        REQUIRE(!val);
-        // ensure that the logger wasn't called
-        REQUIRE(!s_loggerCalled);
-    }
+    IMap<hstring, int> c2 = single_threaded_map_avoid_originate<hstring, int>(std::map<hstring, int>{});
+    val = c2.TryLookup(L"hello"sv);
+    REQUIRE(!val);
+    // ensure that the logger wasn't called
+    REQUIRE(!s_loggerCalled);
 
     // Remove global handler
     winrt_throw_hresult_handler = nullptr;


### PR DESCRIPTION
What:
Address #1376 
- Added new constructors to winrt::hresult_error to opt _out_ of originating the error. 
- Added an optional templated bool to map constructors and factories, to opt in to non-originating E_BOUNDS errors, since these errors are explicitly not helpful.
- To the cancellation_token, added a way to opt in to non-originating errors. 
Also
- added a .runsettings file to add the ability to run the tests from Visual Studio (using a Catch2ToVisualStudioTest adapter)

Why:
When debugging explorer.exe, there are a lot of Cancellations and E_Bounds failures that pop up. To make the debugging experience better, let's opt out of those errors. 

Verified:
ran build_test_all.cmd
Ran tests in Visual Studio:
![image](https://github.com/microsoft/cppwinrt/assets/43587397/de7b7817-f47e-4914-b23d-b56766649166)
