### PR TITLE
Add get_iids_tearoff() hook.

### DIFF
--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -912,6 +912,11 @@ namespace winrt::impl
             return error_no_interface;
         }
 
+        virtual std::vector<guid> get_iids_tearoff() const noexcept
+        {
+            return {};
+        }
+
         root_implements() noexcept
         {
         }
@@ -1021,7 +1026,8 @@ namespace winrt::impl
         int32_t __stdcall NonDelegatingGetIids(uint32_t* count, guid** array) noexcept
         {
             auto const& local_iids = static_cast<D*>(this)->get_local_iids();
-            uint32_t const& local_count = local_iids.first;
+            auto tearoff_iids = get_iids_tearoff();
+            auto local_count = local_iids.first + tearoff_iids.size();
             if constexpr (root_implements_type::is_composing)
             {
                 if (local_count > 0)
@@ -1033,8 +1039,10 @@ namespace winrt::impl
                     {
                         return error_bad_alloc;
                     }
-                    *array = std::copy(local_iids.second, local_iids.second + local_count, *array);
-                    std::copy(inner_iids.cbegin(), inner_iids.cend(), *array);
+                    auto _array = *array;
+                    _array = std::copy(local_iids.second, local_iids.second + local_iids.first, _array);
+                    _array = std::copy(tearoff_iids.cbegin(), tearoff_iids.cend(), _array);
+                    std::copy(inner_iids.cbegin(), inner_iids.cend(), _array);
                 }
                 else
                 {
@@ -1051,7 +1059,9 @@ namespace winrt::impl
                     {
                         return error_bad_alloc;
                     }
-                    std::copy(local_iids.second, local_iids.second + local_count, *array);
+                    auto _array = *array;
+                    _array = std::copy(local_iids.second, local_iids.second + local_iids.first, _array);
+                    std::copy(tearoff_iids.cbegin(), tearoff_iids.cend(), _array);
                 }
                 else
                 {

--- a/test/test/tearoff.cpp
+++ b/test/test/tearoff.cpp
@@ -164,6 +164,11 @@ namespace
             *result = nullptr;
             return E_NOINTERFACE;
         }
+
+        std::vector<winrt::guid> get_iids_tearoff() const noexcept final
+        {
+            return {winrt::guid_of<IPersist>()};
+        }
     };
 
     struct RuntimeType : winrt::implements<RuntimeType, winrt::IClosable>
@@ -196,6 +201,11 @@ namespace
             *result = nullptr;
             return E_NOINTERFACE;
         }
+
+        std::vector<winrt::guid> get_iids_tearoff() const noexcept final
+        {
+            return {winrt::guid_of<winrt::IStringable>()};
+        }
     };
 }
 
@@ -214,6 +224,11 @@ TEST_CASE("tearoff")
         GUID result;
         REQUIRE(S_OK == persist->GetClassID(&result));
         REQUIRE(winrt::is_guid_of<IPersist>(result));
+
+        winrt::com_array<winrt::guid> iids = winrt::get_interfaces(closable);
+        REQUIRE(iids.size() == 2);
+        REQUIRE(std::find(iids.begin(), iids.end(), winrt::guid_of<winrt::IClosable>()) != iids.end());
+        REQUIRE(std::find(iids.begin(), iids.end(), winrt::guid_of<IPersist>()) != iids.end());
 
         // query_interface_tearoff happily ignores any other queries.
         REQUIRE(closable.try_as<winrt::IActivationFactory>() == nullptr);
@@ -248,6 +263,11 @@ TEST_CASE("tearoff")
         // IStringable is implemented as a tearoff.
         winrt::IStringable stringable = closable.as<winrt::IStringable>();
         REQUIRE(stringable.ToString() == L"ToString");
+
+        winrt::com_array<winrt::guid> iids = winrt::get_interfaces(closable);
+        REQUIRE(iids.size() == 2);
+        REQUIRE(std::find(iids.begin(), iids.end(), winrt::guid_of<winrt::IClosable>()) != iids.end());
+        REQUIRE(std::find(iids.begin(), iids.end(), winrt::guid_of<winrt::IStringable>()) != iids.end());
 
         // Calling an IInspectable function on the tearoff forwards to the object.
         REQUIRE(winrt::get_class_name(stringable) == L"RuntimeClassName");


### PR DESCRIPTION
Add a `get_iids_tearoff()` hook to complement the `query_interface_tearoff()` hook.

`query_interface_tearoff()` allows dynamically extending types with additional interfaces that can be accessed with the `QueryInterface()` method. However, these interfaces were not discoverable by the `GetIids()` method (and therefore not by the `winrt::get_interfaces()` function either).

The `get_iids_tearoff()` hook allows adding the GUIDs of interfaces to the array returned by `GetIids()`.

This also fixes a bug in the implementation of the `root_implements_type::is_composing` branch of `NonDelegatingGetIids()` where `*array` was updated causing the local iids to be unreachable by the caller and risking the caller reading past the end of the array.

