### PR TITLE
Stop exporting winrt::impl::get_marshaler to workaround MSVC modules bug

### DIFF
--- a/strings/base_marshaler.h
+++ b/strings/base_marshaler.h
@@ -1,5 +1,5 @@
 
-WINRT_EXPORT namespace winrt::impl
+namespace winrt::impl
 {
     inline std::int32_t make_marshaler(unknown_abi* outer, void** result) noexcept
     {

--- a/test/test_cpp20_module/marshal.cpp
+++ b/test/test_cpp20_module/marshal.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+#include <objidl.h>
+
+import std;
+import winrt.Windows.Foundation.Collections;
+
+using namespace winrt;
+
+struct S : implements<S, Windows::Foundation::IStringable>
+{
+    hstring ToString()
+    {
+        return L"S";
+    }
+};
+
+// When winrt::impl::get_marshaler was being exported, an MSVC bug caused the marshaler
+// object to have a null vtable, which caused a crash when calling any method on the marshaler.
+// This test ensures that the marshaler vtable is properly initialized.
+TEST_CASE("IMarshal")
+{
+    auto s = make<S>();
+    auto marshal = s.as<IMarshal>();
+}

--- a/test/test_cpp20_module/marshal.cpp
+++ b/test/test_cpp20_module/marshal.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include <objidl.h>
+#include <winrt/base.h>
 
 import std;
 import winrt.Windows.Foundation.Collections;

--- a/test/test_cpp20_module/test_cpp20_module.vcxproj
+++ b/test/test_cpp20_module/test_cpp20_module.vcxproj
@@ -25,7 +25,8 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-  </ItemGroup>  <PropertyGroup Label="Globals">
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{B8E3A5CE-4E91-4F27-9B02-E0CAF7E10D72}</ProjectGuid>
     <RootNamespace>test_cpp20_module</RootNamespace>
@@ -91,6 +92,7 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="marshal.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>


### PR DESCRIPTION
An MSVC bug was revealed where the combination of `export extern "C++"`, a function-local type in an inline function, and that type having a user-defined constructor, causes that constructed object to have a zero-filled vtable. So calling any virtual function causes a crash.

This affected `winrt::impl::get_marshaler()`, responsible for constructing the implementation of `IMarshal` for `winrt::implements`.

Verified this bug by adding a case to `test_cpp20_module` that constructs an `implements` object, and queries for `IMarshal`. The ensuing call to `Release()` via that interface causes a crash.

Since `winrt::impl::get_marshaler()` is an implementation detail that doesn't need to be exported (and we are planning to reduce spurious exports anyway), it makes sense to stop exporting this function. This change is sufficient to workaround the MSVC bug and the test now passes.

Fixes: #1590
