### PR TITLE
Move operator<< to winrt::Windows::Foundation

### DIFF
--- a/strings/base_stringable_streams.h
+++ b/strings/base_stringable_streams.h
@@ -1,8 +1,11 @@
 
 #ifndef WINRT_LEAN_AND_MEAN
-inline std::wostream& operator<<(std::wostream& stream, winrt::Windows::Foundation::IStringable const& stringable)
+namespace winrt::Windows::Foundation
 {
-    stream << stringable.ToString();
-    return stream;
+    inline std::wostream& operator<<(std::wostream& stream, winrt::Windows::Foundation::IStringable const& stringable)
+    {
+        stream << stringable.ToString();
+        return stream;
+    }
 }
 #endif


### PR DESCRIPTION
This `operator<<` overload can be found directly by ADL, so it does not need to be placed in the global namespace (this has already been done for [the `hstring` overload](https://github.com/microsoft/cppwinrt/blob/a5e9452e6858849496e61c166ab8510d3acaec2a/strings/base_string_operators.h#L165-L169)). This helps avoid outputting information about this overload when `operator<<` is called incorrectly, and speeds up compilation.