### PR TITLE
Use `actions/cache@v4`

### DIFF
--- a/.github/actions/setup-llvm-mingw/action.yml
+++ b/.github/actions/setup-llvm-mingw/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Cache llvm-mingw (Windows)
       id: cache-llvm
       if: runner.os == 'Windows'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .llvm-mingw
         key: llvm-mingw-${{ runner.os }}-${{ inputs.llvm-mingw-version }}-${{ inputs.host-arch }}
@@ -50,7 +50,7 @@ runs:
     - name: Cache llvm-mingw (Linux)
       id: cache-llvm-linux
       if: runner.os == 'Linux'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /opt/llvm-mingw
         key: llvm-mingw-${{ runner.os }}-${{ inputs.llvm-mingw-version }}-${{ inputs.host-arch }}

--- a/.github/actions/setup-llvm-msvc/action.yml
+++ b/.github/actions/setup-llvm-msvc/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Cache LLVM and tools
       id: cache-llvm
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .LLVM


### PR DESCRIPTION
`actions/cache@v3` runs on node16 which is deprecated.
Unlike `actions/*-artifact@v4`, `actions/cache@v4` is a drop in upgrade:
https://github.com/actions/cache?tab=readme-ov-file#v4