### PR TITLE
Fix setting of IntDir MSBuild property

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -41,6 +41,7 @@
     <CppWinRTPlatform>$(Platform)</CppWinRTPlatform>
     <CppWinRTPlatform Condition="'$(Platform)'=='Win32'">x86</CppWinRTPlatform>
     <OutDir>$(SolutionDir)_build\$(CppWinRTPlatform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)_build\$(CppWinRTPlatform)\$(Configuration)\temp\$(MSBuildProjectName)\</IntDir>
     <CppWinRTDir>$(OutDir)</CppWinRTDir>
     <CppWinRTDir Condition="'$(Platform)'=='ARM64'">$(SolutionDir)_build\x86\$(Configuration)\</CppWinRTDir>
   </PropertyGroup>

--- a/Directory.Build.Targets
+++ b/Directory.Build.Targets
@@ -1,7 +1,0 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <IntDir>$(OutDir)temp\$(ProjectName)\</IntDir>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Building cppwinrt was generating a bunch of warnings like 
```
(CreateRecipeFile target) ->
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(2566,5)
: warning : Remote deployment might be slow/inefficient. Could not find a part of the path 'E:\GitHub\cppwinrt\fast_fwd
\x64\Release\cppwinrt_fast_forwarder.lib.recipe'. [E:\GitHub\cppwinrt\fast_fwd\fast_fwd.vcxproj]
```
I tracked this down to us setting `IntDir` too late in Directory.Build.targets, which was too late, and processed after a bunch of other logic. The result of this was that `IntDir` got the default value, which was then used for `IntDirFullPath`, and then we overrode `IntDir`.

Some MSBuild *.Targets would then use the inconsistent `IntDirFullPath` and complain about folder not being created.

To fix this, we now set both `OutDir` and `IntDir` consistently, in Directory.Build.Props. Since this left Directory.Build.Targets empty, I'm deleting it.

(Also, the old code was using `OutDir` to set `IntDir`, and the official docs say "Don't Do That", so we've also got that, which is nice)

With all that build spew going away, it should be easier to see the actual warnings we care about.