### PR TITLE
base_identity.h: added missing constexpr

### DIFF
--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -11,7 +11,7 @@ WINRT_EXPORT namespace winrt
     }
 
     template <typename... T>
-    bool is_guid_of(guid const& id) noexcept
+    constexpr bool is_guid_of(guid const& id) noexcept
     {
         return ((id == guid_of<T>()) || ...);
     }


### PR DESCRIPTION
Added missing constexpr to is_guid_of helper.

guid_of is already constexpr: https://github.com/microsoft/cppwinrt/blob/55f1b452aca069d6ac7eaad3e05cc1058fc39d27/strings/base_identity.h#L8

and find_iid_traits::test is constexpr and calls is_guid_of: https://github.com/microsoft/cppwinrt/blob/55f1b452aca069d6ac7eaad3e05cc1058fc39d27/strings/base_implements.h#L395
