### PR TITLE
Fix integral conversion and brace elision warnings

### DIFF
--- a/strings/base_collections_base.h
+++ b/strings/base_collections_base.h
@@ -123,7 +123,7 @@ WINRT_EXPORT namespace winrt
             }
             else
             {
-                return std::transform(first, std::next(first, count), result, [&](auto&& value)
+                return std::transform(first, std::next(first, static_cast<std::ptrdiff_t>(count)), result, [&](auto&& value)
                 {
                     if constexpr (!impl::is_key_value_pair<T>::value)
                     {
@@ -217,7 +217,7 @@ WINRT_EXPORT namespace winrt
             {
                 std::uint32_t const actual = (std::min)(static_cast<std::uint32_t>(m_end - m_current), values.size());
                 m_owner->copy_n(m_current, actual, values.begin());
-                m_current += actual;
+                m_current += static_cast<std::ptrdiff_t>(actual);
                 return actual;
             }
 
@@ -254,7 +254,7 @@ WINRT_EXPORT namespace winrt
                 throw hresult_out_of_bounds();
             }
 
-            return static_cast<D const&>(*this).unwrap_value(*std::next(static_cast<D const&>(*this).get_container().begin(), index));
+            return static_cast<D const&>(*this).unwrap_value(*std::next(static_cast<D const&>(*this).get_container().begin(), static_cast<std::ptrdiff_t>(index)));
         }
 
         std::uint32_t Size() const noexcept
@@ -284,7 +284,7 @@ WINRT_EXPORT namespace winrt
             }
 
             std::uint32_t const actual = (std::min)(container_size() - startIndex, values.size());
-            this->copy_n(static_cast<D const&>(*this).get_container().begin() + startIndex, actual, values.begin());
+            this->copy_n(static_cast<D const&>(*this).get_container().begin() + static_cast<std::ptrdiff_t>(startIndex), actual, values.begin());
             return actual;
         }
 
@@ -329,7 +329,7 @@ WINRT_EXPORT namespace winrt
             }
 
             this->increment_version();
-            static_cast<D&>(*this).get_container().insert(static_cast<D const&>(*this).get_container().begin() + index, static_cast<D const&>(*this).wrap_value(value));
+            static_cast<D&>(*this).get_container().insert(static_cast<D const&>(*this).get_container().begin() + static_cast<std::ptrdiff_t>(index), static_cast<D const&>(*this).wrap_value(value));
         }
 
         void RemoveAt(std::uint32_t const index)
@@ -343,7 +343,7 @@ WINRT_EXPORT namespace winrt
             }
 
             this->increment_version();
-            auto itr = static_cast<D&>(*this).get_container().begin() + index;
+            auto itr = static_cast<D&>(*this).get_container().begin() + static_cast<std::ptrdiff_t>(index);
             removedValue.assign(*itr);
             static_cast<D&>(*this).get_container().erase(itr);
         }

--- a/strings/base_collections_vector.h
+++ b/strings/base_collections_vector.h
@@ -149,7 +149,7 @@ WINRT_EXPORT namespace winrt::impl
 
             std::uint32_t const actual = (std::min)(static_cast<std::uint32_t>(m_values.size() - startIndex), values.size());
 
