### PR TITLE
try_as casts should not store COM error context; consume method cast checking should use return codes directly

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1130,15 +1130,14 @@ namespace cppwinrt
             {
                 // we intentionally ignore errors when unregistering event handlers to be consistent with event_revoker
                 //
-                // The `noexcept` versions will crash if check_hresult throws but that is no different than previous
+                // The `noexcept` versions will crash if .as<>() throws but that is no different than previous
                 // behavior where it would not check the cast result and nullptr crash.  At least the exception will terminate
                 // immediately while preserving the error code and local variables.
                 format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_hresult(code);
+            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
         }
@@ -1156,8 +1155,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_hresult(code);
+            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
         }
@@ -1176,8 +1174,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_hresult(code);
+            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1137,7 +1137,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const [castedResult, code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
@@ -1156,7 +1156,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const [castedResult, code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
@@ -1176,7 +1176,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const [castedResult, code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1130,14 +1130,15 @@ namespace cppwinrt
             {
                 // we intentionally ignore errors when unregistering event handlers to be consistent with event_revoker
                 //
-                // The `noexcept` versions will crash if .as<>() throws but that is no different than previous
+                // The `noexcept` versions will crash if check_hresult throws but that is no different than previous
                 // behavior where it would not check the cast result and nullptr crash.  At least the exception will terminate
                 // immediately while preserving the error code and local variables.
                 format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
         }
@@ -1155,7 +1156,8 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
         }
@@ -1174,7 +1176,8 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<D const*>(this)->template as<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1137,7 +1137,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
@@ -1156,7 +1156,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
@@ -1176,7 +1176,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
+            auto const& [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1137,9 +1137,9 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<% const&>(static_cast<D const&>(*this));
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
-            check_cast_result(abiType);
             abiType->%(%);
         }
         else
@@ -1156,9 +1156,9 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<% const&>(static_cast<D const&>(*this));
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
-            check_cast_result(abiType);
             WINRT_VERIFY_(0, abiType->%(%));
         }
         else
@@ -1176,9 +1176,9 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const& castedResult = static_cast<% const&>(static_cast<D const&>(*this));
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
-            check_cast_result(abiType);
             check_hresult(abiType->%(%));
         }
         else

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1130,7 +1130,7 @@ namespace cppwinrt
             {
                 // we intentionally ignore errors when unregistering event handlers to be consistent with event_revoker
                 //
-                // The `noexcept` versions will crash if check_cast_result throws but that is no different than previous
+                // The `noexcept` versions will crash if check_hresult throws but that is no different than previous
                 // behavior where it would not check the cast result and nullptr crash.  At least the exception will terminate
                 // immediately while preserving the error code and local variables.
                 format = R"(    template <typename D%> auto consume_%<D%>::%(%) const noexcept
@@ -1138,7 +1138,7 @@ namespace cppwinrt
         if constexpr (!std::is_same_v<D, %>)
         {
             auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_cast_result(code);
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
         }
@@ -1157,7 +1157,7 @@ namespace cppwinrt
         if constexpr (!std::is_same_v<D, %>)
         {
             auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_cast_result(code);
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
         }
@@ -1177,7 +1177,7 @@ namespace cppwinrt
         if constexpr (!std::is_same_v<D, %>)
         {
             auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
-            check_cast_result(code);
+            check_hresult(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1137,7 +1137,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             abiType->%(%);
@@ -1156,7 +1156,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             WINRT_VERIFY_(0, abiType->%(%));
@@ -1176,7 +1176,7 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_reason<%>();
+            auto const [castedResult, code] = static_cast<D const*>(this)->template try_as_with_reason<%>();
             check_cast_result(code);
             auto const abiType = *(abi_t<%>**)&castedResult;
             check_hresult(abiType->%(%));

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -538,14 +538,6 @@ namespace winrt::impl
         }
         return result;
     }
-
-    inline WINRT_IMPL_NOINLINE void check_cast_result(hresult const result, winrt::impl::slim_source_location const& sourceInformation = winrt::impl::slim_source_location::current())
-    {
-        if (result != 0)
-        {
-            throw hresult_error(result, take_ownership_from_abi, sourceInformation);
-        }
-    }
 }
 
 #undef WINRT_IMPL_RETURNADDRESS

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -539,24 +539,11 @@ namespace winrt::impl
         return result;
     }
 
