### PR TITLE
Enable prefast and warnings checker in SDL

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -32,6 +32,7 @@ extends:
       enabled: false
     
     globalSdl:
+      isNativeCode: true
       asyncSdl:
         enabled: true
       tsa:
@@ -40,8 +41,6 @@ extends:
         compiled: 
           enabled: true
         tsaEnabled: true
-      isNativeCode:
-        enabled: true
       prefast:
         enabled: true
 

--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -40,6 +40,10 @@ extends:
         compiled: 
           enabled: true
         tsaEnabled: true
+      isNativeCode:
+        enabled: true
+      prefast:
+        enabled: true
 
     stages:
     - stage: build

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -36,6 +36,10 @@ extends:
         enabled: false
       sbom:
         enabled: true
+      isNativeCode:
+        enabled: true
+      prefast:
+        enabled: true
 
     stages:
     - stage: build

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -32,11 +32,10 @@ extends:
       product: 'build_tools'
     
     globalSdl:
+      isNativeCode: true
       tsa:
         enabled: false
       sbom:
-        enabled: true
-      isNativeCode:
         enabled: true
       prefast:
         enabled: true

--- a/.pipelines/jobs/OneBranchBuild.yml
+++ b/.pipelines/jobs/OneBranchBuild.yml
@@ -31,6 +31,10 @@ jobs:
     ${{ if eq(parameters.OfficialBuild, 'false') }}:
       ob_sdl_codeSignValidation_excludes: '-|**\*.exe;-|**\*.dll' 
 
+    ob_sdl_prefast_enabled: true
+    ob_sdl_prefast_runDuring: 'Build'
+    ob_sdl_checkCompliantCompilerWarnings: true
+    
     ob_symbolsPublishing_enabled: ${{ parameters.OfficialBuild }}
     ob_symbolsPublishing_symbolsFolder: '$(ob_outputDirectory)'
     ob_symbolsPublishing_searchPattern: '**\*.pdb'

--- a/.pipelines/jobs/OneBranchNuGet.yml
+++ b/.pipelines/jobs/OneBranchNuGet.yml
@@ -17,6 +17,10 @@ jobs:
       ob_outputDirectory: '$(Build.SourcesDirectory)\out'
       PackageVersion: ${{ parameters.BuildVersion }}
 
+      ob_sdl_prefast_enabled: true
+      ob_sdl_prefast_runDuring: 'Build'
+      ob_sdl_checkCompliantCompilerWarnings: true
+
     steps:
       - task: UseDotNet@2
         continueOnError: true

--- a/.pipelines/jobs/OneBranchTest.yml
+++ b/.pipelines/jobs/OneBranchTest.yml
@@ -51,6 +51,10 @@ jobs:
     ob_artifactSuffix: $(TestExe).$(BuildPlatform)
     ob_sdl_codeSignValidation_excludes: '-|**\*.exe;-|**\*.dll' 
 
+    ob_sdl_prefast_enabled: true
+    ob_sdl_prefast_runDuring: 'Build'
+    ob_sdl_checkCompliantCompilerWarnings: true
+
     BuildPath: '$(Build.SourcesDirectory)/_build/$(BuildPlatform)/${{ parameters.BuildConfiguration }}'
   
   steps:

--- a/.pipelines/jobs/OneBranchVsix.yml
+++ b/.pipelines/jobs/OneBranchVsix.yml
@@ -36,6 +36,10 @@ jobs:
     ob_symbolsPublishing_symbolsFolder: '$(ob_outputDirectory)'
     ob_symbolsPublishing_searchPattern: '**\*.pdb'
     ob_symbolsPublishing_indexSources: true
+
+    ob_sdl_prefast_enabled: true
+    ob_sdl_prefast_runDuring: 'Build'
+    ob_sdl_checkCompliantCompilerWarnings: true
     
   steps:
     - task: UseDotNet@2

--- a/natvis/cppwinrtvisualizer.vcxproj
+++ b/natvis/cppwinrtvisualizer.vcxproj
@@ -104,7 +104,6 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;WIN32;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -129,7 +128,6 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -153,7 +151,6 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;_DEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -179,7 +176,6 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;WIN32;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -209,7 +205,6 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -239,7 +234,6 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>VSDEBUGENG_USE_CPP11_SCOPED_ENUMS;NDEBUG;VISUALIZER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);..\cppwinrt;..\strings;$(DIASDKInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>


### PR DESCRIPTION
More compliance work, this time enabline prefast and the compiler warnings checker.

While I was here I also noticed that the visualizer was overriding SDL to disabled, so went ahead and removed that to allow the default "Enabled" value to prevail again.