-            std::transform(m_values.begin() + startIndex, m_values.begin() + startIndex + actual, values.begin(), [&](auto && value)
+            std::transform(m_values.begin() + static_cast<std::ptrdiff_t>(startIndex), m_values.begin() + static_cast<std::ptrdiff_t>(startIndex) + static_cast<std::ptrdiff_t>(actual), values.begin(), [&](auto && value)
                 {
                     return box_value(value);
                 });
@@ -274,12 +274,12 @@ WINRT_EXPORT namespace winrt::impl
                 check_version(*m_owner);
                 std::uint32_t const actual = (std::min)(static_cast<std::uint32_t>(std::distance(m_current, m_end)), values.size());
 
-                std::transform(m_current, m_current + actual, values.begin(), [&](auto && value)
+                std::transform(m_current, m_current + static_cast<std::ptrdiff_t>(actual), values.begin(), [&](auto && value)
                     {
                         return box_value(value);
                     });
 
-                std::advance(m_current, actual);
+                std::advance(m_current, static_cast<std::ptrdiff_t>(actual));
                 return actual;
             }
 

--- a/strings/base_error.h
+++ b/strings/base_error.h
@@ -60,7 +60,7 @@ WINRT_EXPORT namespace winrt::impl
 
         std::uint32_t const size = WINRT_IMPL_FormatMessageW(0x00001300, // FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS
             nullptr,
-            code,
+            static_cast<std::uint32_t>(code),
             0x00000400, // MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)
             reinterpret_cast<wchar_t*>(message.put()),
             0,

--- a/strings/base_events.h
+++ b/strings/base_events.h
@@ -516,7 +516,7 @@ WINRT_EXPORT namespace winrt
 
         event_token get_token(delegate_type const& delegate) const noexcept
         {
-            return event_token{ reinterpret_cast<std::int64_t>(WINRT_IMPL_EncodePointer(get_abi(delegate))) };
+            return event_token{ static_cast<std::int64_t>(reinterpret_cast<std::uintptr_t>(WINRT_IMPL_EncodePointer(get_abi(delegate)))) };
         }
 
         using delegate_array = com_ptr<impl::event_array<delegate_type>>;

--- a/strings/base_identity.h
+++ b/strings/base_identity.h
@@ -22,7 +22,7 @@ WINRT_EXPORT namespace winrt::impl
     template <std::size_t Size, typename T, std::size_t... Index>
     constexpr std::array<T, Size> to_array(T const* value, std::index_sequence<Index...> const) noexcept
     {
-        return { value[Index]... };
+        return {{ value[Index]... }};
     }
 
     template <typename T, std::size_t Size>
@@ -50,7 +50,7 @@ WINRT_EXPORT namespace winrt::impl
         std::index_sequence<LeftIndex...> const,
         std::index_sequence<RightIndex...> const) noexcept
     {
-        return { left[LeftIndex]..., right[RightIndex]... };
+        return {{ left[LeftIndex]..., right[RightIndex]... }};
     }
 
     template <typename T, std::size_t LeftSize, std::size_t RightSize>
@@ -99,7 +99,7 @@ WINRT_EXPORT namespace winrt::impl
     template <typename T, std::size_t LS, std::size_t RS, std::size_t... LI, std::size_t... RI>
     constexpr std::array<T, LS + RS - 1> zconcat_base(std::array<T, LS> const& left, std::array<T, RS> const& right, std::index_sequence<LI...> const, std::index_sequence<RI...> const) noexcept
     {
-        return { left[LI]..., right[RI]..., T{} };
+        return {{ left[LI]..., right[RI]..., T{} }};
     }
 
     template <typename T, std::size_t LS, std::size_t RS>
@@ -111,7 +111,7 @@ WINRT_EXPORT namespace winrt::impl
     template <typename T, std::size_t S, std::size_t... I>
     constexpr std::array<T, S> to_zarray_base(T const(&value)[S], std::index_sequence<I...> const) noexcept
     {
-        return { value[I]... };
+        return {{ value[I]... }};
     }
 
     template <typename T, std::size_t S>
@@ -141,43 +141,43 @@ WINRT_EXPORT namespace winrt::impl
 
     constexpr std::array<std::uint8_t, 4> to_array(std::uint32_t value) noexcept
     {
-        return { static_cast<std::uint8_t>(value & 0x000000ff), static_cast<std::uint8_t>((value & 0x0000ff00) >> 8), static_cast<std::uint8_t>((value & 0x00ff0000) >> 16), static_cast<std::uint8_t>((value & 0xff000000) >> 24) };
+        return {{ static_cast<std::uint8_t>(value & 0x000000ff), static_cast<std::uint8_t>((value & 0x0000ff00) >> 8), static_cast<std::uint8_t>((value & 0x00ff0000) >> 16), static_cast<std::uint8_t>((value & 0xff000000) >> 24) }};
     }
 
     constexpr std::array<std::uint8_t, 2> to_array(std::uint16_t value) noexcept
     {
-        return { static_cast<std::uint8_t>(value & 0x00ff), static_cast<std::uint8_t>((value & 0xff00) >> 8) };
+        return {{ static_cast<std::uint8_t>(value & 0x00ff), static_cast<std::uint8_t>((value & 0xff00) >> 8) }};
     }
 
     constexpr auto to_array(guid const& value) noexcept
     {
         return combine(to_array(value.Data1), to_array(value.Data2), to_array(value.Data3),
-            std::array<std::uint8_t, 8>{ value.Data4[0], value.Data4[1], value.Data4[2], value.Data4[3], value.Data4[4], value.Data4[5], value.Data4[6], value.Data4[7] });
+            std::array<std::uint8_t, 8>{{ value.Data4[0], value.Data4[1], value.Data4[2], value.Data4[3], value.Data4[4], value.Data4[5], value.Data4[6], value.Data4[7] }});
     }
 
     template <typename T>
     constexpr T to_hex_digit(std::uint8_t value) noexcept
     {
         value &= 0xF;
-        return value < 10 ? static_cast<T>('0') + value : static_cast<T>('a') + (value - 10);
+        return value < 10 ? static_cast<T>('0' + value) : static_cast<T>('a' + (value - 10));
     }
 
     template <typename T>
     constexpr std::array<T, 2> uint8_to_hex(std::uint8_t const value) noexcept
     {
-        return { to_hex_digit<T>(value >> 4), to_hex_digit<T>(value & 0xF) };
+        return {{ to_hex_digit<T>(static_cast<std::uint8_t>(value >> 4)), to_hex_digit<T>(static_cast<std::uint8_t>(value & 0xF)) }};
     }
 
     template <typename T>
     constexpr auto uint16_to_hex(std::uint16_t value) noexcept
     {
-        return combine(uint8_to_hex<T>(static_cast<std::uint8_t>(value >> 8)), uint8_to_hex<T>(value & 0xFF));
+        return combine(uint8_to_hex<T>(static_cast<std::uint8_t>(value >> 8)), uint8_to_hex<T>(static_cast<std::uint8_t>(value & 0xFF)));
     }
 
     template <typename T>
     constexpr auto uint32_to_hex(std::uint32_t const value) noexcept
     {
-        return combine(uint16_to_hex<T>(value >> 16), uint16_to_hex<T>(value & 0xFFFF));
+        return combine(uint16_to_hex<T>(static_cast<std::uint16_t>(value >> 16)), uint16_to_hex<T>(static_cast<std::uint16_t>(value & 0xFFFF)));
     }
 
     template <typename T>
