### PR TITLE
fix: `non-virtual-dtor` warning

### DIFF
--- a/strings/base_abi.h
+++ b/strings/base_abi.h
@@ -8,6 +8,7 @@ namespace winrt::impl
             virtual int32_t __stdcall QueryInterface(guid const& id, void** object) noexcept = 0;
             virtual uint32_t __stdcall AddRef() noexcept = 0;
             virtual uint32_t __stdcall Release() noexcept = 0;
+            virtual ~type() noexcept = default;
         };
     };
 


### PR DESCRIPTION
This virtual destructor will resolve the warning of option `-Wnon-virtual-dtor` in MinGW.

Fixes: #1499
