### PR TITLE
Fix CI build by using latest Windows SDK in C# project

### DIFF
--- a/test/nuget/TestRuntimeComponentCSharp/TestRuntimeComponentCSharp.csproj
+++ b/test/nuget/TestRuntimeComponentCSharp/TestRuntimeComponentCSharp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>TestRuntimeComponentCSharp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(WindowsSDKVersion)</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(WindowsSDKVersion.TrimEnd('\'))</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
CI builds recently started failing due to the windows-latest image updating from windows-2022 to windows-2025. The newest image does not carry the 10.0.22621 Windows SDK, just the 10.0.26100.

I'm attempting to use `WindowsSDKVersion` to select the latest installed SDK.