-    inline WINRT_IMPL_NOINLINE void check_cast_result(void* from, winrt::impl::slim_source_location const& sourceInformation = winrt::impl::slim_source_location::current())
+    inline WINRT_IMPL_NOINLINE void check_cast_result(hresult const result, winrt::impl::slim_source_location const& sourceInformation = winrt::impl::slim_source_location::current())
     {
-        if (!from)
+        if (result != 0)
         {
-            com_ptr<impl::IRestrictedErrorInfo> restrictedError;
-            if (WINRT_IMPL_GetRestrictedErrorInfo(restrictedError.put_void()) == 0)
-            {
-                WINRT_IMPL_SetRestrictedErrorInfo(restrictedError.get());
-
-                int32_t code;
-                impl::bstr_handle description;
-                impl::bstr_handle restrictedDescription;
-                impl::bstr_handle capabilitySid;
-                if (restrictedError->GetErrorDetails(description.put(), &code, restrictedDescription.put(), capabilitySid.put()) == 0)
-                {
-                    throw hresult_error(code, take_ownership_from_abi, sourceInformation);
-                }
-            }
+            throw hresult_error(result, take_ownership_from_abi, sourceInformation);
         }
     }
 }

--- a/strings/base_extern.h
+++ b/strings/base_extern.h
@@ -32,8 +32,6 @@ extern "C"
     int32_t __stdcall WINRT_IMPL_RoCaptureErrorContext(int32_t error) noexcept WINRT_IMPL_LINK(RoCaptureErrorContext, 4);
     void __stdcall WINRT_IMPL_RoFailFastWithErrorContext(int32_t) noexcept WINRT_IMPL_LINK(RoFailFastWithErrorContext, 4);
     int32_t __stdcall WINRT_IMPL_RoTransformError(int32_t, int32_t, void*) noexcept WINRT_IMPL_LINK(RoTransformError, 12);
-    int32_t __stdcall WINRT_IMPL_GetRestrictedErrorInfo(void**) noexcept WINRT_IMPL_LINK(GetRestrictedErrorInfo, 4);
-    int32_t __stdcall WINRT_IMPL_SetRestrictedErrorInfo(void*) noexcept WINRT_IMPL_LINK(SetRestrictedErrorInfo, 4);
 
     void* __stdcall WINRT_IMPL_LoadLibraryExW(wchar_t const* name, void* unused, uint32_t flags) noexcept WINRT_IMPL_LINK(LoadLibraryExW, 12);
     int32_t __stdcall WINRT_IMPL_FreeLibrary(void* library) noexcept WINRT_IMPL_LINK(FreeLibrary, 4);

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -789,9 +789,9 @@ namespace winrt::impl
         }
 
         template <typename Qi>
-        auto try_as_reason() const noexcept
+        auto try_as_with_reason() const noexcept
         {
-            return m_inner.try_as_reason<Qi>();
+            return m_inner.try_as_with_reason<Qi>();
         }
 
         explicit operator bool() const noexcept

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -783,15 +783,15 @@ namespace winrt::impl
     struct WINRT_IMPL_EMPTY_BASES root_implements_composing_outer<true>
     {
         template <typename Qi>
-        auto as() const noexcept
-        {
-            return m_inner.as<Qi>();
-        }
-
-        template <typename Qi>
         auto try_as() const noexcept
         {
             return m_inner.try_as<Qi>();
+        }
+
+        template <typename Qi>
+        auto try_as_with_reason() const noexcept
+        {
+            return m_inner.try_as_with_reason<Qi>();
         }
 
         explicit operator bool() const noexcept

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -783,15 +783,15 @@ namespace winrt::impl
     struct WINRT_IMPL_EMPTY_BASES root_implements_composing_outer<true>
     {
         template <typename Qi>
-        auto try_as() const noexcept
+        auto as() const noexcept
         {
-            return m_inner.try_as<Qi>();
+            return m_inner.as<Qi>();
         }
 
         template <typename Qi>
-        auto try_as_with_reason() const noexcept
+        auto try_as() const noexcept
         {
-            return m_inner.try_as_with_reason<Qi>();
+            return m_inner.try_as<Qi>();
         }
 
         explicit operator bool() const noexcept

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -788,19 +788,24 @@ namespace winrt::impl
             return m_inner.try_as<Qi>();
         }
 
+        explicit operator bool() const noexcept
+        {
+            return m_inner.operator bool();
+        }
+
+        template <typename To, typename From>
+        friend auto winrt::impl::try_as_with_reason(From ptr) noexcept;
+
+    protected:
+        static constexpr bool is_composing = true;
+        Windows::Foundation::IInspectable m_inner;
+
+    private:
         template <typename Qi>
         auto try_as_with_reason() const noexcept
         {
             return m_inner.try_as_with_reason<Qi>();
         }
-
-        explicit operator bool() const noexcept
-        {
-            return m_inner.operator bool();
-        }
-    protected:
-        static constexpr bool is_composing = true;
-        Windows::Foundation::IInspectable m_inner;
     };
 
     template <typename D, bool>

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -788,6 +788,12 @@ namespace winrt::impl
             return m_inner.try_as<Qi>();
         }
 
