### PR TITLE
Fix race condition in cancellation setup/teardown

### DIFF
--- a/strings/base_coroutine_threadpool.h
+++ b/strings/base_coroutine_threadpool.h
@@ -146,32 +146,42 @@ WINRT_EXPORT namespace winrt
         void set_canceller(canceller_t canceller, void* context)
         {
             m_context = context;
-            m_canceller.store(canceller, std::memory_order_release);
+            canceller_t expected = nullptr;
+            m_canceller.compare_exchange_strong(expected, canceller, std::memory_order_release, std::memory_order_relaxed);
         }
 
         void revoke_canceller()
         {
-            while (m_canceller.exchange(nullptr, std::memory_order_acquire) == cancelling_ptr)
+            auto existing = m_canceller.load(std::memory_order_relaxed);
+            do
             {
-                std::this_thread::yield();
+                while (existing == cancelling_ptr)
+                {
+                    std::this_thread::yield();
+                    existing = m_canceller.load(std::memory_order_relaxed);
+                }
             }
+            while (!m_canceller.compare_exchange_weak(existing, nullptr, std::memory_order_acquire, std::memory_order_relaxed));
         }
 
         void cancel()
         {
             auto canceller = m_canceller.exchange(cancelling_ptr, std::memory_order_acquire);
-            struct unique_cancellation_lock
+            if (canceller != cancelling_ptr)
             {
-                cancellable_promise* promise;
-                ~unique_cancellation_lock()
+                struct unique_cancellation_lock
                 {
-                    promise->m_canceller.store(nullptr, std::memory_order_release);
-                }
-            } lock{ this };
+                    cancellable_promise* promise;
+                    ~unique_cancellation_lock()
+                    {
+                        promise->m_canceller.store(nullptr, std::memory_order_release);
+                    }
+                } lock{ this };
 
-            if ((canceller != nullptr) && (canceller != cancelling_ptr))
-            {
-                canceller(m_context);
+                if (canceller != nullptr)
+                {
+                    canceller(m_context);
+                }
             }
         }
 


### PR DESCRIPTION
The code failed to handle three cases.

1. A cancellation is in progress when a cancellable awaitable begins.
2. A cancellation is in progress when a cancellable awaitable ends.
3. A cancellation is in progress when a cancel() request is made.

The m_canceller member has one of these three values:

* nullptr, meaning that there is nothing to cancel. It has this value when the coroutine is not awaiting, or if it is awaiting something that cannot be cancelled.
* cancelling_ptr, meaning that another thread (not the coroutine thread) is in the middle of cancellation request.
* function pointer, representing the function to call to cancel the await.

In case 1, we should not overwrite the canceling_ptr with the function pointer, because only the code doing the cancel() can transition into/out of cancelling_ptr.

In case 2, we intended to spin until the m_canceller is no longer cancelling_ptr, but we used m_canceller.exchange(nullptr) in a loop, which means that if m_canceller was cancelling_ptr, we overwrite it with nullptr. As a result, the "while" loop always exits after one iteration. We need to spin on the m_canceller without modifying it if it is cancelling_ptr.

In case 3, cancel() function resets m_cancelling back to nullptr, even if the value was cancelling_ptr on entry, prematurely declaring that the existing cancel() has completed. If the original value was cancelling_ptr, we should leave it that way.

There are still other cases not handled:

* Coroutine already cancelled when a co_await starts.

In this case, we never call the canceller, so the coroutine fails to propagate cancellation. This will require a broader fix, so I'm not going to fix it in this PR. This PR is primarily about fixing the crash caused by case 2. Cases 1 and 3 were fixed opportunistically.