### PR TITLE
Fix #1509 by honoring `CppWinRTModernIDL` in `CppWinRTSetMidlReferences`

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -354,7 +354,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             Returns="@(CppWinRTMdMergeMetadataDirectories);@(CppWinRTMdMergeInputs)">
         <ItemGroup>
             <_MdMergeInputs Remove="@(_MdMergeInputs)"/>
-            <_MdMergeInputs Include="@(Midl)" Condition="'%(Midl.ExcludedFromBuild)' != 'true'">
+            <_MdMergeInputs Include="@(Midl)" Condition="'%(Midl.ExcludedFromBuild)' != 'true' and '$(CppWinRTModernIDL)' != 'false'">
                 <WinMDPath>%(Midl.OutputDirectory)%(Midl.MetadataFileName)</WinMDPath>
                 <MdMergeOutputFile>$(CppWinRTProjectWinMD)</MdMergeOutputFile>
             </_MdMergeInputs>


### PR DESCRIPTION
When `CppWinRTModernIDL` is set to `false`, it means the `Midl` items in the project should not be used for `WinMD` merging.
See #1509 for details.

Fixes: #1509