+        template <typename Qi>
+        auto try_as_reason() const noexcept
+        {
+            return m_inner.try_as_reason<Qi>();
+        }
+
         explicit operator bool() const noexcept
         {
             return m_inner.operator bool();

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -133,7 +133,7 @@ namespace winrt::impl
     }
 
     template <typename To, typename From, std::enable_if_t<is_com_interface_v<To>, int> = 0>
-    std::pair<com_ref<To>, hresult> try_as_reason(From* ptr) noexcept
+    std::pair<com_ref<To>, hresult> try_as_with_reason(From* ptr) noexcept
     {
 #ifdef WINRT_DIAGNOSTICS
         get_diagnostics_info().add_query<To>();
@@ -223,9 +223,9 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
         }
 
         template <typename To>
-        auto try_as_reason() const noexcept
+        auto try_as_with_reason() const noexcept
         {
-            return impl::try_as_reason<To>(m_ptr);
+            return impl::try_as_with_reason<To>(m_ptr);
         }
 
         template <typename To>

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -128,12 +128,25 @@ namespace winrt::impl
         }
 
         void* result{};
-        hresult code = ptr->QueryInterface(guid_of<To>(), &result);
-        if (code < 0)
-        {
-            WINRT_IMPL_RoCaptureErrorContext(code);
-        }
+        ptr->QueryInterface(guid_of<To>(), &result);
         return wrap_as_result<To>(result);
+    }
+
+    template <typename To, typename From, std::enable_if_t<is_com_interface_v<To>, int> = 0>
+    std::pair<com_ref<To>, hresult> try_as_reason(From* ptr) noexcept
+    {
+#ifdef WINRT_DIAGNOSTICS
+        get_diagnostics_info().add_query<To>();
+#endif
+
+        if (!ptr)
+        {
+            return { nullptr, 0 };
+        }
+
+        void* result{};
+        hresult code = ptr->QueryInterface(guid_of<To>(), &result);
+        return { wrap_as_result<To>(result), code };
     }
 }
 
@@ -207,6 +220,12 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
         auto try_as() const noexcept
         {
             return impl::try_as<To>(m_ptr);
+        }
+
+        template <typename To>
+        auto try_as_reason() const noexcept
+        {
+            return impl::try_as_reason<To>(m_ptr);
         }
 
         template <typename To>

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -131,23 +131,6 @@ namespace winrt::impl
         ptr->QueryInterface(guid_of<To>(), &result);
         return wrap_as_result<To>(result);
     }
-
-    template <typename To, typename From, std::enable_if_t<is_com_interface_v<To>, int> = 0>
-    std::pair<com_ref<To>, hresult> try_as_with_reason(From* ptr) noexcept
-    {
-#ifdef WINRT_DIAGNOSTICS
-        get_diagnostics_info().add_query<To>();
-#endif
-
-        if (!ptr)
-        {
-            return { nullptr, 0 };
-        }
-
-        void* result{};
-        hresult code = ptr->QueryInterface(guid_of<To>(), &result);
-        return { wrap_as_result<To>(result), code };
-    }
 }
 
 WINRT_EXPORT namespace winrt::Windows::Foundation
