### PR TITLE
Add a guid constructor overload taking Data4 by reference to array

### DIFF
--- a/strings/base_types.h
+++ b/strings/base_types.h
@@ -140,6 +140,14 @@ WINRT_EXPORT namespace winrt
 
         guid() noexcept = default;
 
+        constexpr guid(std::uint32_t const Data1, std::uint16_t const Data2, std::uint16_t const Data3, std::uint8_t const (&Data4)[8]) noexcept :
+            Data1(Data1),
+            Data2(Data2),
+            Data3(Data3),
+            Data4{ Data4[0], Data4[1], Data4[2], Data4[3], Data4[4], Data4[5], Data4[6], Data4[7] }
+        {
+        }
+
         constexpr guid(std::uint32_t const Data1, std::uint16_t const Data2, std::uint16_t const Data3, std::array<std::uint8_t, 8> const& Data4) noexcept :
             Data1(Data1),
             Data2(Data2),


### PR DESCRIPTION
The `guid` constructor takes `Data4` as `std::array<std::uint8_t, 8> const&`. Because `std::array` wraps a C array, a braced call site elides the inner braces, and MSVC reports C5246 (`the initialization of a subobject should be wrapped in braces`) at each such call site - including the `guid` literals C++/WinRT generates for every namespace header.

### Change

Add an overload taking `std::uint8_t const (&)[8]` alongside the existing `std::array` one, rather than replacing it. A braced initializer binds to the C array directly, so there is no intervening subobject and no warning, and callers that pass a `std::array` keep compiling unchanged.

### Why not suppress it at the constructor

The diagnostic is attributed to the caller, not to the constructor definition, so a `push` / `disable` / `pop` around the constructor has no effect:

| variant | C5246 |
| --- | --- |
| `std::array` parameter, braced call site | 1, reported at the call site |
| same, with `warning(push/disable: 5246/pop)` around the constructor | 1, unchanged |
| same, call site double-braced `{{...}}` | 0 |
| `std::uint8_t const (&)[8]` parameter | 0 |

Suppressing would therefore have to happen at every call site, which includes all of the generated namespace headers and any `guid` a consumer writes.

### Why an overload rather than changing the parameter

Replacing the parameter is source-breaking for callers passing a `std::array` lvalue:

```
error C2440: 'initializing': cannot convert from 'initializer list' to 'guid'
```

Adding the overload avoids that. I checked that it does not introduce ambiguity, on MSVC and clang-cl, for braced-init-lists, `const` and non-`const` `std::array` lvalues, `std::array` temporaries, and C array lvalues - all five compile clean with no C5246 and no `-Wmissing-braces`.

### Validation

`/Wall`, MSVC x64, `/std:c++20 /permissive-`, on a translation unit exercising collections, coroutines, delegates, `implements`, factories and classic COM:

- C5246: **114 -> 20**
- no errors, and no change to any other diagnostic (C4265 x15, C4365 x21, C4946 x16 before and after)
