### PR TITLE
Add get_unchecked() to async operations

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1433,24 +1433,28 @@ namespace cppwinrt
         else if (type_name == "Windows.Foundation.IAsyncAction")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperation`1")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncActionWithProgress`1")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperationWithProgress`2")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1475,28 +1475,36 @@ namespace cppwinrt
         else if (type_name == "Windows.Foundation.IAsyncAction")
         {
             w.write(R"(        auto get() const;
-        auto get_only_safe_from_non_presenting_sta() const;
+        // Synchronously waits without asserting that the calling thread is not an STA.
+        // Use only when the STA is not presenting UI and blocking is known to be safe.
+        auto get_unchecked() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperation`1")
         {
             w.write(R"(        auto get() const;
-        auto get_only_safe_from_non_presenting_sta() const;
+        // Synchronously waits without asserting that the calling thread is not an STA.
+        // Use only when the STA is not presenting UI and blocking is known to be safe.
+        auto get_unchecked() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncActionWithProgress`1")
         {
             w.write(R"(        auto get() const;
-        auto get_only_safe_from_non_presenting_sta() const;
+        // Synchronously waits without asserting that the calling thread is not an STA.
+        // Use only when the STA is not presenting UI and blocking is known to be safe.
+        auto get_unchecked() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperationWithProgress`2")
         {
             w.write(R"(        auto get() const;
-        auto get_only_safe_from_non_presenting_sta() const;
+        // Synchronously waits without asserting that the calling thread is not an STA.
+        // Use only when the STA is not presenting UI and blocking is known to be safe.
+        auto get_unchecked() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }

--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -1475,24 +1475,28 @@ namespace cppwinrt
         else if (type_name == "Windows.Foundation.IAsyncAction")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperation`1")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncActionWithProgress`1")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }
         else if (type_name == "Windows.Foundation.IAsyncOperationWithProgress`2")
         {
             w.write(R"(        auto get() const;
+        auto get_only_safe_from_non_presenting_sta() const;
         auto wait_for(Windows::Foundation::TimeSpan const& timeout) const;
 )");
         }

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -99,6 +99,19 @@ namespace winrt::impl
         return async.GetResults();
     }
 
+    template <typename Async>
+    auto wait_get_bypass_sta_check(Async const& async)
+    {
+        auto status = async.Status();
+        if (status == Windows::Foundation::AsyncStatus::Started)
+        {
+            status = wait_for_completed(async, 0xFFFFFFFF); // INFINITE
+        }
+        check_status_canceled(status);
+
+        return async.GetResults();
+    }
+
 #ifdef WINRT_IMPL_COROUTINES
     struct ignore_apartment_context {};
 
@@ -220,6 +233,11 @@ namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
     }
     template <typename D>