@@ -185,15 +185,15 @@ WINRT_EXPORT namespace winrt::impl
     {
         return combine
         (
-            std::array<T, 1>{'{'},
-            uint32_to_hex<T>(value.Data1), std::array<T, 1>{'-'},
-            uint16_to_hex<T>(value.Data2), std::array<T, 1>{'-'},
-            uint16_to_hex<T>(value.Data3), std::array<T, 1>{'-'},
-            uint16_to_hex<T>(value.Data4[0] << 8 | value.Data4[1]), std::array<T, 1>{'-'},
-            uint16_to_hex<T>(value.Data4[2] << 8 | value.Data4[3]),
-            uint16_to_hex<T>(value.Data4[4] << 8 | value.Data4[5]),
-            uint16_to_hex<T>(value.Data4[6] << 8 | value.Data4[7]),
-            std::array<T, 1>{'}'}
+            std::array<T, 1>{{'{'}},
+            uint32_to_hex<T>(value.Data1), std::array<T, 1>{{'-'}},
+            uint16_to_hex<T>(value.Data2), std::array<T, 1>{{'-'}},
+            uint16_to_hex<T>(value.Data3), std::array<T, 1>{{'-'}},
+            uint16_to_hex<T>(static_cast<std::uint16_t>(value.Data4[0] << 8 | value.Data4[1])), std::array<T, 1>{{'-'}},
+            uint16_to_hex<T>(static_cast<std::uint16_t>(value.Data4[2] << 8 | value.Data4[3])),
+            uint16_to_hex<T>(static_cast<std::uint16_t>(value.Data4[4] << 8 | value.Data4[5])),
+            uint16_to_hex<T>(static_cast<std::uint16_t>(value.Data4[6] << 8 | value.Data4[7])),
+            std::array<T, 1>{{'}'}}
         );
     }
 
