### PR TITLE
Clarify how InitializeComponent works in the template comment

### DIFF
--- a/vsix/ItemTemplates/BlankPage/BlankPage.h
+++ b/vsix/ItemTemplates/BlankPage/BlankPage.h
@@ -9,6 +9,7 @@ namespace winrt::$rootnamespace$::implementation
         $safeitemname$() 
         {
             // Xaml objects should not call InitializeComponent during construction.
+            // If a Xaml object needs to access a Xaml property during initialization, it should override InitializeComponent.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
         }
 

--- a/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
+++ b/vsix/ItemTemplates/BlankUserControl/BlankUserControl.h
@@ -13,6 +13,7 @@ namespace winrt::$rootnamespace$::implementation
         $safeitemname$() 
         {
             // Xaml objects should not call InitializeComponent during construction.
+            // If a Xaml object needs to access a Xaml property during initialization, it should override InitializeComponent.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
         }
 

--- a/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
+++ b/vsix/ProjectTemplates/VC/Windows Universal/BlankApp/MainPage.h
@@ -9,6 +9,7 @@ namespace winrt::$safeprojectname$::implementation
         MainPage()
         {
             // Xaml objects should not call InitializeComponent during construction.
+            // If a Xaml object needs to access a Xaml property during initialization, it should override InitializeComponent.
             // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
         }
 


### PR DESCRIPTION
The default template describes what *not* to do with `InitializeComponent`, but it doesn't describe how developers are supposed to interact with it. This change clarifies the comment so it's more obvious why the link is relevant to the developer.