+    auto consume_Windows_Foundation_IAsyncAction<D>::get_only_safe_from_non_presenting_sta() const
+    {
+        impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D>
     auto consume_Windows_Foundation_IAsyncAction<D>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
     {
         return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
@@ -229,6 +247,11 @@ namespace winrt::impl
     auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get() const
     {
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TResult>
+    auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get_only_safe_from_non_presenting_sta() const
+    {
+        return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult>
     auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
@@ -242,6 +265,11 @@ namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TProgress>
+    auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::get_only_safe_from_non_presenting_sta() const
+    {
+        impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TProgress>
     auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
     {
         return impl::wait_for(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)), timeout);
@@ -251,6 +279,11 @@ namespace winrt::impl
     auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get() const
     {
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TResult, typename TProgress>
+    auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get_only_safe_from_non_presenting_sta() const
+    {
+        return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult, typename TProgress>
     auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::wait_for(Windows::Foundation::TimeSpan const& timeout) const

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -99,6 +99,19 @@ WINRT_EXPORT namespace winrt::impl
         return async.GetResults();
     }
 
+    template <typename Async>
+    auto wait_get_bypass_sta_check(Async const& async)
+    {
+        auto status = async.Status();
+        if (status == Windows::Foundation::AsyncStatus::Started)
+        {
+            status = wait_for_completed(async, 0xFFFFFFFF); // INFINITE
+        }
+        check_status_canceled(status);
+
+        return async.GetResults();
+    }
+
 #ifdef WINRT_IMPL_COROUTINES
     struct ignore_apartment_context {};
 
@@ -220,6 +233,11 @@ WINRT_EXPORT namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
     }
     template <typename D>
+    auto consume_Windows_Foundation_IAsyncAction<D>::get_only_safe_from_non_presenting_sta() const
+    {
+        impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D>
     auto consume_Windows_Foundation_IAsyncAction<D>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
     {
         return impl::wait_for(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)), timeout);
@@ -229,6 +247,11 @@ WINRT_EXPORT namespace winrt::impl
     auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get() const
     {
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TResult>
+    auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get_only_safe_from_non_presenting_sta() const
+    {
+        return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult>
     auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
@@ -242,6 +265,11 @@ WINRT_EXPORT namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TProgress>
+    auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::get_only_safe_from_non_presenting_sta() const
+    {
+        impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TProgress>
     auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::wait_for(Windows::Foundation::TimeSpan const& timeout) const
     {
         return impl::wait_for(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)), timeout);
@@ -251,6 +279,11 @@ WINRT_EXPORT namespace winrt::impl
     auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get() const
     {
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
+    }
+    template <typename D, typename TResult, typename TProgress>
+    auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get_only_safe_from_non_presenting_sta() const
+    {
+        return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult, typename TProgress>
     auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::wait_for(Windows::Foundation::TimeSpan const& timeout) const

--- a/strings/base_coroutine_foundation.h
+++ b/strings/base_coroutine_foundation.h
@@ -233,7 +233,7 @@ WINRT_EXPORT namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
     }
     template <typename D>
-    auto consume_Windows_Foundation_IAsyncAction<D>::get_only_safe_from_non_presenting_sta() const
+    auto consume_Windows_Foundation_IAsyncAction<D>::get_unchecked() const
     {
         impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncAction const&>(static_cast<D const&>(*this)));
     }
@@ -249,7 +249,7 @@ WINRT_EXPORT namespace winrt::impl
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult>
-    auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get_only_safe_from_non_presenting_sta() const
+    auto consume_Windows_Foundation_IAsyncOperation<D, TResult>::get_unchecked() const
     {
         return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperation<TResult> const&>(static_cast<D const&>(*this)));
     }
@@ -265,7 +265,7 @@ WINRT_EXPORT namespace winrt::impl
         impl::wait_get(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TProgress>
-    auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::get_only_safe_from_non_presenting_sta() const
+    auto consume_Windows_Foundation_IAsyncActionWithProgress<D, TProgress>::get_unchecked() const
     {
         impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncActionWithProgress<TProgress> const&>(static_cast<D const&>(*this)));
     }
@@ -281,7 +281,7 @@ WINRT_EXPORT namespace winrt::impl
         return impl::wait_get(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
     }
     template <typename D, typename TResult, typename TProgress>
-    auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get_only_safe_from_non_presenting_sta() const
+    auto consume_Windows_Foundation_IAsyncOperationWithProgress<D, TResult, TProgress>::get_unchecked() const
     {
         return impl::wait_get_bypass_sta_check(static_cast<Windows::Foundation::IAsyncOperationWithProgress<TResult, TProgress> const&>(static_cast<D const&>(*this)));
     }

--- a/test/test_nocoro/get.cpp
+++ b/test/test_nocoro/get.cpp
@@ -2,6 +2,7 @@
 
 using namespace winrt;
 using namespace Windows::Foundation;
+using namespace Windows::Storage;
 
 template<typename TResult>
 struct async_completion_source : implements<async_completion_source<TResult>, IAsyncOperation<TResult>, IAsyncInfo>
@@ -71,4 +72,36 @@ TEST_CASE("get")
     worker.detach();
 
     REQUIRE(acs.as<IAsyncOperation<uint32_t>>().get() == 0xDEADBEEF);
+}
+
+TEST_CASE("get_only_safe_from_non_presenting_sta")
+{
+    // Call a real WinRT async operation from an STA thread.
+    // This is the scenario the new API is designed for: an STA that is not
+    // presenting UI, where a synchronous blocking wait is safe.
+    std::exception_ptr failure{};
+    std::thread sta_thread([&failure]
+    {
+        try
+        {
+            winrt::init_apartment(winrt::apartment_type::single_threaded);
+
+            auto content = PathIO::ReadTextAsync(L"C:\\Windows\\win.ini").get_only_safe_from_non_presenting_sta();
+
+            REQUIRE(content.size() > 0);
+
+            winrt::uninit_apartment();
+        }
+        catch (...)
+        {
+            failure = std::current_exception();
+        }
+    });
+
+    sta_thread.join();
+
+    if (failure)
+    {
+        std::rethrow_exception(failure);
+    }
 }

--- a/test/test_nocoro/get.cpp
+++ b/test/test_nocoro/get.cpp
@@ -80,17 +80,22 @@ TEST_CASE("get_unchecked")
     // This is the scenario the new API is designed for: an STA that is not
     // presenting UI, where a synchronous blocking wait is safe.
     std::exception_ptr failure{};
-    std::thread sta_thread([&failure]
+    bool content_available = false;
+    std::thread sta_thread([&failure, &content_available]
     {
         try
         {
             winrt::init_apartment(winrt::apartment_type::single_threaded);
+            struct apartment_guard
+            {
+                ~apartment_guard()
+                {
+                    winrt::uninit_apartment();
+                }
+            } guard;
 
             auto content = PathIO::ReadTextAsync(L"C:\\Windows\\win.ini").get_unchecked();
-
-            REQUIRE(content.size() > 0);
-
-            winrt::uninit_apartment();
+            content_available = content.size() > 0;
         }
         catch (...)
         {
@@ -104,4 +109,6 @@ TEST_CASE("get_unchecked")
     {
         std::rethrow_exception(failure);
     }
+
+    REQUIRE(content_available);
 }

--- a/test/test_nocoro/get.cpp
+++ b/test/test_nocoro/get.cpp
@@ -74,7 +74,7 @@ TEST_CASE("get")
     REQUIRE(acs.as<IAsyncOperation<uint32_t>>().get() == 0xDEADBEEF);
 }
 
-TEST_CASE("get_only_safe_from_non_presenting_sta")
+TEST_CASE("get_unchecked")
 {
     // Call a real WinRT async operation from an STA thread.
     // This is the scenario the new API is designed for: an STA that is not
@@ -86,7 +86,7 @@ TEST_CASE("get_only_safe_from_non_presenting_sta")
         {
             winrt::init_apartment(winrt::apartment_type::single_threaded);
 
-            auto content = PathIO::ReadTextAsync(L"C:\\Windows\\win.ini").get_only_safe_from_non_presenting_sta();
+            auto content = PathIO::ReadTextAsync(L"C:\\Windows\\win.ini").get_unchecked();
 
             REQUIRE(content.size() > 0);
 

--- a/test/test_nocoro/pch.h
+++ b/test/test_nocoro/pch.h
@@ -2,5 +2,6 @@
 
 #include "catch.hpp"
 #include "winrt/Windows.Foundation.h"
+#include "winrt/Windows.Storage.h"
 
 using namespace std::literals;


### PR DESCRIPTION
## Summary

Add `get_unchecked()` as a peer to `.get()` on all four WinRT async interfaces (`IAsyncAction`, `IAsyncOperation`, `IAsyncActionWithProgress`, `IAsyncOperationWithProgress`). It synchronously waits for the operation and returns the same result as `.get()`, but deliberately skips the STA blocking assertion.

## Motivation

The existing `.get()` asserts `!is_sta_thread()` to guard against blocking a UI thread. However:

- **Not all STAs are UI threads** — some never present UI, have not presented UI yet, or never will.
- **The assert is `_DEBUG`-only** — `WINRT_ASSERT` is a no-op in release builds, making this protection invisible to codebases that do not build with `_DEBUG` (for example, the Windows OS).

`get_unchecked()` has the same synchronous wait and result/error behavior as `.get()`. Its only behavioral difference is that it does not call the STA check before waiting. Because blocking an STA that owns or presents UI can deadlock, callers must use this method only when they know the STA is non-presenting and the wait is safe.

## Changes

- **`strings/base_coroutine_foundation.h`**: Add the `wait_get_bypass_sta_check()` implementation helper and `get_unchecked()` definitions for all four async consume templates
- **`cppwinrt/code_writers.h`**: Add the `get_unchecked()` declaration to generated output for all four async types, with a comment documenting the safety contract
- **`test/test_nocoro`**: Add a test that calls `get_unchecked()` from an STA thread using a real WinRT async operation (`PathIO::ReadTextAsync` on `C:\Windows\win.ini`)

## Testing

The existing STA-specific test exercises the new API on a non-presenting STA and verifies that the asynchronous operation completes successfully. A local `test_nocoro` build with the newest MSVC toolset is currently blocked by the toolchain's hard error for the deprecated `<experimental/coroutine>` header; the repository's C++17 `/await:strict` configuration needs a separate compatibility fix.