@@ -226,7 +226,7 @@ WINRT_EXPORT namespace winrt::impl
 
     constexpr std::uint16_t endian_swap(std::uint16_t value) noexcept
     {
-        return (value & 0xFF00) >> 8 | (value & 0x00FF) << 8;
+        return static_cast<std::uint16_t>((value & 0xFF00) >> 8 | (value & 0x00FF) << 8);
     }
 
     constexpr guid endian_swap(guid value) noexcept
@@ -247,7 +247,7 @@ WINRT_EXPORT namespace winrt::impl
     template <typename T, std::size_t Size, std::size_t... Index>
     constexpr std::array<std::uint8_t, Size> char_to_byte_array(std::array<T, Size> const& value, std::index_sequence<Index...> const) noexcept
     {
-        return { static_cast<std::uint8_t>(value[Index])... };
+        return {{ static_cast<std::uint8_t>(value[Index])... }};
     }
 
     constexpr auto sha1_rotl(std::uint8_t bits, std::uint32_t word) noexcept
@@ -337,7 +337,7 @@ WINRT_EXPORT namespace winrt::impl
             A = temp;
         }
 
-        return { intermediate_hash[0] + A, intermediate_hash[1] + B, intermediate_hash[2] + C, intermediate_hash[3] + D, intermediate_hash[4] + E };
+        return {{ intermediate_hash[0] + A, intermediate_hash[1] + B, intermediate_hash[2] + C, intermediate_hash[3] + D, intermediate_hash[4] + E }};
     }
 
     template <std::size_t Size>
@@ -349,7 +349,7 @@ WINRT_EXPORT namespace winrt::impl
     constexpr std::array<std::uint8_t, 8> size_to_bytes(std::size_t size) noexcept
     {
         return
-        {
+        {{
             static_cast<std::uint8_t>((size & 0xff00000000000000) >> 56),
             static_cast<std::uint8_t>((size & 0x00ff000000000000) >> 48),
             static_cast<std::uint8_t>((size & 0x0000ff0000000000) >> 40),
@@ -358,13 +358,13 @@ WINRT_EXPORT namespace winrt::impl
             static_cast<std::uint8_t>((size & 0x0000000000ff0000) >> 16),
             static_cast<std::uint8_t>((size & 0x000000000000ff00) >> 8),
             static_cast<std::uint8_t>((size & 0x00000000000000ff) >> 0)
-        };
+        }};
     }
 
     template <std::size_t Size, std::size_t RemainingSize, std::size_t... Index>
     constexpr std::array<std::uint8_t, RemainingSize + 1> make_remaining([[maybe_unused]] std::array<std::uint8_t, Size> const& input, [[maybe_unused]] std::size_t start_pos, std::index_sequence<Index...>) noexcept
     {
-        return { input[Index + start_pos]..., 0x80 };
+        return {{ input[Index + start_pos]..., 0x80 }};
     }
 
     template <std::size_t Size>
@@ -402,7 +402,7 @@ WINRT_EXPORT namespace winrt::impl
     template <std::size_t... Index>
     constexpr std::array<std::uint8_t, 20> get_result(std::array<std::uint32_t, 5> const& intermediate_hash, std::index_sequence<Index...>) noexcept
     {
-        return { static_cast<std::uint8_t>(intermediate_hash[Index >> 2] >> (8 * (3 - (Index & 0x03))))... };
+        return {{ static_cast<std::uint8_t>(intermediate_hash[Index >> 2] >> (8 * (3 - (Index & 0x03))))... }};
     }
 
     constexpr auto get_result(std::array<std::uint32_t, 5> const& intermediate_hash) noexcept
