### PR TITLE
Fix CppWinRTAddXamlReferences to not use outputs as inputs

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -859,9 +859,9 @@ $(XamlMetaDataProviderPch)
     <!--Add references to all merged project WinMD files for Xaml Compiler-->
     <Target Name="CppWinRTAddXamlReferences"
             Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT'"
-            DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn)">
+            DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn);CppWinRTGetResolvedWinMD;GetCppWinRTProjectWinMDReferences">
         <ItemGroup>
-            <XamlReferencesToCompile Include="$(OutDir)*.winmd" />
+            <XamlReferencesToCompile Include="@(WinMDFullPath);@(CppWinRTDynamicProjectWinMDReferences)" />
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
Incremental builds fail when a referenced project's winmd has been updated.  This is because the CppWinRT reference projection is properly using project's referenced winmds as inputs.  But the MarkupCompilePass2 target is using XamlReferencesToCompile, which has been set here to use previously copied output files.
