### PR TITLE
Output the module intermediate files to `$(IntDir)Microsoft\cppwinrt\`

### DIFF
--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -917,6 +917,10 @@ $(XamlMetaDataProviderPch)
                 <CompileAs>CompileAsCppModule</CompileAs>
                 <ModulesSupported>true</ModulesSupported>
                 <PrecompiledHeader>NotUsing</PrecompiledHeader>
+                <ModuleOutputFile>$(IntDir)Microsoft\cppwinrt\</ModuleOutputFile>
+                <ObjectFileName>$(IntDir)Microsoft\cppwinrt\</ObjectFileName>
+                <ModuleDependenciesFile>$(IntDir)Microsoft\cppwinrt\</ModuleDependenciesFile>
+                <SourceDependenciesFile>$(IntDir)Microsoft\cppwinrt\</SourceDependenciesFile>
             </ClCompile>
         </ItemGroup>
     </Target>
@@ -924,7 +928,7 @@ $(XamlMetaDataProviderPch)
     <!--
       When CppWinRTBuildModule is true, export the generated files directory and IFC output
       directory so that consuming projects can resolve them via ProjectReference.
-      The IFC files are written to IntDir by MSBuild's module build system.
+      The IFC files are written to '$(IntDir)Microsoft\cppwinrt\' by MSBuild's module build system.
     -->
     <Target Name="CppWinRTGetModuleOutputs"
             Condition="'$(CppWinRTBuildModule)'=='true'"
@@ -932,8 +936,7 @@ $(XamlMetaDataProviderPch)
         <ItemGroup>
             <CppWinRTModuleOutputs Include="$(MSBuildProjectFullPath)">
                 <CppWinRTModuleGeneratedFilesDir>$(GeneratedFilesDir)</CppWinRTModuleGeneratedFilesDir>
-                <CppWinRTModuleIfcDir>$(IntDir)</CppWinRTModuleIfcDir>
-                <CppWinRTModuleLibDir>$(OutDir)</CppWinRTModuleLibDir>
+                <CppWinRTModuleIfcDir>$(IntDir)Microsoft\cppwinrt\</CppWinRTModuleIfcDir>
             </CppWinRTModuleOutputs>
         </ItemGroup>
     </Target>

--- a/nuget/Microsoft.Windows.CppWinRT.targets
+++ b/nuget/Microsoft.Windows.CppWinRT.targets
@@ -920,7 +920,6 @@ $(XamlMetaDataProviderPch)
                 <ModuleOutputFile>$(IntDir)Microsoft\cppwinrt\</ModuleOutputFile>
                 <ObjectFileName>$(IntDir)Microsoft\cppwinrt\</ObjectFileName>
                 <ModuleDependenciesFile>$(IntDir)Microsoft\cppwinrt\</ModuleDependenciesFile>
-                <SourceDependenciesFile>$(IntDir)Microsoft\cppwinrt\</SourceDependenciesFile>
             </ClCompile>
         </ItemGroup>
     </Target>


### PR DESCRIPTION
This path follows the conventions used by the compiler and the STL (the STL uses the path $(IntDir)Microsoft\STL), avoiding mixing library intermediate files with those of the project files.

The PR also removed CppWinRTModuleLibDir because it appeared in isolation, was unused, and had no explanation.