@@ -413,7 +413,7 @@ WINRT_EXPORT namespace winrt::impl
     template <std::size_t Size>
     constexpr auto calculate_sha1(std::array<std::uint8_t, Size> const& input) noexcept
     {
-        std::array<std::uint32_t, 5> intermediate_hash{ 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
+        std::array<std::uint32_t, 5> intermediate_hash{{ 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 }};
         std::size_t i = 0;
 
         while (i + 64 <= Size)
@@ -468,7 +468,7 @@ WINRT_EXPORT namespace winrt::impl
         combine
         (
             to_array<wchar_t>(guid_of<T>()),
-            std::array<wchar_t, 1>{ L'\0' }
+            std::array<wchar_t, 1>{{ L'\0' }}
         )
     };
 

--- a/strings/base_implements.h
+++ b/strings/base_implements.h
@@ -232,6 +232,24 @@ WINRT_EXPORT namespace winrt::impl
             std::memset(ptr, 0, sizeof(T));
         }
     }
+
+    // Converts between an implementation type and the ABI type it is layout compatible with.
+    // Classic COM interfaces derive from ::IUnknown rather than from unknown_abi, and producer
+    // holds its vtable by value for WinRT interfaces, so the two types are often unrelated and
+    // only a reinterpret_cast will do. Where they are related, a reinterpret_cast is both
+    // unnecessary and reported as C4946, so prefer the checked conversion when one exists.
+    template <typename To, typename From>
+    To* abi_cast(From* from) noexcept
+    {
+        if constexpr (std::is_convertible_v<From*, To*>)
+        {
+            return static_cast<To*>(from);
+        }
+        else
+        {
+            return reinterpret_cast<To*>(from);
+        }
+    }
 }
 
 WINRT_EXPORT namespace winrt
@@ -257,13 +275,13 @@ WINRT_EXPORT namespace winrt
     template <typename I, typename D>
     impl::abi_t<I>* to_abi(impl::producer<D, I> const* from) noexcept
     {
-        return reinterpret_cast<impl::abi_t<I>*>(const_cast<impl::producer<D, I>*>(from));
+        return impl::abi_cast<impl::abi_t<I>>(const_cast<impl::producer<D, I>*>(from));
     }
 
     template <typename I, typename D>
     impl::abi_t<I>* to_abi(impl::producer_convert<D, I> const* from) noexcept
     {
-        return reinterpret_cast<impl::abi_t<I>*>((impl::producer<D, default_interface<I>>*)from);
+        return impl::abi_cast<impl::abi_t<I>>(const_cast<impl::producer<D, default_interface<I>>*>(static_cast<impl::producer<D, default_interface<I>> const*>(from)));
     }
 }
 
@@ -1260,10 +1278,11 @@ WINRT_EXPORT namespace winrt::impl
             }
         }
 
-        static bool is_weak_ref(std::intptr_t const value) noexcept
+        static bool is_weak_ref(std::uintptr_t const value) noexcept
         {
             static_assert(is_weak_ref_source::value, "Weak references are not supported because no_weak_ref was specified.");
-            return value < 0;
+            constexpr std::uintptr_t pointer_flag = static_cast<std::uintptr_t>(1) << ((sizeof(std::uintptr_t) * 8) - 1);
+            return (value & pointer_flag) != 0;
         }
 
         static weak_ref_t* decode_weak_ref(std::uintptr_t const value) noexcept
@@ -1567,7 +1586,7 @@ WINRT_EXPORT namespace winrt
 
         impl::unknown_abi* get_unknown() const noexcept override
         {
-            return reinterpret_cast<impl::unknown_abi*>(to_abi<typename impl::implements_default_interface<D>::type>(this));
+            return impl::abi_cast<impl::unknown_abi>(to_abi<typename impl::implements_default_interface<D>::type>(this));
         }
 
         hstring GetRuntimeClassName() const override

--- a/strings/base_string.h
+++ b/strings/base_string.h
@@ -5,13 +5,13 @@ WINRT_EXPORT namespace winrt::impl
     {
         atomic_ref_count() noexcept = default;
 
-        explicit atomic_ref_count(std::uint32_t count) noexcept : m_count(count)
+        explicit atomic_ref_count(std::uint32_t count) noexcept : m_count(static_cast<std::int32_t>(count))
         {
         }
 
         std::uint32_t operator=(std::uint32_t count) noexcept
         {
-            return m_count = count;
+            return static_cast<std::uint32_t>(m_count = static_cast<std::int32_t>(count));
         }
 
         std::uint32_t operator++() noexcept
@@ -639,7 +639,7 @@ WINRT_EXPORT namespace winrt::impl
         }
         WINRT_ASSERT(result.ec == std::errc{});
         wchar_t buffer[32];
