### PR TITLE
Make consume methods more amenable to optimization

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1137,7 +1137,8 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [_winrt_casted_result, _winrt_cast_result_code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
+            winrt::hresult _winrt_cast_result_code;
+            auto const _winrt_casted_result = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this), _winrt_cast_result_code);
             check_hresult(_winrt_cast_result_code);
             auto const _winrt_abi_type = *(abi_t<%>**)&_winrt_casted_result;
             _winrt_abi_type->%(%);
@@ -1156,7 +1157,8 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [_winrt_casted_result, _winrt_cast_result_code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
+            winrt::hresult _winrt_cast_result_code;
+            auto const _winrt_casted_result = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this), _winrt_cast_result_code);
             check_hresult(_winrt_cast_result_code);
             auto const _winrt_abi_type = *(abi_t<%>**)&_winrt_casted_result;
             WINRT_VERIFY_(0, _winrt_abi_type->%(%));
@@ -1176,7 +1178,8 @@ namespace cppwinrt
     {%
         if constexpr (!std::is_same_v<D, %>)
         {
-            auto const [_winrt_casted_result, _winrt_cast_result_code] = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this));
+            winrt::hresult _winrt_cast_result_code;
+            auto const _winrt_casted_result = impl::try_as_with_reason<%, D const*>(static_cast<D const*>(this), _winrt_cast_result_code);
             check_hresult(_winrt_cast_result_code);
             auto const _winrt_abi_type = *(abi_t<%>**)&_winrt_casted_result;
             check_hresult(_winrt_abi_type->%(%));

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -794,7 +794,7 @@ namespace winrt::impl
         }
 
         template <typename To, typename From>
-        friend auto winrt::impl::try_as_with_reason(From ptr) noexcept;
+        friend auto winrt::impl::try_as_with_reason(From ptr, hresult& code) noexcept;
 
     protected:
         static constexpr bool is_composing = true;
@@ -802,9 +802,9 @@ namespace winrt::impl
 
     private:
         template <typename Qi>
-        auto try_as_with_reason() const noexcept
+        auto try_as_with_reason(hresult& code) const noexcept
         {
-            return m_inner.try_as_with_reason<Qi>();
+            return m_inner.try_as_with_reason<Qi>(code);
         }
     };
 


### PR DESCRIPTION
The temporary std::pair introduced with `try_as_with_reason` sometimes causes spurious temporary dtor calls, depending on the optimization flags used and/or the version of the compiler. This didn't result in an extra refcount bump/release, but it still resulted in generating spurious destructor calls to `winrt::Foundation::~IUnknown()` as a result of that temporary.

The temporary had already been moved-from into the local variables, so was always zero, but this code bloat, extra function call and branch, when multiplied over thousands of projected methods can still add up.