### PR TITLE
Fix various build warnings

### DIFF
--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -176,7 +176,7 @@ int32_t __stdcall WINRT_CanUnloadNow() noexcept
 {
 #ifdef _WRL_MODULE_H_
 #ifdef _MSC_VER
-#pragma warning(disable: 4324) // structure was padded due to alignment specifier
+#pragma warning(suppress: 4324) // structure was padded due to alignment specifier
 #endif
     if (!::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().Terminate())
     {

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -175,6 +175,9 @@ void* __stdcall %_get_activation_factory([[maybe_unused]] std::wstring_view cons
 int32_t __stdcall WINRT_CanUnloadNow() noexcept
 {
 #ifdef _WRL_MODULE_H_
+#ifdef _MSC_VER
+#pragma warning(disable: 4324) // structure was padded due to alignment specifier
+#endif
     if (!::Microsoft::WRL::Module<::Microsoft::WRL::InProc>::GetModule().Terminate())
     {
         return 1;

--- a/prebuild/prebuild.vcxproj
+++ b/prebuild/prebuild.vcxproj
@@ -88,6 +88,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -98,6 +99,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,6 +110,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -120,6 +123,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,6 +138,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -148,6 +153,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/prebuild/prebuild.vcxproj
+++ b/prebuild/prebuild.vcxproj
@@ -88,7 +88,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,7 +98,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -110,7 +108,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\cppwinrt</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/strings/base_composable.h
+++ b/strings/base_composable.h
@@ -6,7 +6,7 @@ namespace winrt::impl
     {
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4702)
+#pragma warning(disable: 4702) // Compiler bug causing spurious "unreachable code" warnings
 #endif
         template <typename I, typename... Args>
         static I CreateInstance(const Windows::Foundation::IInspectable& outer, Windows::Foundation::IInspectable& inner, Args&&... args)

--- a/strings/base_composable.h
+++ b/strings/base_composable.h
@@ -4,6 +4,10 @@ namespace winrt::impl
     template <typename D>
     struct composable_factory
     {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
         template <typename I, typename... Args>
         static I CreateInstance(const Windows::Foundation::IInspectable& outer, Windows::Foundation::IInspectable& inner, Args&&... args)
         {
@@ -11,6 +15,9 @@ namespace winrt::impl
             inner = CreateInstanceImpl(outer, std::forward<Args>(args)...);
             return inner.as<I>();
         }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
     private:
         template <typename... Args>

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1392,7 +1392,7 @@ WINRT_EXPORT namespace winrt
 {
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4702)
+#pragma warning(disable: 4702) // Compiler bug causing spurious "unreachable code" warnings
 #endif
     template <typename D, typename... Args>
     auto make(Args&&... args)

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -1390,6 +1390,10 @@ namespace winrt::impl
 
 WINRT_EXPORT namespace winrt
 {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     template <typename D, typename... Args>
     auto make(Args&&... args)
     {
@@ -1443,6 +1447,9 @@ WINRT_EXPORT namespace winrt
             return { impl::create_and_initialize<D>(std::forward<Args>(args)...), take_ownership_from_abi };
         }
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
     template <typename... FactoryClasses>
     inline void clear_factory_static_lifetime()

--- a/test/old_tests/Component/Component.idl
+++ b/test/old_tests/Component/Component.idl
@@ -243,7 +243,7 @@ namespace Component
         HRESULT Create([in] Windows.Foundation.Collections.IVectorView<HSTRING>* _in, [out, retval] FastInputVector** _out);
     };
 
-    midl_pragma warning(disable: 4066)
+    midl_pragma warning(disable: 4066) // A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class.
 
     [version(1.0), activatable(IFastInputVectorFactory, 1.0)]
     runtimeclass FastInputVector

--- a/test/old_tests/Component/Component.idl
+++ b/test/old_tests/Component/Component.idl
@@ -243,6 +243,8 @@ namespace Component
         HRESULT Create([in] Windows.Foundation.Collections.IVectorView<HSTRING>* _in, [out, retval] FastInputVector** _out);
     };
 
+    midl_pragma warning(disable: 4066)
+
     [version(1.0), activatable(IFastInputVectorFactory, 1.0)]
     runtimeclass FastInputVector
     {
@@ -270,6 +272,8 @@ namespace Component
         interface Windows.Foundation.Collections.IMap<HSTRING, HSTRING>;
         interface Windows.Foundation.Collections.IMapView<HSTRING, HSTRING>;
     };
+
+    midl_pragma warning(default: 4066)
 
     //
     // Boxing support for enums and their underlying types.

--- a/test/test/fast_iterator.cpp
+++ b/test/test/fast_iterator.cpp
@@ -48,7 +48,7 @@ TEST_CASE("fast_iterator")
         REQUIRE(2 - (vbegin + 4) > vbegin);
         REQUIRE(vbegin < vbegin + 2);
         REQUIRE(vbegin + 2 - 2 == vbegin);
-        REQUIRE(end(v) - begin(v) == v.Size());
+        REQUIRE(static_cast<uint32_t>(end(v) - begin(v)) == v.Size());
         REQUIRE((begin(v) + 3)[-1] == 4);
     }
     {

--- a/test/test_component/OverloadClass.cpp
+++ b/test/test_component/OverloadClass.cpp
@@ -8,15 +8,15 @@ namespace winrt::test_component::implementation
     {
         throw hresult_not_implemented();
     }
-    void OverloadClass::Overload(int a)
+    void OverloadClass::Overload(int /*a*/)
     {
         throw hresult_not_implemented();
     }
-    void OverloadClass::Overload(int a, int b)
+    void OverloadClass::Overload(int /*a*/, int /*b*/)
     {
         throw hresult_not_implemented();
     }
-    void OverloadClass::Overload(int a, int b, int c)
+    void OverloadClass::Overload(int /*a*/, int /*b*/, int /*c*/)
     {
         throw hresult_not_implemented();
     }

--- a/test/test_component_base/HierarchyB.cpp
+++ b/test/test_component_base/HierarchyB.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "HierarchyB.h"
 
+#pragma warning(disable: 4702)
+
 namespace winrt::test_component_base::implementation
 {
     HierarchyB::HierarchyB(hstring const& name)


### PR DESCRIPTION
Needed to fix a BinSkim issue flagging CFG on prebuild.exe. While I was at it, I fixed a few more warnings. A few were genuine code tweaks, a few were warning suppressions for stuff that's either by design or out of our control.

At this point, the official build pipelines are looking almost 100% clean. Might even be able to enable /WX and cause the build to break on new warnings.