### PR TITLE
Projected winrt::consume_ methods will nullptr crash if 

### DIFF
--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -29,6 +29,7 @@ extern "C"
     int32_t __stdcall WINRT_IMPL_SetThreadpoolTimerEx(winrt::impl::ptp_timer, void*, uint32_t, uint32_t) noexcept WINRT_IMPL_LINK(SetThreadpoolTimerEx, 16);
     int32_t __stdcall WINRT_IMPL_SetThreadpoolWaitEx(winrt::impl::ptp_wait, void*, void*, void*) noexcept WINRT_IMPL_LINK(SetThreadpoolWaitEx, 16);
     int32_t __stdcall WINRT_IMPL_RoOriginateLanguageException(int32_t error, void* message, void* exception) noexcept WINRT_IMPL_LINK(RoOriginateLanguageException, 12);
+    int32_t __stdcall WINRT_IMPL_RoCaptureErrorContext(int32_t error) noexcept WINRT_IMPL_LINK(RoCaptureErrorContext, 4);
     void __stdcall WINRT_IMPL_RoFailFastWithErrorContext(int32_t) noexcept WINRT_IMPL_LINK(RoFailFastWithErrorContext, 4);
     int32_t __stdcall WINRT_IMPL_RoTransformError(int32_t, int32_t, void*) noexcept WINRT_IMPL_LINK(RoTransformError, 12);
 

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -788,6 +788,12 @@ namespace winrt::impl
             return m_inner.try_as<Qi>();
         }
 
+        template <typename Qi>
+        auto as_or_failfast() const noexcept
+        {
+            return m_inner.as_or_failfast<Qi>();
+        }
+
         explicit operator bool() const noexcept
         {
             return m_inner.operator bool();

--- a/strings/base_meta.h
+++ b/strings/base_meta.h
@@ -159,7 +159,7 @@ namespace winrt::impl
     {
         operator I() const noexcept
         {
-            return static_cast<D const*>(this)->template try_as<I>();
+            return static_cast<D const*>(this)->template as_or_failfast<I>();
         }
     };
 

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -148,6 +148,10 @@ namespace winrt::impl
         hresult code = ptr->QueryInterface(guid_of<To>(), &result);
         if (code < 0)
         {
+            // Capture an error context immediately before the failfast call.  The failfast gives the best
+            // output when there is a "stowed" exception.  Capturing the error context will stow it enough
+            // for the failfast to find it and use it when creating an exception context record.
+            WINRT_IMPL_RoCaptureErrorContext(code);
             WINRT_IMPL_RoFailFastWithErrorContext(code);
         }
         return wrap_as_result<To>(result);

--- a/test/test/missing_required_interfaces.cpp
+++ b/test/test/missing_required_interfaces.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+
+// Unset lean and mean so we can implement a type from the test_component namespace
+#undef WINRT_LEAN_AND_MEAN
+#include <winrt/test_component.h>
+
+namespace
+{
+    struct LiesAboutInheritance : public winrt::implements<LiesAboutInheritance, winrt::test_component::ILiesAboutInheritance>
+    {
+        LiesAboutInheritance() = default;
+        void StubMethod() {}
+    };
+}
+
+bool g_failfastCalled = false;
+
+void __stdcall WINRT_IMPL_RoFailFastWithErrorContext(int32_t) noexcept
+{
+    g_failfastCalled = true;
+}
+
+void DoTheUncatcheable(winrt::test_component::LiesAboutInheritance& lies) noexcept
+{
+    lies.ToString();
+}
+
+bool CatchTheUncatcheable(winrt::test_component::LiesAboutInheritance& lies) noexcept
+{
+    bool caughtCrash = false;
+    __try
+    {
+        // We verify that our replacement version of WINRT_IMPL_RoFailFastWithErrorContext is
+        // called.  In a real program that would exit the process.  But this is a test so it
+        // continues execution and hits a nullptr dereference instead.  Eat that known/expected
+        // error and allow execution to continue onto other test cases.
+        DoTheUncatcheable(lies);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        caughtCrash = true;
+    }
+    return caughtCrash;
+}
+
+TEST_CASE("missing_required_interfaces")
+{
+    auto lies = winrt::make_self<LiesAboutInheritance>().as<winrt::test_component::LiesAboutInheritance>();
+    REQUIRE(lies);
+    REQUIRE_NOTHROW(lies.StubMethod());
+
+    REQUIRE(!g_failfastCalled);
+    const bool caughtCrash = CatchTheUncatcheable(lies);
+    REQUIRE(caughtCrash);
+    REQUIRE(g_failfastCalled);
+}

--- a/test/test/test.vcxproj
+++ b/test/test/test.vcxproj
@@ -387,6 +387,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="memory_buffer.cpp" />
+    <ClCompile Include="missing_required_interfaces.cpp" />
     <ClCompile Include="module_lock_dll.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/test/test_component/test_component.idl
+++ b/test/test_component/test_component.idl
@@ -163,6 +163,13 @@ namespace test_component
         static void StaticMethodWithAsyncReturn();
     }
 