@@ -220,12 +203,6 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
         auto try_as() const noexcept
         {
             return impl::try_as<To>(m_ptr);
-        }
-
-        template <typename To>
-        auto try_as_with_reason() const noexcept
-        {
-            return impl::try_as_with_reason<To>(m_ptr);
         }
 
         template <typename To>

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -148,6 +148,12 @@ namespace winrt::impl
         hresult code = ptr->QueryInterface(guid_of<To>(), &result);
         return { wrap_as_result<To>(result), code };
     }
+
+    template <typename To, typename From>
+    auto try_as_with_reason(From ptr) noexcept
+    {
+        return ptr->template try_as_with_reason<To>();
+    }
 }
 
 WINRT_EXPORT namespace winrt::Windows::Foundation

--- a/strings/base_windows.h
+++ b/strings/base_windows.h
@@ -131,6 +131,23 @@ namespace winrt::impl
         ptr->QueryInterface(guid_of<To>(), &result);
         return wrap_as_result<To>(result);
     }
+
+    template <typename To, typename From, std::enable_if_t<is_com_interface_v<To>, int> = 0>
+    std::pair<com_ref<To>, hresult> try_as_with_reason(From* ptr) noexcept
+    {
+#ifdef WINRT_DIAGNOSTICS
+        get_diagnostics_info().add_query<To>();
+#endif
+
+        if (!ptr)
+        {
+            return { nullptr, 0 };
+        }
+
+        void* result{};
+        hresult code = ptr->QueryInterface(guid_of<To>(), &result);
+        return { wrap_as_result<To>(result), code };
+    }
 }
 
 WINRT_EXPORT namespace winrt::Windows::Foundation
@@ -203,6 +220,12 @@ WINRT_EXPORT namespace winrt::Windows::Foundation
         auto try_as() const noexcept
         {
             return impl::try_as<To>(m_ptr);
+        }
+
+        template <typename To>
+        auto try_as_with_reason() const noexcept
+        {
+            return impl::try_as_with_reason<To>(m_ptr);
         }
 
         template <typename To>


### PR DESCRIPTION
## Why is this change being made?
I have been trying to ingest the HEAD of cppwinrt for some large internal projects and one of them had some test failures with the new version.  The failures are because there is a `try_as` cast in their code that fails and is handled fine, but it leaves a COM error context floating around on that thread.  Subsequent code fails to originate an error because it sees a context already active on the thread and NOOP'ed.

What this boils down to is that `try_as` should not have a behavioral change to store context when the cast fails.

## Briefly summarize what changed
To address this problem I am taking a PR suggestion from @oldnewthing to have a new `try_as_with_reason` method that returns both the cast result as well as the HRESULT.  The error context logic was only there to smuggle the HRESULT out of a call without an HRESULT return value, so if it is a direct return we don't need that anymore.  The new method directly returns the HRESULT so there is no ambiguity.

The previous approach relied on a cast operator to call try_as (or just addref when the type is already a match).  Thanks to the recent `if constexpr` code gen change those cases are now separated out.  We have a code block where we know a cast is needed so `try_as_with_reason` can be called unconditionally.  The code path where no cast is needed already circumvents this and is nicely unaffected.

This also made `check_cast_result` equiavelnt to `check_hresult` so it was deleted in favor of just calling `check_hresult`.

## How was this change tested?
I did local builds of cppwinrt (both Debug and Release) and ran the tests.  I am also compiling some large internal projects with it to ensure that there are no obvious breaks or regressions.  I am expecting minimal to no binary size impact from this change.

Here is what the latest code gen is for IStringable::ToString()
```cpp
    template <typename D> auto consume_Windows_Foundation_IStringable<D>::ToString() const
    {
        void* value{};
        if constexpr (!std::is_same_v<D, winrt::Windows::Foundation::IStringable>)
        {
            auto const [castedResult, code] = impl::try_as_with_reason<winrt::Windows::Foundation::IStringable, D const*>(static_cast<D const*>(this));
            check_hresult(code);
            auto const abiType = *(abi_t<winrt::Windows::Foundation::IStringable>**)&castedResult;
            check_hresult(abiType->ToString(&value));
        }
        else
        {
            auto const abiType = *(abi_t<winrt::Windows::Foundation::IStringable>**)this;
            check_hresult(abiType->ToString(&value));
        }
        return hstring{ value, take_ownership_from_abi };
    }
```