### PR TITLE
Changed visibility of `observable_map_base::call_changed` to `protected`

### DIFF
--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -619,14 +619,16 @@ WINRT_EXPORT namespace winrt
             call_changed(Windows::Foundation::Collections::CollectionChange::Reset, impl::empty_value<K>());
         }
 
-    private:
-
-        event<Windows::Foundation::Collections::MapChangedEventHandler<K, V>> m_changed;
+    protected:
 
         void call_changed(Windows::Foundation::Collections::CollectionChange const change, K const& key)
         {
             m_changed(static_cast<D const&>(*this), make<args>(change, key));
         }
+
+    private:
+
+        event<Windows::Foundation::Collections::MapChangedEventHandler<K, V>> m_changed;
 
         struct args : implements<args, Windows::Foundation::Collections::IMapChangedEventArgs<K>>
         {


### PR DESCRIPTION
This matches the visibility of `observable_vector_base::call_changed` to enable derived classes to raise change notifications when the underlying container changes.

Fixes: #1422
