### PR TITLE
Latest vpack has an extra cppwinrt folder

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -85,10 +85,10 @@ extends:
             - task: CopyFiles@2
               displayName: 'Stage compiler vpack contents'
               inputs:
-                SourceFolder: $(Build.SourcesDirectory)/x86
+                SourceFolder: $(Build.SourcesDirectory)/x86/cppwinrt
                 Contents: |
-                  cppwinrt/cppwinrt.exe
-                  cppwinrt/cppwinrt.pdb
+                  cppwinrt.exe
+                  cppwinrt.pdb
                 TargetFolder: $(ob_outputDirectory)
             
         - job: MSBuild_vpack


### PR DESCRIPTION
Trying to test the latest changes using a vpack, the latest vpacks are being built with an extra cppwinrt folder compared to previous vpacks. Unclear why this has changed, but it's been a long time since the last vpack was built, so any number of minor changes could have resulted in this.

Prior vPack contents:
```
|- cppwinrt.exe
|- cppwinrt.pdb
```

Latest vPack contents:
```
|- cppwinrt/
  |- cppwinrt.exe
  |- cppwinrt.pdb
```

This simply changes the vpack contents structure back to the prior format, to avoid needlessly churning the consuming build systems.