-        auto end = std::copy(std::begin(temp), result.ptr, buffer);
+        auto end = std::transform(std::begin(temp), result.ptr, buffer, [](char value) noexcept { return static_cast<wchar_t>(value); });
         return hstring{ std::wstring_view{ buffer, static_cast<std::size_t>(end - buffer)} };
     }
 
@@ -785,7 +785,7 @@ WINRT_EXPORT namespace winrt
             return{};
         }
 
-        impl::hstring_builder result(size);
+        impl::hstring_builder result(static_cast<std::uint32_t>(size));
         WINRT_VERIFY_(size, WINRT_IMPL_MultiByteToWideChar(65001 /*CP_UTF8*/, 0, view.data(), static_cast<std::int32_t>(view.size()), result.data(), size));
         return result.to_hstring();
     }
@@ -799,7 +799,7 @@ WINRT_EXPORT namespace winrt
             return{};
         }
 
-        std::string result(size, '?');
+        std::string result(static_cast<std::size_t>(size), '?');
         WINRT_VERIFY_(size, WINRT_IMPL_WideCharToMultiByte(65001 /*CP_UTF8*/, 0, value.data(), static_cast<std::int32_t>(value.size()), result.data(), size, nullptr, nullptr));
         return result;
     }

--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -43,12 +43,12 @@ WINRT_EXPORT namespace winrt::impl
     template <typename T>
     constexpr std::uint8_t hex_to_uint8(T const a, T const b)
     {
-        return (hex_to_uint(a) << 4) | hex_to_uint(b);
+        return static_cast<std::uint8_t>((hex_to_uint(a) << 4) | hex_to_uint(b));
     }
 
     constexpr std::uint16_t uint8_to_uint16(std::uint8_t a, std::uint8_t b)
     {
-        return (static_cast<std::uint16_t>(a) << 8) | static_cast<std::uint16_t>(b);
+        return static_cast<std::uint16_t>((static_cast<std::uint16_t>(a) << 8) | static_cast<std::uint16_t>(b));
     }
 
     constexpr std::uint32_t uint8_to_uint32(std::uint8_t a, std::uint8_t b, std::uint8_t c, std::uint8_t d)


### PR DESCRIPTION
These sites produce MSVC warnings under `/Wall` on both x64 and x86, which forces consumers building at high warning levels to wrap every C++/WinRT include in `#pragma warning` blocks.

| Warning | Sites | Cause |
|---|---|---|
| C5246 | most of `base_identity.h` | `std::array` aggregate init needs two brace levels |
| C4365 | `base_collections_base.h`, `base_collections_vector.h`, `base_string.h`, `base_error.h`, `base_types.h` | integral promotion, and `uint32_t` -> `ptrdiff_t` iterator arithmetic on 32-bit |
| C4826 | `base_events.h` | `reinterpret_cast` of a pointer to `int64_t` sign-extends |
| C4946 | `base_implements.h` | `reinterpret_cast` between related classes; every abi type derives from `unknown_abi`, so `static_cast` is correct |

Two are worth calling out:

`to_hstring` used `std::copy` to widen `char` to `wchar_t`. The assignment happens inside `<xutility>`, so a caller cannot silence it; `std::transform` with an explicit cast can. `to_chars` only writes ASCII there, so the cast is exact. Minimal repro:

```cpp
// cl /std:c++20 /W4 /w14365
#include <algorithm>
#include <iterator>
char narrow[8]{};
wchar_t wide[8]{};
wchar_t* widen() { return std::copy(std::begin(narrow), std::end(narrow), wide); }
```

`is_weak_ref` took `intptr_t` and tested `value < 0` while every caller holds a `uintptr_t`. It now takes `uintptr_t` and tests the high bit explicitly.

No generated files change, and no public signatures change.

Validated on a translation unit exercising `implements<>`, delegates, events, all collection flavours, coroutines, `agile_ref`, `weak_ref`, boxing and error handling.

Part of #1620.
