### PR TITLE
Remove references to stale winmd files to fix incremental builds

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -861,7 +861,9 @@ $(XamlMetaDataProviderPch)
             Condition="'@(Page)@(ApplicationDefinition)' != '' and '$(XamlLanguage)' == 'CppWinRT'"
             DependsOnTargets="$(CppWinRTAddXamlReferencesDependsOn);CppWinRTGetResolvedWinMD;GetCppWinRTProjectWinMDReferences">
         <ItemGroup>
-            <XamlReferencesToCompile Include="@(WinMDFullPath);@(CppWinRTDynamicProjectWinMDReferences)" />
+            <XamlReferencesToCompile Include="$(OutDir)*.winmd" />
+            <!--Remove references to stale artifacts that will be copied later-->
+            <XamlReferencesToCompile Remove="@(ReferenceCopyLocalPaths)" MatchOnMetadata="FileName;Extension"/>
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
The original attempt at a fix for this was too aggressive: https://github.com/microsoft/cppwinrt/pull/1381/files

This fix is targeted specifically at removing references to stale winmd files that have yet to be copied from referenced projects (e.g., from a runtime component to an app).

