### PR TITLE
Clean up the remaining workaround of fast_fwd.h

### DIFF
--- a/strings/base_fast_forward.h
+++ b/strings/base_fast_forward.h
@@ -30,11 +30,7 @@ static_assert(WINRT_FAST_ABI_SIZE >= %);
 
 #pragma detect_mismatch("WINRT_FAST_ABI_SIZE", WINRT_IMPL_STRING(WINRT_FAST_ABI_SIZE))
 
-#ifndef WINRT_EXPORT
-#define WINRT_EXPORT
-#endif // WINRT_EXPORT
-
-WINRT_EXPORT namespace winrt::impl
+namespace winrt::impl
 {
     // Thunk definitions are in arch-specific assembly sources
 %


### PR DESCRIPTION
This PR reverts the module v2's modifications to this file, as those changes are meaningless. I originally introduced these changes in my own branch, and they were inherited by module v2. Supporting fastabi with the winrt module requires further modifications to base_fast_forward.h and the generator, so there is no need to keep them for now.