### PR TITLE
Value-init fields of WinRT structs (fix warning C24695 in generated code)

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -2716,7 +2716,7 @@ struct WINRT_IMPL_EMPTY_BASES produce_dispatch_to_overridable<T, D, %>
 
     static void write_struct_field(writer& w, std::pair<std::string_view, std::string> const& field)
     {
-        w.write("        @ %;\n",
+        w.write("        @ % {};\n",
             field.second,
             field.first);
     }


### PR DESCRIPTION
Current codegen was triggering [Warning C24695 - Variable 'foo' is uninitialized](https://learn.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-170).

This adds a default initializer to struct fields.

Before:
```cpp
namespace winrt::Windows::UI::Xaml::Interop
{
    struct TypeName
    {
        hstring Name;
        winrt::Windows::UI::Xaml::Interop::TypeKind Kind;
    };
}
```

After:
```cpp
namespace winrt::Windows::UI::Xaml::Interop
{
    struct TypeName
    {
        hstring Name {};
        winrt::Windows::UI::Xaml::Interop::TypeKind Kind {};
    };
}
```

Since consume* methods that return a struct are already value-initializing the return value, this has a negligible effect on the compiler codegen there. So that's nice.