### PR TITLE
Remove WINRT_EXPORT in Component.g.cpp

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -226,6 +226,17 @@ namespace cppwinrt
         return { w, write_close_namespace };
     }
 
+    [[nodiscard]] static finish_with wrap_type_namespace_without_export(writer& w, std::string_view const& ns)
+    {
+        auto format = R"(namespace winrt::@
+{
+)";
+
+        w.write(format, ns);
+
+        return { w, write_close_namespace };
+    }
+
     static void write_enum_field(writer& w, Field const& field)
     {
         auto format = R"(        % = %,

--- a/cppwinrt/component_writers.h
+++ b/cppwinrt/component_writers.h
@@ -400,7 +400,7 @@ catch (...) { return winrt::to_hresult(); }
             return;
         }
 
-        auto wrap_type = wrap_type_namespace(w, type_namespace);
+        auto wrap_type = wrap_type_namespace_without_export(w, type_namespace);
 
         for (auto&&[factory_name, factory] : get_factories(w, type))
         {


### PR DESCRIPTION
The WINRT_EXPORT namespace block here only contains definitions of the component's member functions, so it is meaningless.