### PR TITLE
Add [[nodiscard]] to overloads of static events that return winrt::event_token

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -3157,11 +3157,12 @@ struct WINRT_IMPL_EMPTY_BASES produce_dispatch_to_overridable<T, D, %>
             method_signature signature{ method };
             auto method_name = get_name(method);
             auto async_types_guard = w.push_async_types(signature.is_async());
+            auto is_event = is_add_overload(method);
 
             if (is_opt_type)
             {
                 w.write("        %static % %(%);\n",
-                    is_get_overload(method) ? "[[nodiscard]] " : "",
+                    is_get_overload(method) || is_event ? "[[nodiscard]] " : "",
                     signature.return_signature(),
                     method_name,
                     bind<write_consume_params>(signature));
@@ -3169,12 +3170,12 @@ struct WINRT_IMPL_EMPTY_BASES produce_dispatch_to_overridable<T, D, %>
             else
             {
                 w.write("        %static auto %(%);\n",
-                    is_get_overload(method) ? "[[nodiscard]] " : "",
+                    is_get_overload(method) || is_event ? "[[nodiscard]] " : "",
                     method_name,
                     bind<write_consume_params>(signature));
             }
 
-            if (is_add_overload(method))
+            if (is_event)
             {
                 {
                     auto format = R"(        using %_revoker = impl::factory_event_revoker<%, &impl::abi_t<%>::remove_%>;


### PR DESCRIPTION
Some events in WinRT are static, such as [Clipboard.ContentChanged](https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.clipboard.contentchanged?view=winrt-26100).For these events, the only way to release a delegate is through `winrt::event_token`, because the delegate is not stored in any user-controllable object. Therefore, if the `winrt::event_token` returned by these events is discarded, the delegate will leak. This PR adds the `[[nodiscard]]` attribute to the overloads that return `winrt::event_token` for static events to indicate that their return value should not be ignored, just like the overloads that return a revoker.

```cpp
struct Clipboard
{
    [[nodiscard]] static auto ContentChanged(EventHandler<IInspectable> const& handler);
};
```
