### PR TITLE
Optimize `to_string`

### DIFF
--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -717,7 +717,7 @@ WINRT_EXPORT namespace winrt
     	result.resize_and_overwrite(size, [&](char* buffer, std::size_t) -> std::size_t
     		{
     			auto bytes_written = WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, size, nullptr, nullptr);
-                WINRT_VERIFY_(size, bytes_written);
+    			WINRT_VERIFY_(size, bytes_written);
     			return bytes_written == size ? size : 0;
     		});
 #else

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -720,8 +720,8 @@ WINRT_EXPORT namespace winrt
     			return size;
     		});
 #else
-    	std::string result(size, '?');
-    	WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), result.data(), size, nullptr, nullptr));
+        std::string result(size, '?');
+        WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), result.data(), size, nullptr, nullptr));
 #endif
         return result;
     }

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -674,14 +674,7 @@ WINRT_EXPORT namespace winrt
     template <typename T, std::enable_if_t<std::is_same_v<T, bool>, int> = 0>
     hstring to_hstring(T const value)
     {
-        if (value)
-        {
-            return hstring{ L"true" };
-        }
-        else
-        {
-            return hstring{ L"false" };
-        }
+        return hstring{ value ? L"true" : L"false" };
     }
 
     inline hstring to_hstring(guid const& value)
@@ -719,8 +712,17 @@ WINRT_EXPORT namespace winrt
             return{};
         }
 
-        std::string result(size, '?');
-        WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), result.data(), size, nullptr, nullptr));
+#if defined(__cpp_lib_string_resize_and_overwrite) && __cpp_lib_string_resize_and_overwrite >= 202110L
+    	std::string result;
+    	result.resize_and_overwrite(size, [&](char* buffer, std::size_t) -> std::size_t
+    		{
+    			WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, size, nullptr, nullptr));
+    			return size;
+    		});
+#else
+    	std::string result(size, '?');
+    	WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), result.data(), size, nullptr, nullptr));
+#endif
         return result;
     }
 }

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -674,8 +674,14 @@ WINRT_EXPORT namespace winrt
     template <typename T, std::enable_if_t<std::is_same_v<T, bool>, int> = 0>
     hstring to_hstring(T const value)
     {
-        using namespace std::literals;
-        return hstring{value ? L"true"sv : L"false"sv};
+        if (value)
+        {
+            return hstring{ L"true" };
+        }
+        else
+        {
+            return hstring{ L"false" };
+        }
     }
 
     inline hstring to_hstring(guid const& value)

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -721,11 +721,11 @@ WINRT_EXPORT namespace winrt
 
 #if defined(__cpp_lib_string_resize_and_overwrite) && __cpp_lib_string_resize_and_overwrite >= 202110L
     	std::string result;
-    	result.resize_and_overwrite(size, [&](char* buffer, std::size_t) -> std::size_t
+    	result.resize_and_overwrite(size, [value](char* buffer, std::size_t size) -> std::size_t
     		{
-    			auto bytes_written = WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, size, nullptr, nullptr);
+    			auto bytes_written = WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, static_cast<std::int32_t>(size), nullptr, nullptr);
     			WINRT_VERIFY_(size, bytes_written);
-    			return bytes_written == size ? size : 0;
+    			return bytes_written;
     		});
 #else
         std::string result(size, '?');

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -674,7 +674,8 @@ WINRT_EXPORT namespace winrt
     template <typename T, std::enable_if_t<std::is_same_v<T, bool>, int> = 0>
     hstring to_hstring(T const value)
     {
-        return hstring{ value ? L"true" : L"false" };
+        using namespace std::literals;
+        return hstring{value ? L"true"sv : L"false"sv};
     }
 
     inline hstring to_hstring(guid const& value)

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -716,8 +716,9 @@ WINRT_EXPORT namespace winrt
     	std::string result;
     	result.resize_and_overwrite(size, [&](char* buffer, std::size_t) -> std::size_t
     		{
-    			WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, size, nullptr, nullptr));
-    			return size;
+    			auto bytes_written = WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), buffer, size, nullptr, nullptr);
+                WINRT_VERIFY_(size, bytes_written);
+    			return bytes_written == size ? size : 0;
     		});
 #else
         std::string result(size, '?');


### PR DESCRIPTION
C++23 added `resize_and_overwrite` to avoid the problem of initializing the entire string to zero during `resize`. `winrt::to_hstring(std::string_view)` can take advantage of this feature.