### PR TITLE
Spelling

### DIFF
--- a/cross-mingw-toolchain.cmake
+++ b/cross-mingw-toolchain.cmake
@@ -1,5 +1,5 @@
 # This is a cmake-toolchain(5) file that can be used to cross-build
-# cppwinrt.exe fron Linux or other operating systems using a mingw-w64 cross
+# cppwinrt.exe from Linux or other operating systems using a mingw-w64 cross
 # toolchain. This should work with both GCC-based and llvm-mingw toolchains.
 #
 # Example usage with external toolchain:

--- a/natvis/object_visualizer.h
+++ b/natvis/object_visualizer.h
@@ -26,7 +26,7 @@ enum class ObjectType
     Projection,
 };
 
-// Metatdata for resolving a runtime class property value
+// Metadata for resolving a runtime class property value
 struct PropertyData 
 {
     std::wstring iid;

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -28,7 +28,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CppWinRTParameters Condition="'$(CppWinRTFastAbi)'=='true'">$(CppWinRTParameters) -fastabi</CppWinRTParameters>
         <CppWinRTPath Condition="'$(CppWinRTPackage)' == 'true' and '$(CppWinRTPath)'==''">"$(CppWinRTPackageDir)bin\"</CppWinRTPath>
         <CppWinRTPath Condition="'$(CppWinRTPackage)' != 'true' and '$(CppWinRTPath)'==''">"$(CppWinRTPackageDir)"</CppWinRTPath>
-        <!-- By default enable C++/WinRT to include target platform winmds if we didn't overide sdk references and the C++ Project system isn't already adding them -->
+        <!-- By default enable C++/WinRT to include target platform winmds if we didn't override sdk references and the C++ Project system isn't already adding them -->
         <!-- _PrepareForReferenceResolution adds the references if TargetPlatformIdentifier is UAP -->
         <CppWinRTImplicitlyExpandTargetPlatform Condition="'$(CppWinRTImplicitlyExpandTargetPlatform)' == '' and '$(CppWinRTOverrideSDKReferences)' != 'true' and '$(TargetPlatformIdentifier)' != 'UAP'">true</CppWinRTImplicitlyExpandTargetPlatform>
         <XamlLanguage Condition="'$(CppWinRTProjectLanguage)' == 'C++/CX'">C++</XamlLanguage>

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -114,7 +114,7 @@ void MyComponent::InitializeComponent()
 
 ***[Windows|Microsoft]::UI::Xaml::Markup::ComponentConnectorT***
 
-A consequence of calling InitializeComponent outside construction is that Xaml runtime callbacks to IComponentConnector::Connect and IComponentConnector2::GetBindingConnector are now dispatched to the most derived implementations. Previously, these calls were dispatched directly to the class under construction, as the vtable had yet to be initialized. For objects with markup that derive from composable base classes with markup, this is a breaking change. Derived classes must now implement IComponentConnector::Connect and IComponentConnector2::GetBindingConnector by explicitly calling into the base class. The ComponentConnectorT template provides a correct implemenation for these interfaces:
+A consequence of calling InitializeComponent outside construction is that Xaml runtime callbacks to IComponentConnector::Connect and IComponentConnector2::GetBindingConnector are now dispatched to the most derived implementations. Previously, these calls were dispatched directly to the class under construction, as the vtable had yet to be initialized. For objects with markup that derive from composable base classes with markup, this is a breaking change. Derived classes must now implement IComponentConnector::Connect and IComponentConnector2::GetBindingConnector by explicitly calling into the base class. The ComponentConnectorT template provides a correct implementation for these interfaces:
 
 ```cpp
 struct DerivedPage : winrt::Windows::UI::Xaml::Markup::ComponentConnectorT<DerivedPageT<DerivedPage>>

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -41,7 +41,7 @@ It sets the following project properties and item metadata:
 | Link.AdditionalDependencies | WindowsApp.lib | Umbrella library for Windows Runtime imports |
 | Midl.AdditionalOptions | /reference ... | Enables faster compilation with winmd references (versus idl imports) |
 | Midl.EnableWindowsRuntime | true | Enables Windows Runtime semantics |
-| Midl.MetadataFileName | Unmerged\%(Filename).winmd | Generates unmerged metadata in a tempoary location |
+| Midl.MetadataFileName | Unmerged\%(Filename).winmd | Generates unmerged metadata in a temporary location |
 | Midl.GenerateClientFiles, GenerateServerFiles, GenerateStublessProxies, GenerateTypeLibrary, HeaderFileName, DllDataFileName, InterfaceIdentifierFileName, ProxyFileName, TypeLibraryName | *nul, *None, *false | Disable unnecessary output |
 \*If not already set 
 

--- a/nuget/readme.md
+++ b/nuget/readme.md
@@ -147,7 +147,7 @@ For example, if the verbosity is set to minimal, then only messages with high im
 The default importance of C++/WinRT build messages is 'normal', but this can be overridden with the CppWinRTVerbosity property to enable throttling of C++/WinRT messages independent of the overall verbosity level.
 
 Example:
-> msbuild project.vcxproj /vebosity:minimal /property:CppWinRTVerbosity=high ...
+> msbuild project.vcxproj /verbosity:minimal /property:CppWinRTVerbosity=high ...
 
 For more complex analysis of build errors, the [MSBuild Binary and Structured Log Viewer](http://msbuildlog.com/) is highly recommended.
 

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -7779,7 +7779,7 @@ namespace Catch {
                 result = -erfc_inv(2.0 * p);
                 // result *= normal distribution standard deviation (1.0) * sqrt(2)
                 result *= /*sd * */ ROOT_TWO;
-                // result += normal disttribution mean (0)
+                // result += normal distribution mean (0)
                 return result;
             }
 

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -11310,7 +11310,7 @@ namespace Catch {
     std::string TagInfo::all() const {
         size_t size = 0;
         for (auto const& spelling : spellings) {
-            // Add 2 for the brackes
+            // Add 2 for the brackets
             size += spelling.size() + 2;
         }
 

--- a/test/old_tests/Component/Component.idl
+++ b/test/old_tests/Component/Component.idl
@@ -247,7 +247,7 @@ namespace Component
     runtimeclass FastInputVector
     {
         // Don't confuse this for a high-performance vector. This is for testing fast-input binding support.
-        // The default interface is intentionally not one of the collection intefaces to force them to be convertible for testing.
+        // The default interface is intentionally not one of the collection interfaces to force them to be convertible for testing.
         [default] interface Windows.Foundation.IClosable;
         interface Windows.Foundation.Collections.IVector<HSTRING>;
         interface Windows.Foundation.Collections.IVectorView<HSTRING>;
@@ -265,7 +265,7 @@ namespace Component
     runtimeclass FastInputMap
     {
         // Don't confuse this for a high-performance map. This is for testing fast-input binding support.
-        // The default interface is intentionally not one of the collection intefaces to force them to be convertible for testing.
+        // The default interface is intentionally not one of the collection interfaces to force them to be convertible for testing.
         [default] interface Windows.Foundation.IClosable;
         interface Windows.Foundation.Collections.IMap<HSTRING, HSTRING>;
         interface Windows.Foundation.Collections.IMapView<HSTRING, HSTRING>;

--- a/test/old_tests/UnitTests/abi_guard.cpp
+++ b/test/old_tests/UnitTests/abi_guard.cpp
@@ -12,7 +12,7 @@ using namespace Windows::Foundation;
 namespace
 {
     //
-    // This implemenetation uses the simplest abi_enter and abi_exit methods.
+    // This implementation uses the simplest abi_enter and abi_exit methods.
     //
     struct A : implements<A, IClosable, IStringable>
     {
@@ -60,7 +60,7 @@ namespace
     }
 
     //
-    // This implemenetation uses the abi_enter but omits the abi_exit method.
+    // This implementation uses the abi_enter but omits the abi_exit method.
     //
     struct B : implements<B, IClosable, IStringable>
     {
@@ -102,7 +102,7 @@ namespace
     }
 
     //
-    // This implemenetation throws from the abi_enter method.
+    // This implementation throws from the abi_enter method.
     //
     struct C : implements<C, IClosable, IStringable>
     {
@@ -145,7 +145,7 @@ namespace
     }
 
     //
-    // This implemenetation provides a nested abi_guard
+    // This implementation provides a nested abi_guard
     //
     struct D : implements<D, IClosable, IStringable>
     {
@@ -223,7 +223,7 @@ namespace
     };
 
     //
-    // This implemenetation use an abi_guard type alias
+    // This implementation use an abi_guard type alias
     //
     struct E : implements<E, IClosable, IStringable>
     {
@@ -275,7 +275,7 @@ namespace
     };
 
     //
-    // This implemenetation use an abi_guard type alias that thows
+    // This implementation use an abi_guard type alias that thows
     //
     struct F : implements<F, IClosable, IStringable>
     {

--- a/test/old_tests/UnitTests/abi_guard.cpp
+++ b/test/old_tests/UnitTests/abi_guard.cpp
@@ -275,7 +275,7 @@ namespace
     };
 
     //
-    // This implementation use an abi_guard type alias that thows
+    // This implementation use an abi_guard type alias that throws
     //
     struct F : implements<F, IClosable, IStringable>
     {

--- a/test/old_tests/UnitTests/async.cpp
+++ b/test/old_tests/UnitTests/async.cpp
@@ -1098,7 +1098,7 @@ TEST_CASE("async, Cancel_IAsyncOperationWithProgress, 2")
 }
 
 //
-// These tests confirm the implicit cancelation behavior. The obeservable behavior should be the same as above
+// These tests confirm the implicit cancelation behavior. The observable behavior should be the same as above
 // but the implementation relies on an exception so we confirm that the state changes occur as before.
 //
 

--- a/test/old_tests/UnitTests/delegate.cpp
+++ b/test/old_tests/UnitTests/delegate.cpp
@@ -680,7 +680,7 @@ TEST_CASE("delegate,MapChangedEventHandler")
 TEST_CASE("delegate,collection")
 {
     //
-    // Mostly a compiliation test to ensure that we can create collections of delegates. This is a rare corner case that was 
+    // Mostly a compilation test to ensure that we can create collections of delegates. This is a rare corner case that was 
     // previously not working.
     //
 

--- a/test/old_tests/UnitTests/make_self.cpp
+++ b/test/old_tests/UnitTests/make_self.cpp
@@ -8,7 +8,7 @@
 #endif
 
 //
-// These tests ensure that the make_self function works as expected to provide direct acccess
+// These tests ensure that the make_self function works as expected to provide direct access
 // to an implementation.
 //
 // The IMakeSelf IUnknown interface is also tested as this covers an edge case in the implements

--- a/test/old_tests/UnitTests/marshal.cpp
+++ b/test/old_tests/UnitTests/marshal.cpp
@@ -2,7 +2,7 @@
 #include "catch.hpp"
 
 // These tests do not attempt to test the FTM itself, but merely to confirm that the presence and
-// absence of the non_agile marker does indeed produce the correct reponses from QueryInterface.
+// absence of the non_agile marker does indeed produce the correct responses from QueryInterface.
 // CoMarshalInterfaceXxxx is also used to exercise the code paths. Also, these tests confirm that
 // the weak reference object inherits the same agility as the source. Although much of this is 
 // tested elsewhere, it was helpful to have these tests as a set.

--- a/test/old_tests/UnitTests/produce.cpp
+++ b/test/old_tests/UnitTests/produce.cpp
@@ -4,7 +4,7 @@
 //
 // These tests cover the production of the three core interfaces namely IUnknown, IInspectable, and IActivationFactory.
 // Tests ensure that the ABI surface lines up on the consumer and producer sides and this is mainly done simply by calling
-// the various inteface methods.
+// the various interface methods.
 //
 
 using namespace winrt;

--- a/test/old_tests/UnitTests/produce_async.cpp
+++ b/test/old_tests/UnitTests/produce_async.cpp
@@ -4,7 +4,7 @@
 //
 // These tests cover the production of the various async interfaces.
 // Tests ensure that the ABI surface lines up on the consumer and producer sides and this is mainly done simply by calling
-// the various inteface methods.
+// the various interface methods.
 //
 
 using namespace winrt;

--- a/test/old_tests/UnitTests/produce_map.cpp
+++ b/test/old_tests/UnitTests/produce_map.cpp
@@ -5,7 +5,7 @@
 //
 // These tests cover the production of the various map-related interfaces.
 // Tests ensure that the ABI surface lines up on the consumer and producer sides and this is mainly done simply by calling
-// the various inteface methods.
+// the various interface methods.
 //
 
 using namespace winrt;

--- a/test/old_tests/UnitTests/produce_vector.cpp
+++ b/test/old_tests/UnitTests/produce_vector.cpp
@@ -5,7 +5,7 @@
 //
 // These tests cover the production of the various vector-related interfaces.
 // Tests ensure that the ABI surface lines up on the consumer and producer sides and this is mainly done simply by calling
-// the various inteface methods.
+// the various interface methods.
 //
 
 using namespace winrt;

--- a/test/old_tests/UnitTests/struct.cpp
+++ b/test/old_tests/UnitTests/struct.cpp
@@ -47,7 +47,7 @@ TEST_CASE("struct, TypeName")
 //
 // This second test ensures that structures with IReference<T> fields are projected correctly.
 // In this case, a suitable interface is not available in the Windows SDK so we hand-roll the 
-// the necessary intput and output patterms for code generation. We also rely on a custom 
+// the necessary input and output patterms for code generation. We also rely on a custom 
 // implementation of IReference<T> so that we can additionally check that the object is 
 // destroyed correctly. 
 //

--- a/test/old_tests/UnitTests/struct.cpp
+++ b/test/old_tests/UnitTests/struct.cpp
@@ -47,7 +47,7 @@ TEST_CASE("struct, TypeName")
 //
 // This second test ensures that structures with IReference<T> fields are projected correctly.
 // In this case, a suitable interface is not available in the Windows SDK so we hand-roll the 
-// the necessary input and output patterms for code generation. We also rely on a custom 
+// the necessary input and output patterns for code generation. We also rely on a custom 
 // implementation of IReference<T> so that we can additionally check that the object is 
 // destroyed correctly. 
 //

--- a/test/old_tests/UnitTests/struct.cpp
+++ b/test/old_tests/UnitTests/struct.cpp
@@ -10,7 +10,7 @@ using namespace Windows::Web::Http;
 //
 // This first test ensures that structures with HSTRING fields are projected correctly.
 // In this case, a suitable interface is provided by the Windows SDK to simplify testing.
-// IControlTemplate provides the necessary methods for excercising input and output 
+// IControlTemplate provides the necessary methods for exercising input and output 
 // patterns for code generation.
 //
 

--- a/test/test/abi_guard.cpp
+++ b/test/test/abi_guard.cpp
@@ -167,7 +167,7 @@ namespace
     };
 
     //
-    // This implementation use an abi_guard type alias that thows
+    // This implementation use an abi_guard type alias that throws
     //
     struct ThrowAlias : implements<ThrowAlias, IClosable, IStringable>
     {

--- a/test/test/abi_guard.cpp
+++ b/test/test/abi_guard.cpp
@@ -6,7 +6,7 @@ using namespace Windows::Foundation;
 namespace
 {
     //
-    // This implemenetation uses the simplest abi_enter and abi_exit methods
+    // This implementation uses the simplest abi_enter and abi_exit methods
     //
     struct Simple : implements<Simple, IClosable, IStringable>
     {
@@ -34,7 +34,7 @@ namespace
     };
 
     //
-    // This implemenetation uses the abi_enter but omits the abi_exit method
+    // This implementation uses the abi_enter but omits the abi_exit method
     //
     struct OnlyEnter : implements<OnlyEnter, IClosable, IStringable>
     {
@@ -56,7 +56,7 @@ namespace
     };
 
     //
-    // This implemenetation throws from the abi_enter method
+    // This implementation throws from the abi_enter method
     //
     struct Throwing : implements<Throwing, IClosable, IStringable>
     {
@@ -83,7 +83,7 @@ namespace
     };
 
     //
-    // This implemenetation provides a nested abi_guard
+    // This implementation provides a nested abi_guard
     //
     struct NestedGuard : implements<NestedGuard, IClosable, IStringable>
     {
@@ -138,7 +138,7 @@ namespace
     };
 
     //
-    // This implemenetation use an abi_guard type alias
+    // This implementation use an abi_guard type alias
     //
     struct GuardAlias : implements<GuardAlias, IClosable, IStringable>
     {
@@ -167,7 +167,7 @@ namespace
     };
 
     //
-    // This implemenetation use an abi_guard type alias that thows
+    // This implementation use an abi_guard type alias that thows
     //
     struct ThrowAlias : implements<ThrowAlias, IClosable, IStringable>
     {

--- a/test/test/cmd_reader.cpp
+++ b/test/test/cmd_reader.cpp
@@ -122,7 +122,7 @@ TEST_CASE("cmd_reader")
         REQUIRE_FALSE(args.exists("verbose"));
     }
 
-    // response file #4: really really long path
+    // response file #4: really, really, long path
     {
         const char* argv[] = { "progname", "@respfile.txt" };
         const size_t argc = _countof(argv);

--- a/test/test/thread_pool.cpp
+++ b/test/test/thread_pool.cpp
@@ -53,7 +53,7 @@ TEST_CASE("thread_pool")
     uint32_t const stable_counter = test(test_iterations, 1, 1);
     uint32_t const unstable_counter = test(test_iterations, 10, 10);
 
-    // This is determinstic since the queue is single-threaded.
+    // This is deterministic since the queue is single-threaded.
     REQUIRE(stable_counter == test_iterations);
 
     // This is unlikely to fail since the pool is multi-threaded.

--- a/test/test_component_base/pch.h
+++ b/test/test_component_base/pch.h
@@ -4,6 +4,6 @@
 #include "winrt/base.h"
 
 // get_module_lock will always return true if WINRT_NO_MODULE_LOCK is defined.
-// This ensures that if the DLL unecessarily exports DllCanUnloadNow that it
+// This ensures that if the DLL unnecessarily exports DllCanUnloadNow that it
 // will in turn return S_FALSE.
 static_assert(winrt::get_module_lock());


### PR DESCRIPTION
Fixes misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings will be reported at https://github.com/jsoref/cppwinrt/actions/runs/8574313379

The action will report that the changes in this PR would make it happy: https://github.com/jsoref/cppwinrt/actions/runs/8574313511

(Sorry, I'm heading out and these are running behind a CI task that's validating things, but I'm fairly confident in the changes...)