### PR TITLE
Fix vpack clobbering and update to newer Windows container image

### DIFF
--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -121,8 +121,6 @@ extends:
               inputs:
                 script: |
                   set TargetDir=$(ob_outputDirectory)
-                  rd /s /q %TargetDir% >nul 2>&1
-                  md %TargetDir%
                   cd %TargetDir%
 
                   copy $(Build.SourcesDirectory)\vsix\Microsoft.Cpp.CppWinRT.props

--- a/.pipelines/OneBranch.Official.yml
+++ b/.pipelines/OneBranch.Official.yml
@@ -27,6 +27,10 @@ extends:
     platform:
       name: 'windows_undocked'
       product: 'build_tools'
+    
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
             
     cloudvault:
       enabled: false

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -31,6 +31,10 @@ extends:
       name: 'windows_undocked'
       product: 'build_tools'
     
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+    
     globalSdl:
       isNativeCode: true
       tsa:

--- a/.pipelines/variables/OneBranchVariables.yml
+++ b/.pipelines/variables/OneBranchVariables.yml
@@ -10,7 +10,7 @@ variables:
   NUGET_XMLDOC_MODE: none
 
   # Docker image which is used to build the project https://aka.ms/obpipelines/containers
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest' 
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' 
 
   Codeql.Enabled: true #  CodeQL once every 3 days on the default branch for all languages its applicable to in that pipeline.
   GDN_USE_DOTNET: true


### PR DESCRIPTION
I found that after #1479 a left overline in the msbuild vpack copy was clobbering the compiler contents we had previously copied over. Didn't notice until I tried to use the new vpack and cppwinrt.exe was missing.

While we're at it, let's go ahead and update our pipeline container images from 2019 to the latest (and recommended) 2022 version.