+    // This class declares that it implements another interface but under the covers it actually does
+    // not.  This allows us to test the behavior when QI's that should not fail, do fail.
+    runtimeclass LiesAboutInheritance : Windows.Foundation.IStringable
+    {
+        void StubMethod();
+    }
+
     namespace Structs
     {
         struct All


### PR DESCRIPTION
## Why is this change being made?
The generated projection code for interfaces that the metadata declares as required for a runtimeclass assume that QueryInterface never fails. Assuming the metadata is correct in the first place, this is a valid assumption for inproc calls.

However, for cross-process calls the QI can fail even if the metadata is correct and the class really does implement all of the required interfaces. It can fail with E_ACCESSDENIED and a variety of other RPC error codes.

When this happens there is a nullptr crash in the generated consume method. This can be very painful to debug because the HRESULT is lost by the time it crashes.

## Briefly summarize what changed
This set of changes does not fix the underlying issue.  The program will still crash.  However, it changes the way in which the program crashes so that it is easier to diagnose what went wrong.

The major difference is that the `struct require_one` cast operator now uses a new `as_or_failfast` method instead of `try_as`.  The new `as_or_failfast` method is identical to `try_as` except that it will detect failure and failfast when the QueryInterface call fails.  The code gen comes with a bit of plumbing to generate the new `as_or_failfast` method.

In local testing it was not sufficient to just call `RoFailFastWithErrorContext`.  I had to first call `RoCaptureErrorContext` so that there was stowed context to failfast with.  (It still terminated the process, but the exception record was missing the context).  There is no stub for `RoCaptureErrorContext` so I had to add one.  The macros are a bit unclear on that so I'm _guessing_ that the count is the number of bytes for the argument list.

I also added a new file of test code that exercises this code path.  The test_component IDL declares a runtimeclass that implements `IStringable`.  And then the implementation fails to implement `IStringable`.  When `ToString` is called on this object it hits the failure path.  The cppwinrt code gen will not allow this to happen so I had to directly use `winrt::implements`.

Test code for failfast code paths is tricky.  I used an overload to hook RoFailFastWithErrorContext to use a test stub that confirms it is called.  It doesn't stop execution so the call returns and the original nullptr crash hits the test suite.  I had to use some ugly __try/__except nonsense to eat the nullptr crash so that test execution can continue.  This is a travesty but it also seems to work reliably and I have no better idea as to how to test this effectively.

In the future it would be nice to make this code non-crashing.  There are concerns about binary size if this code path throws exceptions so this is left as an exercise for the future.
 
## How was this change tested?
Besides the new test cases I also wrote a little console app that crashes this way.  I built and ran it using the latest stable cppwinrt as well as my private new one.  As expected the debugger blame is far more useful with these changes.

Before:
`FAILURE_BUCKET_ID:  ACCESS_VIOLATION_c0000005_CppwinrtQIFailureCrashRepro.exe!winrt::impl::consume_Windows_Foundation_IStringable_winrt::CrashRepro::LiesAboutInheritance_::ToString`

After:
`FAILURE_BUCKET_ID:  STOWED_EXCEPTION_80004002_CppwinrtQIFailureCrashRepro.exe!winrt::impl::require_one_winrt::CrashRepro::LiesAboutInheritance,winrt::Windows::Foundation::IStringable_::operator_winrt::Windows::Foundation::IStringable`

Note that the HRESULT ends up in the signature and the blame has the "requires LiesAboutInheritance to implement IStringable" as the method name.


Closes #1441