### PR TITLE
Add missing `<exception>` to base_includes.h

### DIFF
--- a/strings/base_includes.h
+++ b/strings/base_includes.h
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstring>
+#include <exception>
 #include <iterator>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Clang with `std=c++23` rightfully complains that `std::exception_ptr` isn't defined.