### PR TITLE
Massive speedup to file_equal and file_to_string

### DIFF
--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -13,8 +13,12 @@ namespace cppwinrt
 {
     inline std::string file_to_string(std::string const& filename)
     {
-        std::ifstream file(filename, std::ios::binary);
-        return static_cast<std::stringstream const&>(std::stringstream() << file.rdbuf()).str();
+        std::ifstream file(filename, std::ios::binary | std::ios::ate);
+        const auto size = file.tellg();
+        file.seekg(0);
+        std::string result(size, '\0');
+        file.read(result.data(), size);
+        return result;
     }
 
     template <typename T>
@@ -218,17 +222,12 @@ namespace cppwinrt
 
         bool file_equal(std::string const& filename) const
         {
-            if (!std::filesystem::exists(filename))
+            if (!std::filesystem::exists(filename) || std::filesystem::file_size(filename) != m_first.size() + m_second.size())
             {
                 return false;
             }
 
             auto file = file_to_string(filename);
-
-            if (file.size() != m_first.size() + m_second.size())
-            {
-                return false;
-            }
 
             if (!std::equal(m_first.begin(), m_first.end(), file.begin(), file.begin() + m_first.size()))
             {

--- a/cppwinrt/text_writer.h
+++ b/cppwinrt/text_writer.h
@@ -14,10 +14,24 @@ namespace cppwinrt
     inline std::string file_to_string(std::string const& filename)
     {
         std::ifstream file(filename, std::ios::binary | std::ios::ate);
-        const auto size = file.tellg();
+        if (!file) { return{}; }
+
+        const auto stream_size = file.tellg();
+        if (stream_size == std::ifstream::pos_type(-1))
+        {
+            return {};
+        }
+
         file.seekg(0);
+
+        auto size = static_cast<std::size_t>(stream_size);
         std::string result(size, '\0');
         file.read(result.data(), size);
+        if (!file)
+        {
+            result.resize(static_cast<std::size_t>(file.gcount()));
+        }
+
         return result;
     }
 
@@ -222,7 +236,9 @@ namespace cppwinrt
 
         bool file_equal(std::string const& filename) const
         {
-            if (!std::filesystem::exists(filename) || std::filesystem::file_size(filename) != m_first.size() + m_second.size())
+            // Non-throwing file_size returns uintmax_t(-1) on errors, which shouldn't ever be the size of m_first or m_second
+            std::error_code ec;
+            if (std::filesystem::file_size(filename, ec) != m_first.size() + m_second.size())
             {
                 return false;
             }


### PR DESCRIPTION
I was testing some quality of life improvements, and I saw that in incremental situations when there are already headers in the output folder, cppwinrt.exe takes twice as long to run!

Before writing pending output, it reads the existing file in and compares it, skipping the write if the contents are identical. The comparison itself is fast enough, using `std::equal` which boils down to `memcmp`, but the read is using `std::ifstream::operator<<` to read a `std::string`, and this operation processes the file contents a single character at a time, resulting in tons of overhead.

With this change, we now do a single bulk read of the file contents. Additionally, before we read the contents, we check the file size in the filesystem *before* reading the contents, allowing us to short-circuit even faster.

A before/after comparison on a Release x64 run of regenerating the local SDK projection without cleaning the output folder first, shows a 50% speedup in wall clock time.

Here's the results from an instrumented profile run in Visual Studio.
Before:
<img width="1475" height="790" alt="image" src="https://github.com/user-attachments/assets/1d692cc1-db83-4892-91ee-77ca60efc838" />
<img width="1473" height="425" alt="image" src="https://github.com/user-attachments/assets/d328938c-2959-4ac3-9e39-01ffdf5f12c9" />

After:
<img width="1475" height="793" alt="image" src="https://github.com/user-attachments/assets/f75f454f-de5a-41f8-a844-d00dccce1948" />
<img width="1471" height="427" alt="image" src="https://github.com/user-attachments/assets/7ab1026c-2069-4e5d-bd45-011711e2413c" />
