### PR TITLE
Fix warnings in natvis project

### DIFF
--- a/natvis/object_visualizer.cpp
+++ b/natvis/object_visualizer.cpp
@@ -671,7 +671,7 @@ HRESULT object_visualizer::GetItems(
 
     auto pParent = pVisualizedExpression;
     auto childCount = std::min(m_propertyData.size() - StartIndex, (size_t)Count);
-    for(auto i = 0; i < childCount; ++i)
+    for(size_t i = 0; i < childCount; ++i)
     {
         auto& prop = m_propertyData[i + (size_t)StartIndex];
         com_ptr<DkmChildVisualizedExpression> pPropertyVisualized;

--- a/natvis/pch.h
+++ b/natvis/pch.h
@@ -4,7 +4,10 @@
 #define NOMINMAX
 
 #include <windows.h>
+#pragma warning(push)
+#pragma warning(disable : 4471)
 #include <vsdebugeng.h>
+#pragma warning(pop)
 #include <vsdebugeng.templates.h>
 #include <Dia2.h>
 #include "base_includes.h"


### PR DESCRIPTION
There are a slew of compilation warnings in the natvis project. This addresses them.

Most are coming from a the `<vsdebugeng.h>` header in the `Microsoft.VSSDK.Debugger.VSDebugEng.16.0.2012201-preview` package.

But there were a few where a global variable named `db` was getting hidden by a local `db` in a different scope. Let's just give the global a more unique name for now.