### PR TITLE
Suppress non-virtual destructor warnings in the generated headers

### DIFF
--- a/cppwinrt/code_writers.h
+++ b/cppwinrt/code_writers.h
@@ -81,8 +81,45 @@ namespace cppwinrt
         w.write(format);
     }
 
+    // The ABI interface structs, the delegate structs, and the produce<D, I> vtable adapters
+    // all have virtual functions and non-virtual destructors, which trips C4265/C5204 on MSVC
+    // and -Wnon-virtual-dtor on clang. None of those types is ever deleted. The only
+    // refcounted, heap-allocated type is root_implements, and it already has a virtual
+    // destructor; everything below it is a non-owning subobject whose address is simply the
+    // COM interface pointer. The warning is therefore reporting a delete that cannot occur.
+    // Scoped with push/pop so that consumer code outside these headers is unaffected.
+    static void write_diagnostic_push(writer& w)
+    {
+        auto format = R"(#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4265) // class has virtual functions, but destructor is not virtual
+#pragma warning(disable: 5204) // class has virtual functions, but its trivial destructor is not virtual
+#endif // _MSC_VER
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
+#endif // __clang__
+)";
+
+        w.write(format);
+    }
+
+    static void write_diagnostic_pop(writer& w)
+    {
+        auto format = R"(#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+)";
+
+        w.write(format);
+    }
+
     static void write_close_file_guard(writer& w)
     {
+        write_diagnostic_pop(w);
         write_endif(w);
     }
 
@@ -108,6 +145,7 @@ namespace cppwinrt
 )";
 
         w.write(format, mangled_name, mangled_name);
+        write_diagnostic_push(w);
     }
 
     template<typename... Args>


### PR DESCRIPTION
Part of #1620.

`-Wnon-virtual-dtor` (clang) and C4265/C5204 (MSVC) fire on the ABI interface structs, the
delegate structs, and the `produce<D, I>` vtable adapters. That is about 200 warnings in a
single translation unit that exercises `implements<>`, delegates, events, and the collection
helpers.

They are false positives. The only refcounted, heap-allocated type here is `root_implements`,
and it already has a virtual destructor. `producer`, `produce<D, I>`, and the ABI structs are
non-owning subobjects -- each one's address is simply the COM interface pointer handed out for
that interface -- and none of them is ever deleted. The warning is reporting a delete that
cannot occur.

This emits a scoped push/disable/pop around the body of each generated header, matching the
guarded style already used in `base_delegate.h`, `base_implements.h`, `base_activation.h`, and
`base_error.h`. It is popped at the end of every header, so consumer code outside these headers
keeps the warning.

Measured against the shipped headers with the same pragmas applied:

| | before | after |
|---|---|---|
| clang `-Wnon-virtual-dtor` | 200 | 0 |
| MSVC `/Wall` C4265 (x64) | 15 | 0 |
| MSVC `/Wall` C4265 (x86) | 15 | 0 |
| errors | 0 | 0 |

The earlier revision of this PR gave those types protected destructors instead. That was
replaced per review feedback: suppression leaves the types untouched, so there is no question
of affecting an ABI type or forbidding a derivation that compiles today.
