### PR TITLE
Update com_ptr dereference implementation to account for proyected types

### DIFF
--- a/strings/base_com_ptr.h
+++ b/strings/base_com_ptr.h
@@ -112,7 +112,10 @@ WINRT_EXPORT namespace winrt
 
         T& operator*() const noexcept
         {
-            return *m_ptr;
+            if constexpr (std::is_same_v<T, type>)
+                return *const_cast<T*>(m_ptr);
+            else
+                return *reinterpret_cast<T*>(const_cast<com_ptr*>(this));
         }
 
         type* get() const noexcept

--- a/test/old_tests/UnitTests/com_ptr.cpp
+++ b/test/old_tests/UnitTests/com_ptr.cpp
@@ -385,3 +385,27 @@ TEST_CASE("com_ptr, compare")
     REQUIRE(!(nullptr != c));
     REQUIRE(!(c != nullptr));
 }
+
+TEST_CASE("com_ptr, calls")
+{
+    hstring test_string;
+
+    // here com_ptr<Stringable>::type == Stringable
+    const wchar_t * grettings = L"Hello world!";
+    com_ptr<Stringable> impl = make_self<Stringable>(grettings);
+
+    // -> calls the projection
+    REQUIRE_NOTHROW(test_string = impl->ToString());
+    REQUIRE(grettings == test_string);
+
+    // here com_ptr<IStringable>::type == abi_t<IStringable>
+    com_ptr<IStringable> str(detach_abi(impl.as<IStringable>()), take_ownership_from_abi);
+
+    // -> calls the abi
+    REQUIRE(0 == str->ToString(put_abi(test_string)));
+    REQUIRE(grettings == test_string);
+
+    // * calls the projection
+    REQUIRE_NOTHROW(test_string = (*str).ToString());
+    REQUIRE(grettings == test_string);
+}


### PR DESCRIPTION
The current implementation:
```c++
    T& com_ptr<T>::operator*() const noexcept
    {
        return *m_ptr;
    }
```
cannot work for proyected types because `abi_t<T> != T`.
Note that proyections provide `abi_t` specializations. By default `abi_t<T> == T` and the operator works.

The fix takes into account two cases:
+ The `com_ptr<>` wraps a COM/WinRT interface, that is `T != abi_t<T>`.
    ```
    com_ptr
      ┕> m_ptr = impl::abi_t<T>*
    ``` 
   Because the projected wrapper layout is:
    ```
    IXXX
      ┕> m_ptr = impl::unknown_abi*
    ```
   Then a plain cast would do: `return *reinterpret_cast<IXXX*>(const_cast<com_ptr*>(this));`

+ The `com_ptr<>` wraps an implementation object, that is `T == abi_t<T>`. E.g. an `event_array`:
    ```
    com_ptr
      ┕> m_ptr = EventHandler<int>*
    ```
    return a reference to the member object: `return *const_cast<EventHandler<int>*>(m_ptr);`

A regression test is included.
