### PR TITLE
Unique matrix artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Upload built executables
         uses: actions/upload-artifact@v3
         with:
-          name: msvc-build-${{ matrix.arch }}-${{ matrix.config }}-bin
+          name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: |
             _build/${{ matrix.arch }}/${{ matrix.config }}/*.exe
             _build/${{ matrix.arch }}/${{ matrix.config }}/*.dll
@@ -118,14 +118,14 @@ jobs:
         if: matrix.arch != 'arm64'
         uses: actions/download-artifact@v3
         with:
-          name: msvc-build-${{ matrix.arch }}-${{ matrix.config }}-bin
+          name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: _build/${{ matrix.arch }}/${{ matrix.config }}/
 
       - name: Fetch x86 cppwinrt executables (arm64 only)
         if: matrix.arch == 'arm64'
         uses: actions/download-artifact@v3
         with:
-          name: msvc-build-x86-Release-bin
+          name: msvc-build-${{ matrix.compiler}}-x86-Release-bin
           path: _build/x86/Release/
 
       - name: Download nuget
@@ -242,7 +242,7 @@ jobs:
         if: matrix.arch == 'arm64'
         uses: actions/upload-artifact@v3
         with:
-          name: msvc-tests-${{ matrix.arch }}-${{ matrix.config }}-bin
+          name: msvc-tests-${{ matrix.test_exe }}-${{ matrix.compiler }}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: |
             _build/${{ matrix.arch }}/${{ matrix.config }}/*.exe
             _build/${{ matrix.arch }}/${{ matrix.config }}/*.dll
@@ -323,10 +323,12 @@ jobs:
           cmd /c "$env:VSDevCmd" "&" msbuild /m /clp:ForceConsoleColor "$env:msbuild_config_props" /p:Deployment=${{ matrix.Deployment }} natvis\cppwinrtvisualizer.sln
 
   build-msvc-nuget-test:
-    name: 'Build nuget test'
+    name: 'Build nuget test (${{ matrix.arch }})'
     needs: test-msvc-cppwinrt-build
     strategy:
       matrix:
+        compiler:
+          - MSVC
         arch: [x86, x64]
         config: [Release]
     runs-on: windows-latest
@@ -336,7 +338,7 @@ jobs:
       - name: Fetch cppwinrt executables
         uses: actions/download-artifact@v3
         with:
-          name: msvc-build-${{ matrix.arch }}-${{ matrix.config }}-bin
+          name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: _build/${{ matrix.arch }}/${{ matrix.config }}/
 
       - name: Download nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           cmd /c "$env:VSDevCmd" "&" msbuild /m /clp:ForceConsoleColor "$env:msbuild_config_props" cppwinrt.sln /t:cppwinrt
 
       - name: Upload built executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: |
@@ -116,14 +116,14 @@ jobs:
 
       - name: Fetch cppwinrt executables
         if: matrix.arch != 'arm64'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: _build/${{ matrix.arch }}/${{ matrix.config }}/
 
       - name: Fetch x86 cppwinrt executables (arm64 only)
         if: matrix.arch == 'arm64'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msvc-build-${{ matrix.compiler}}-x86-Release-bin
           path: _build/x86/Release/
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload arm64 test executables
         if: matrix.arch == 'arm64'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: msvc-tests-${{ matrix.test_exe }}-${{ matrix.compiler }}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: |
@@ -279,7 +279,7 @@ jobs:
           cmake --build build/cross_x64/ --target install -j2
 
       - name: Upload cppwinrt.exe
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cross-build-${{ matrix.arch }}-bin
           path: install/bin/cppwinrt.exe
@@ -336,7 +336,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch cppwinrt executables
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: msvc-build-${{ matrix.compiler}}-${{ matrix.arch }}-${{ matrix.config }}-bin
           path: _build/${{ matrix.arch }}/${{ matrix.config }}/
@@ -398,7 +398,7 @@ jobs:
           }
 
       - name: Upload nuget package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: "*.nupkg"


### PR DESCRIPTION
Fixes #1407
Fixes #1408

This ensures artifacts to be uploaded by matrix jobs are unique (which is more or less a requirement of GitHub's `actions/*-artifact@v4` api).